### PR TITLE
feat: implement binding extends inheritance for guardrail DI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1003,6 +1003,76 @@ outputs:
     template: ./templates/cursor-hook-wrapper.sh.hbs
 ````
 
+### Binding inheritance
+
+Binding files support `extends` for inheriting and extending a base binding, using the same mechanism as DSL-level `extends`.
+
+A base binding defines shared guardrail implementations and outputs:
+
+````yaml
+# skeleton/bindings/cursor.yaml (base)
+software: cursor
+version: 1
+
+guardrail_impl:
+  no-force-push:
+    checks:
+      - hook_event: beforeShellExecution
+        matcher:
+          type: command_regex
+          pattern: "git\\s+push\\s+.*--force"
+        message: "Force push is forbidden"
+
+outputs:
+  policy-bundle:
+    target: "{cursor_root}/guardrails/policy.json"
+    mode: write
+    inline_template: "{{json resolved_checks}}"
+````
+
+A project binding extends the base and adds project-specific guardrail implementations:
+
+````yaml
+# project/bindings/cursor.yaml
+extends: ../../skeleton/bindings/cursor.yaml
+software: cursor
+version: 1
+
+guardrail_impl:
+  lint-on-save:
+    checks:
+      - hook_event: afterFileEdit
+        matcher:
+          type: file_glob
+          pattern: "**/*.{ts,tsx}"
+        message: "TS file edited — lint results attached."
+````
+
+The result is a single merged binding with all guardrail implementations from both base and project.
+
+Merge behavior:
+
+| Field | Behavior |
+|-------|----------|
+| `software` | Project wins |
+| `guardrail_impl` | Map merge by guardrail ID (new IDs added; same ID deep-merged) |
+| `outputs` | Map merge by output ID (project overrides base) |
+| `reporting` | Deep merge (project fields override base) |
+| passthrough fields | Project wins |
+
+All merge operators (`$append`, `$prepend`, `$insert_after`, `$replace`, `$remove`) work within binding `extends`, the same as DSL `extends`.
+
+Chained inheritance (grandparent → parent → child) and both local path (`./`, `../`) and npm package references are supported. Circular extends are detected and rejected.
+
+When using binding `extends`, the config only needs to list the child binding:
+
+````yaml
+# agent-contracts.config.yaml
+bindings:
+  - ./bindings/cursor.yaml    # extends base internally
+  - ./bindings/git.yaml
+````
+
 ### Config
 
 ````yaml

--- a/docs/spec/guardrail-di.md
+++ b/docs/spec/guardrail-di.md
@@ -1,8 +1,8 @@
 # Guardrail Definition & DI Binding Specification
 
-**Version**: 0.1.0 (draft)
-**Date**: 2026-04-16
-**Status**: Proposed
+**Version**: 0.2.0
+**Date**: 2026-04-17
+**Status**: Partially Implemented
 **Prerequisite reading**: `guardrail-di-spec.md`, `shift-left-guidline.md`, `feasibility-study.md`, `ai-observ-agent-contracts-refactoring.md`
 
 ---
@@ -790,10 +790,13 @@ agent-contracts generate guardrails -c agent-contracts.config.yaml --binding cur
 1. Load config
 2. Load and resolve DSL (existing pipeline)
 3. Select `active_guardrail_policy` from DSL `guardrail_policies`
-4. Load each binding file from `config.bindings`
-5. Validate binding schemas
-6. Run cross-reference checks (binding keys → DSL guardrails, policy → guardrails)
-7. For each binding with `outputs`:
+4. Load each binding file from `config.bindings`:
+   a. Parse YAML
+   b. Resolve `extends` chain recursively (see section 10.2)
+   c. Merge base and project bindings
+   d. Validate merged result against `SoftwareBindingSchema`
+5. Run cross-reference checks (binding keys → DSL guardrails, policy → guardrails)
+6. For each binding with `outputs`:
    a. Resolve the `GuardrailGenerationContext` (see section 9)
    b. For each output entry, resolve the target path (section 5)
    c. Render using inline or external template
@@ -933,26 +936,170 @@ The resolved DSL contains both `no-force-push` (from base) and `english-only-cod
 
 ### 10.2 Binding Inheritance
 
-Binding files support their own `extends` field:
+Binding files support their own `extends` field, mirroring the DSL-level `extends` mechanism. This allows organizations to define shared base bindings (e.g., common guardrail implementations for Cursor or Git) and let individual projects extend them with project-specific additions or overrides.
+
+**Status**: Implemented in v0.11.x (`src/config/binding-loader.ts`, `src/config/binding-merger.ts`).
+
+#### 10.2.1 Resolution Pipeline
+
+When `loadBindings` encounters a binding file with an `extends` field, it resolves the base before schema validation:
+
+1. Parse the binding YAML into a raw object
+2. If `extends` is present:
+   a. Resolve the base path (local or npm package — see §10.2.3)
+   b. Load the base binding YAML recursively (the base may itself have `extends`)
+   c. Merge base and project using `mergeBinding()` (see §10.2.2)
+3. Validate the merged result against `SoftwareBindingSchema`
+
+The `extends` field is stripped from the merged result, just like DSL `extends`.
+
+#### 10.2.2 Merge Semantics
+
+The `mergeBinding(base, project)` function applies field-specific merge strategies:
+
+| Field | Merge Behavior |
+|-------|---------------|
+| `software` | Project wins (scalar override) |
+| `version` | Project wins (scalar override) |
+| `guardrail_impl` | **Map merge** by guardrail ID. New IDs from the project are added. Same IDs are deep-merged (project fields override base fields within each guardrail entry). Merge operators (`$append`, `$prepend`, `$insert_after`, `$replace`, `$remove`) are supported on `checks` arrays when `extends` is present. |
+| `outputs` | **Map merge** by output ID. New output IDs from the project are added. Same IDs are deep-merged (project fields override base fields). |
+| `reporting` | **Deep merge**. Project fields override base fields recursively. If only the base has `reporting`, it is inherited as-is. |
+| passthrough fields (`x-*`, etc.) | Project wins for same keys; base keys not in the project are preserved. |
+| `extends` | Stripped from the final merged result. |
+
+The merge implementation reuses `mergeEntityMaps` and `deepMergeEntities` from the DSL merger (`src/resolver/merger.ts`), ensuring consistent operator behavior.
+
+**Example — disjoint guardrail_impl (typical project extension):**
 
 ```yaml
-# agent-contracts/bindings/cursor.yaml
-extends: "@my-org/cursor-bindings-base"
+# base/bindings/cursor.yaml
 software: cursor
 version: 1
-
 guardrail_impl:
-  english-only-code:
+  no-force-push:
     checks:
-      - hook_event: afterFileEdit
-        matcher:
-          type: content_regex
-          pattern: "[\\u3040-\\u309F]"
-          file_glob: "src/**"
-        message: "Japanese characters detected"
+      - hook_event: beforeShellExecution
+        matcher: { type: command_regex, pattern: "git\\s+push\\s+.*--force" }
+        message: "Force push is forbidden"
+  no-rebase:
+    checks:
+      - hook_event: beforeShellExecution
+        matcher: { type: command_regex, pattern: "git\\s+rebase" }
+        message: "Rebase is prohibited"
+outputs:
+  policy-bundle:
+    target: "{cursor_root}/guardrails/policy.json"
+    mode: write
+    inline_template: "{{json resolved_checks}}"
 ```
 
-The binding loader resolves `extends` before merging, using the same base resolution mechanism as DSL extends.
+```yaml
+# project/bindings/cursor.yaml
+extends: ../../base/bindings/cursor.yaml
+software: cursor
+version: 1
+guardrail_impl:
+  lint-on-save:
+    checks:
+      - hook_event: afterFileEdit
+        matcher: { type: file_glob, pattern: "**/*.{ts,tsx}" }
+        message: "TS file edited — lint results attached."
+  lineage-impact-check:
+    checks:
+      - hook_event: afterFileEdit
+        matcher: { type: file_glob, pattern: "{server/**,frontend/**}/*.ts" }
+        message: "Lineage-scoped file changed."
+```
+
+Merged result: `guardrail_impl` contains all four entries (`no-force-push`, `no-rebase`, `lint-on-save`, `lineage-impact-check`). The `outputs.policy-bundle` is inherited from the base, producing a single `policy.json` with checks from all four guardrails.
+
+**Example — $append operator on checks array:**
+
+```yaml
+# project/bindings/cursor.yaml
+extends: ../../base/bindings/cursor.yaml
+software: cursor
+version: 1
+guardrail_impl:
+  no-force-push:
+    checks:
+      $append:
+        - hook_event: beforeShellExecution
+          matcher: { type: command_regex, pattern: "git\\s+push\\s+.*-f\\b" }
+          message: "Force push (-f shorthand) is forbidden"
+```
+
+Merged result: `no-force-push.checks` contains both the base check (`--force`) and the appended check (`-f`).
+
+**Example — output override:**
+
+```yaml
+# project/bindings/cursor.yaml
+extends: ../../base/bindings/cursor.yaml
+software: cursor
+version: 1
+outputs:
+  policy-bundle:
+    target: "{cursor_root}/guardrails/policy.json"
+    mode: write
+    template: ./templates/custom-policy.json.hbs
+```
+
+Merged result: `policy-bundle.template` is overridden to use a project-specific template, while the `target` is preserved from the project definition.
+
+#### 10.2.3 Base Path Resolution
+
+The `extends` value is resolved using the same strategies as DSL `extends`:
+
+| Pattern | Resolution |
+|---------|-----------|
+| `./path` or `../path` | Relative to the binding file's directory |
+| `@scope/package` or `package-name` | npm package resolution via `import.meta.resolve` |
+
+**Local path resolution:**
+
+- If the path resolves to a **file**, that file is loaded directly.
+- If the path resolves to a **directory**, the loader looks for `binding.yaml` or `binding.yml` within it (in that order). If neither exists, an error is thrown.
+
+**npm package resolution:**
+
+```yaml
+extends: "@my-org/agent-contracts-base-bindings"
+```
+
+The loader uses `import.meta.resolve` to find the package, then looks for a `binding.yaml` entry file in the resolved directory.
+
+#### 10.2.4 Chained Inheritance
+
+Binding `extends` supports arbitrary chain depth. Each base is resolved recursively before merging:
+
+```
+grandparent.yaml → parent.yaml → child.yaml
+```
+
+The merge applies bottom-up: grandparent is merged with parent first, then the result is merged with child. This follows the same precedence as DSL `extends` chains.
+
+#### 10.2.5 Circular Detection
+
+The binding loader tracks all visited file paths during recursive resolution. If a path is encountered a second time, the loader throws a `ConfigLoadError` with a clear message:
+
+```
+Circular binding extends detected: /path/to/binding.yaml
+```
+
+#### 10.2.6 Config Impact
+
+When using binding `extends`, the config's `bindings` array should list only the **leaf** (child) binding files. Base bindings referenced via `extends` are loaded automatically and should not appear separately in the config:
+
+```yaml
+# agent-contracts.config.yaml
+bindings:
+  - ./bindings/cursor.yaml         # extends base internally
+  - ./bindings/git.yaml
+  - ./bindings/observability.yaml
+```
+
+If both a base and its child are listed in the config, they are treated as independent bindings — the base is loaded twice (once standalone, once as extends target). This is valid but typically not desired.
 
 ---
 
@@ -1012,15 +1159,16 @@ Additionally, a new schema file `schemas/binding.schema.json` should be generate
 
 ## 13. Implementation Priority
 
-| Order | Item | Estimated Effort |
-|-------|------|-----------------|
-| 1 | DSL `guardrails:` schema + validate/lint | 1 week |
-| 2 | DSL `guardrail_policies:` schema + guardrail ID reference checks | 3 days |
-| 3 | Config `bindings:` + `active_guardrail_policy:` + `paths:` + binding loader | 1 week |
-| 4 | Binding validation + DSL↔binding cross-reference checks | 3 days |
-| 5 | `generate guardrails` command: Cursor minimal implementation (path resolution + inline_template) | 1–2 weeks |
-| 6 | Observability binding: reporting definition + event schema output | 3 days |
-| 7 | GitHub / Git binding support | 1 week each |
+| Order | Item | Estimated Effort | Status |
+|-------|------|-----------------|--------|
+| 1 | DSL `guardrails:` schema + validate/lint | 1 week | ✅ Done |
+| 2 | DSL `guardrail_policies:` schema + guardrail ID reference checks | 3 days | ✅ Done |
+| 3 | Config `bindings:` + `active_guardrail_policy:` + `paths:` + binding loader | 1 week | ✅ Done |
+| 4 | Binding validation + DSL↔binding cross-reference checks | 3 days | ✅ Done |
+| 5 | `generate guardrails` command: Cursor minimal implementation (path resolution + inline_template) | 1–2 weeks | ✅ Done |
+| 5a | Binding `extends` inheritance (§10.2) | 2 days | ✅ Done (v0.2.0) |
+| 6 | Observability binding: reporting definition + event schema output | 3 days | Planned |
+| 7 | GitHub / Git binding support | 1 week each | Planned |
 
 ### 13.1 Vertical Slice Strategy
 
@@ -1052,3 +1200,5 @@ This validates the entire pipeline before broadening to more guardrails and bind
 | Observability binding has no `guardrail_impl` | The observability engine never evaluates guardrails; it only defines recording commands and event schemas |
 | `reporting.commands` uses placeholder patterns | Templates expand placeholders without knowing the observability engine's CLI parameter format; recording backend is swappable |
 | Hook-event-level file generation with subshell script execution | One pre-commit file contains all guardrails; script exit codes don't affect other checks; block accumulation determines final exit |
+| Binding `extends` mirrors DSL `extends` semantics | Reuses the same merge operators and resolution strategies; organizations define shared base bindings, projects extend with additions; config lists only leaf bindings |
+| `mergeBinding` reuses DSL merger primitives (`mergeEntityMaps`, `deepMergeEntities`) | Consistent merge behavior across DSL and bindings; single source of truth for operator semantics; reduces implementation surface |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-contracts",
-  "version": "0.9.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-contracts",
-      "version": "0.9.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "@stoplight/spectral-core": "^1.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/config/binding-loader.ts
+++ b/src/config/binding-loader.ts
@@ -1,14 +1,114 @@
 import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { stat } from "node:fs/promises";
 import { parse as parseYaml } from "yaml";
 import {
   SoftwareBindingSchema,
   type SoftwareBinding,
 } from "../schema/index.js";
 import { ConfigLoadError } from "./loader.js";
+import { mergeBinding } from "./binding-merger.js";
 
 export interface LoadedBinding {
   filePath: string;
   binding: SoftwareBinding;
+}
+
+async function loadRawBinding(filePath: string): Promise<Record<string, unknown>> {
+  let content: string;
+  try {
+    content = await readFile(filePath, "utf8");
+  } catch {
+    throw new ConfigLoadError(
+      `Failed to read binding file: ${filePath}`,
+      filePath,
+    );
+  }
+
+  try {
+    return parseYaml(content) as Record<string, unknown>;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new ConfigLoadError(
+      `Invalid YAML syntax in binding file ${filePath}: ${msg}`,
+      filePath,
+    );
+  }
+}
+
+async function resolveBindingExtends(
+  raw: Record<string, unknown>,
+  filePath: string,
+  seen: Set<string>,
+): Promise<Record<string, unknown>> {
+  const extendsValue = raw["extends"];
+  if (typeof extendsValue !== "string") {
+    return raw;
+  }
+
+  const bindingDir = dirname(filePath);
+  let basePath: string;
+
+  if (extendsValue.startsWith("./") || extendsValue.startsWith("../")) {
+    basePath = resolve(bindingDir, extendsValue);
+  } else {
+    try {
+      const resolved = import.meta.resolve(extendsValue);
+      basePath = new URL(resolved).pathname;
+    } catch {
+      throw new ConfigLoadError(
+        `Could not resolve binding extends package: ${extendsValue}`,
+        filePath,
+      );
+    }
+  }
+
+  // If the resolved path is a directory, look for a binding YAML entry file
+  try {
+    const s = await stat(basePath);
+    if (s.isDirectory()) {
+      const candidates = ["binding.yaml", "binding.yml"];
+      let found = false;
+      for (const name of candidates) {
+        const candidate = resolve(basePath, name);
+        try {
+          const cs = await stat(candidate);
+          if (cs.isFile()) {
+            basePath = candidate;
+            found = true;
+            break;
+          }
+        } catch {
+          continue;
+        }
+      }
+      if (!found) {
+        throw new ConfigLoadError(
+          `No binding.yaml found in directory: ${basePath}`,
+          filePath,
+        );
+      }
+    }
+  } catch (err) {
+    if (err instanceof ConfigLoadError) throw err;
+    throw new ConfigLoadError(
+      `Base binding path not found: ${basePath}`,
+      filePath,
+    );
+  }
+
+  if (seen.has(basePath)) {
+    throw new ConfigLoadError(
+      `Circular binding extends detected: ${basePath}`,
+      filePath,
+    );
+  }
+  seen.add(basePath);
+
+  const baseRaw = await loadRawBinding(basePath);
+  const resolvedBase = await resolveBindingExtends(baseRaw, basePath, seen);
+
+  return mergeBinding(resolvedBase, raw);
 }
 
 export async function loadBindings(
@@ -16,28 +116,10 @@ export async function loadBindings(
 ): Promise<LoadedBinding[]> {
   const results: LoadedBinding[] = [];
   for (const filePath of bindingPaths) {
-    let content: string;
-    try {
-      content = await readFile(filePath, "utf8");
-    } catch {
-      throw new ConfigLoadError(
-        `Failed to read binding file: ${filePath}`,
-        filePath,
-      );
-    }
+    const raw = await loadRawBinding(filePath);
+    const merged = await resolveBindingExtends(raw, filePath, new Set([filePath]));
 
-    let raw: unknown;
-    try {
-      raw = parseYaml(content);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      throw new ConfigLoadError(
-        `Invalid YAML syntax in binding file ${filePath}: ${msg}`,
-        filePath,
-      );
-    }
-
-    const result = SoftwareBindingSchema.safeParse(raw);
+    const result = SoftwareBindingSchema.safeParse(merged);
     if (!result.success) {
       const issues = result.error.issues
         .map((i) => `  ${i.path.join(".")}: ${i.message}`)

--- a/src/config/binding-merger.ts
+++ b/src/config/binding-merger.ts
@@ -1,0 +1,51 @@
+import { mergeEntityMaps, deepMergeEntities } from "../resolver/index.js";
+
+type AnyRecord = Record<string, unknown>;
+
+function isRecord(v: unknown): v is AnyRecord {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+const BINDING_MERGE_SECTIONS = ["guardrail_impl", "outputs"];
+
+export function mergeBinding(
+  base: AnyRecord,
+  project: AnyRecord,
+): AnyRecord {
+  const hasExtends = typeof project["extends"] === "string";
+  const result: AnyRecord = { ...base, ...project };
+
+  for (const section of BINDING_MERGE_SECTIONS) {
+    const baseVal = base[section];
+    const projVal = project[section];
+
+    if (projVal === undefined) {
+      continue;
+    }
+
+    const baseMap = isRecord(baseVal) ? baseVal : {};
+    result[section] = mergeEntityMaps(
+      baseMap,
+      projVal as AnyRecord,
+      section,
+      hasExtends,
+    );
+  }
+
+  // reporting: deep merge when both sides are objects, otherwise project wins
+  if (
+    project["reporting"] !== undefined &&
+    isRecord(base["reporting"]) &&
+    isRecord(project["reporting"])
+  ) {
+    result["reporting"] = deepMergeEntities(
+      base["reporting"] as AnyRecord,
+      project["reporting"] as AnyRecord,
+      "reporting",
+      hasExtends,
+    );
+  }
+
+  delete result["extends"];
+  return result;
+}

--- a/src/resolver/index.ts
+++ b/src/resolver/index.ts
@@ -1,4 +1,9 @@
 export { resolveBase, resolveLocalBase, BaseResolveError } from "./base-resolver.js";
-export { mergeDsl, MergeError } from "./merger.js";
+export {
+  mergeDsl,
+  mergeEntityMaps,
+  deepMergeEntities,
+  MergeError,
+} from "./merger.js";
 export { resolve, type ResolveResult } from "./resolve.js";
 export { substituteVars, VarsSubstitutionError } from "./substitute-vars.js";

--- a/src/resolver/merger.ts
+++ b/src/resolver/merger.ts
@@ -160,7 +160,7 @@ function applyMapMergeOperator(
   }
 }
 
-function deepMergeEntities(
+export function deepMergeEntities(
   base: AnyRecord,
   project: AnyRecord,
   path: string,
@@ -205,7 +205,7 @@ function deepMergeEntities(
   return result;
 }
 
-function mergeEntityMaps(
+export function mergeEntityMaps(
   baseMap: AnyRecord,
   projectMap: AnyRecord,
   path: string,

--- a/test/config/binding-loader.test.ts
+++ b/test/config/binding-loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { mkdtemp, writeFile, mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadBindings } from "../../src/config/binding-loader.js";
@@ -88,5 +88,340 @@ describe("loadBindings", () => {
     const [row] = await loadBindings([filePath]);
     expect(row.binding.software).toBe("my-ide");
     expect(row.binding.version).toBe(1);
+  });
+});
+
+describe("loadBindings — extends", () => {
+  it("merges guardrail_impl from base binding via extends", async () => {
+    const baseDir = join(tempDir, "base");
+    await mkdir(baseDir, { recursive: true });
+
+    const basePath = join(baseDir, "cursor.yaml");
+    await writeFile(
+      basePath,
+      [
+        "software: cursor",
+        "version: 1",
+        "guardrail_impl:",
+        "  no-force-push:",
+        "    checks:",
+        "      - message: base check",
+        "  no-rebase:",
+        "    checks:",
+        "      - message: rebase check",
+      ].join("\n"),
+    );
+
+    const childPath = join(tempDir, "cursor-project.yaml");
+    await writeFile(
+      childPath,
+      [
+        `extends: ./base/cursor.yaml`,
+        "software: cursor",
+        "version: 1",
+        "guardrail_impl:",
+        "  project-guard:",
+        "    checks:",
+        "      - message: project check",
+      ].join("\n"),
+    );
+
+    const [result] = await loadBindings([childPath]);
+    const implKeys = Object.keys(result.binding.guardrail_impl ?? {});
+    expect(implKeys).toContain("no-force-push");
+    expect(implKeys).toContain("no-rebase");
+    expect(implKeys).toContain("project-guard");
+    expect(implKeys).toHaveLength(3);
+  });
+
+  it("child guardrail_impl overrides base for same guardrail ID", async () => {
+    const basePath = join(tempDir, "base.yaml");
+    await writeFile(
+      basePath,
+      [
+        "software: cursor",
+        "version: 1",
+        "guardrail_impl:",
+        "  gr1:",
+        "    checks:",
+        "      - message: from base",
+      ].join("\n"),
+    );
+
+    const childPath = join(tempDir, "child.yaml");
+    await writeFile(
+      childPath,
+      [
+        "extends: ./base.yaml",
+        "software: cursor",
+        "version: 1",
+        "guardrail_impl:",
+        "  gr1:",
+        "    checks:",
+        "      - message: from child",
+      ].join("\n"),
+    );
+
+    const [result] = await loadBindings([childPath]);
+    const checks = result.binding.guardrail_impl!["gr1"]!.checks;
+    expect(checks).toHaveLength(1);
+    expect(checks[0]).toMatchObject({ message: "from child" });
+  });
+
+  it("child outputs override base outputs for same output ID", async () => {
+    const basePath = join(tempDir, "base.yaml");
+    await writeFile(
+      basePath,
+      [
+        "software: cursor",
+        "version: 1",
+        "outputs:",
+        "  policy-bundle:",
+        "    target: '{cursor_root}/guardrails/base-policy.json'",
+        "    mode: write",
+        "    inline_template: base",
+      ].join("\n"),
+    );
+
+    const childPath = join(tempDir, "child.yaml");
+    await writeFile(
+      childPath,
+      [
+        "extends: ./base.yaml",
+        "software: cursor",
+        "version: 1",
+        "outputs:",
+        "  policy-bundle:",
+        "    target: '{cursor_root}/guardrails/policy.json'",
+        "    mode: write",
+        "    inline_template: child",
+      ].join("\n"),
+    );
+
+    const [result] = await loadBindings([childPath]);
+    expect(result.binding.outputs!["policy-bundle"]!.target).toBe(
+      "{cursor_root}/guardrails/policy.json",
+    );
+  });
+
+  it("inherits base outputs when child does not define outputs", async () => {
+    const basePath = join(tempDir, "base.yaml");
+    await writeFile(
+      basePath,
+      [
+        "software: cursor",
+        "version: 1",
+        "outputs:",
+        "  hook-script:",
+        "    target: '{cursor_root}/hooks/eval.sh'",
+        "    mode: write",
+        "    inline_template: inherited",
+      ].join("\n"),
+    );
+
+    const childPath = join(tempDir, "child.yaml");
+    await writeFile(
+      childPath,
+      [
+        "extends: ./base.yaml",
+        "software: cursor",
+        "version: 1",
+        "guardrail_impl:",
+        "  gr1:",
+        "    checks:",
+        "      - message: child check",
+      ].join("\n"),
+    );
+
+    const [result] = await loadBindings([childPath]);
+    expect(result.binding.outputs!["hook-script"]!.target).toBe(
+      "{cursor_root}/hooks/eval.sh",
+    );
+  });
+
+  it("child software field overrides base software", async () => {
+    const basePath = join(tempDir, "base.yaml");
+    await writeFile(basePath, "software: base-cursor\nversion: 1\n");
+
+    const childPath = join(tempDir, "child.yaml");
+    await writeFile(
+      childPath,
+      "extends: ./base.yaml\nsoftware: cursor\nversion: 1\n",
+    );
+
+    const [result] = await loadBindings([childPath]);
+    expect(result.binding.software).toBe("cursor");
+  });
+
+  it("supports chained extends (grandparent → parent → child)", async () => {
+    const gpPath = join(tempDir, "gp.yaml");
+    await writeFile(
+      gpPath,
+      [
+        "software: cursor",
+        "version: 1",
+        "guardrail_impl:",
+        "  gr-gp:",
+        "    checks:",
+        "      - message: grandparent",
+      ].join("\n"),
+    );
+
+    const parentPath = join(tempDir, "parent.yaml");
+    await writeFile(
+      parentPath,
+      [
+        "extends: ./gp.yaml",
+        "software: cursor",
+        "version: 1",
+        "guardrail_impl:",
+        "  gr-parent:",
+        "    checks:",
+        "      - message: parent",
+      ].join("\n"),
+    );
+
+    const childPath = join(tempDir, "child.yaml");
+    await writeFile(
+      childPath,
+      [
+        "extends: ./parent.yaml",
+        "software: cursor",
+        "version: 1",
+        "guardrail_impl:",
+        "  gr-child:",
+        "    checks:",
+        "      - message: child",
+      ].join("\n"),
+    );
+
+    const [result] = await loadBindings([childPath]);
+    const implKeys = Object.keys(result.binding.guardrail_impl ?? {});
+    expect(implKeys).toContain("gr-gp");
+    expect(implKeys).toContain("gr-parent");
+    expect(implKeys).toContain("gr-child");
+  });
+
+  it("throws on circular extends", async () => {
+    const aPath = join(tempDir, "a.yaml");
+    const bPath = join(tempDir, "b.yaml");
+    await writeFile(aPath, "extends: ./b.yaml\nsoftware: x\nversion: 1\n");
+    await writeFile(bPath, "extends: ./a.yaml\nsoftware: x\nversion: 1\n");
+
+    await expect(loadBindings([aPath])).rejects.toSatisfy(
+      (err: unknown) =>
+        err instanceof ConfigLoadError &&
+        err.message.includes("Circular binding extends"),
+    );
+  });
+
+  it("throws when extends target does not exist", async () => {
+    const childPath = join(tempDir, "child.yaml");
+    await writeFile(
+      childPath,
+      "extends: ./nonexistent.yaml\nsoftware: x\nversion: 1\n",
+    );
+
+    await expect(loadBindings([childPath])).rejects.toSatisfy(
+      (err: unknown) =>
+        err instanceof ConfigLoadError &&
+        err.message.includes("Base binding path not found"),
+    );
+  });
+
+  it("resolves extends pointing to a directory with binding.yaml", async () => {
+    const baseDir = join(tempDir, "base-pkg");
+    await mkdir(baseDir, { recursive: true });
+    await writeFile(
+      join(baseDir, "binding.yaml"),
+      [
+        "software: cursor",
+        "version: 1",
+        "guardrail_impl:",
+        "  base-gr:",
+        "    checks:",
+        "      - message: from dir",
+      ].join("\n"),
+    );
+
+    const childPath = join(tempDir, "child.yaml");
+    await writeFile(
+      childPath,
+      [
+        "extends: ./base-pkg",
+        "software: cursor",
+        "version: 1",
+        "guardrail_impl:",
+        "  child-gr:",
+        "    checks:",
+        "      - message: from child",
+      ].join("\n"),
+    );
+
+    const [result] = await loadBindings([childPath]);
+    const implKeys = Object.keys(result.binding.guardrail_impl ?? {});
+    expect(implKeys).toContain("base-gr");
+    expect(implKeys).toContain("child-gr");
+  });
+
+  it("child inherits base reporting when child omits it", async () => {
+    const basePath = join(tempDir, "base.yaml");
+    await writeFile(
+      basePath,
+      [
+        "software: observ",
+        "version: 1",
+        "reporting:",
+        "  commands:",
+        "    emit: 'observ emit {{id}}'",
+        "  fail_open: true",
+        "  timeout_ms: 5000",
+      ].join("\n"),
+    );
+
+    const childPath = join(tempDir, "child.yaml");
+    await writeFile(
+      childPath,
+      "extends: ./base.yaml\nsoftware: observ\nversion: 1\n",
+    );
+
+    const [result] = await loadBindings([childPath]);
+    expect(result.binding.reporting?.commands).toEqual({ emit: "observ emit {{id}}" });
+  });
+
+  it("supports $append merge operator on guardrail_impl checks", async () => {
+    const basePath = join(tempDir, "base.yaml");
+    await writeFile(
+      basePath,
+      [
+        "software: cursor",
+        "version: 1",
+        "guardrail_impl:",
+        "  gr1:",
+        "    checks:",
+        "      - message: base-check-1",
+      ].join("\n"),
+    );
+
+    const childPath = join(tempDir, "child.yaml");
+    await writeFile(
+      childPath,
+      [
+        "extends: ./base.yaml",
+        "software: cursor",
+        "version: 1",
+        "guardrail_impl:",
+        "  gr1:",
+        "    checks:",
+        "      $append:",
+        "        - message: child-check-2",
+      ].join("\n"),
+    );
+
+    const [result] = await loadBindings([childPath]);
+    const checks = result.binding.guardrail_impl!["gr1"]!.checks;
+    expect(checks).toHaveLength(2);
+    expect(checks[0]).toMatchObject({ message: "base-check-1" });
+    expect(checks[1]).toMatchObject({ message: "child-check-2" });
   });
 });

--- a/test/config/binding-merger.test.ts
+++ b/test/config/binding-merger.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from "vitest";
+import { mergeBinding } from "../../src/config/binding-merger.js";
+
+describe("mergeBinding", () => {
+  it("returns project fields when base is empty", () => {
+    const base = { software: "cursor", version: 1 };
+    const project = {
+      extends: "./base.yaml",
+      software: "cursor",
+      version: 1,
+      guardrail_impl: { gr1: { checks: [{ message: "a" }] } },
+    };
+    const result = mergeBinding(base, project);
+    expect(result["guardrail_impl"]).toEqual({
+      gr1: { checks: [{ message: "a" }] },
+    });
+    expect(result["extends"]).toBeUndefined();
+  });
+
+  it("merges guardrail_impl maps from base and project (disjoint keys)", () => {
+    const base = {
+      software: "cursor",
+      version: 1,
+      guardrail_impl: {
+        gr1: { checks: [{ message: "base-1" }] },
+        gr2: { checks: [{ message: "base-2" }] },
+      },
+    };
+    const project = {
+      extends: "./base.yaml",
+      software: "cursor",
+      version: 1,
+      guardrail_impl: {
+        gr3: { checks: [{ message: "proj-3" }] },
+      },
+    };
+    const result = mergeBinding(base, project) as Record<string, unknown>;
+    const impl = result["guardrail_impl"] as Record<string, unknown>;
+    expect(Object.keys(impl)).toEqual(
+      expect.arrayContaining(["gr1", "gr2", "gr3"]),
+    );
+    expect(Object.keys(impl)).toHaveLength(3);
+  });
+
+  it("project guardrail_impl overrides base for same key", () => {
+    const base = {
+      software: "cursor",
+      version: 1,
+      guardrail_impl: {
+        gr1: { checks: [{ message: "base" }] },
+      },
+    };
+    const project = {
+      extends: "./base.yaml",
+      software: "cursor",
+      version: 1,
+      guardrail_impl: {
+        gr1: { checks: [{ message: "project" }] },
+      },
+    };
+    const result = mergeBinding(base, project) as Record<string, unknown>;
+    const impl = result["guardrail_impl"] as Record<string, { checks: unknown[] }>;
+    expect(impl["gr1"]!.checks).toEqual([{ message: "project" }]);
+  });
+
+  it("merges outputs maps from base and project", () => {
+    const base = {
+      software: "cursor",
+      version: 1,
+      outputs: {
+        "hook-script": { target: "a", mode: "write", inline_template: "x" },
+      },
+    };
+    const project = {
+      extends: "./base.yaml",
+      software: "cursor",
+      version: 1,
+      outputs: {
+        "policy-bundle": { target: "b", mode: "write", inline_template: "y" },
+      },
+    };
+    const result = mergeBinding(base, project) as Record<string, unknown>;
+    const outputs = result["outputs"] as Record<string, unknown>;
+    expect(Object.keys(outputs)).toEqual(
+      expect.arrayContaining(["hook-script", "policy-bundle"]),
+    );
+  });
+
+  it("project outputs override base for same key", () => {
+    const base = {
+      software: "cursor",
+      version: 1,
+      outputs: {
+        "policy-bundle": {
+          target: "base-path",
+          mode: "write",
+          inline_template: "base",
+        },
+      },
+    };
+    const project = {
+      extends: "./base.yaml",
+      software: "cursor",
+      version: 1,
+      outputs: {
+        "policy-bundle": {
+          target: "project-path",
+          mode: "write",
+          inline_template: "project",
+        },
+      },
+    };
+    const result = mergeBinding(base, project) as Record<string, unknown>;
+    const outputs = result["outputs"] as Record<string, { target: string }>;
+    expect(outputs["policy-bundle"]!.target).toBe("project-path");
+  });
+
+  it("project software overrides base software", () => {
+    const base = { software: "base-soft", version: 1 };
+    const project = { extends: "./b.yaml", software: "proj-soft", version: 1 };
+    const result = mergeBinding(base, project);
+    expect(result["software"]).toBe("proj-soft");
+  });
+
+  it("inherits base guardrail_impl when project omits it", () => {
+    const base = {
+      software: "cursor",
+      version: 1,
+      guardrail_impl: { gr1: { checks: [{ message: "base" }] } },
+    };
+    const project = { extends: "./base.yaml", software: "cursor", version: 1 };
+    const result = mergeBinding(base, project) as Record<string, unknown>;
+    const impl = result["guardrail_impl"] as Record<string, unknown>;
+    expect(impl["gr1"]).toBeDefined();
+  });
+
+  it("inherits base outputs when project omits outputs", () => {
+    const base = {
+      software: "cursor",
+      version: 1,
+      outputs: {
+        out1: { target: "t", mode: "write", inline_template: "x" },
+      },
+    };
+    const project = { extends: "./base.yaml", software: "cursor", version: 1 };
+    const result = mergeBinding(base, project) as Record<string, unknown>;
+    const outputs = result["outputs"] as Record<string, unknown>;
+    expect(outputs["out1"]).toBeDefined();
+  });
+
+  it("deep-merges reporting from base and project", () => {
+    const base = {
+      software: "observ",
+      version: 1,
+      reporting: {
+        commands: { emit: "observ emit", on_fail: "observ fail" },
+        fail_open: true,
+        timeout_ms: 5000,
+      },
+    };
+    const project = {
+      extends: "./base.yaml",
+      software: "observ",
+      version: 1,
+      reporting: {
+        timeout_ms: 3000,
+      },
+    };
+    const result = mergeBinding(base, project) as Record<string, unknown>;
+    const reporting = result["reporting"] as Record<string, unknown>;
+    expect(reporting["timeout_ms"]).toBe(3000);
+    expect(reporting["fail_open"]).toBe(true);
+    expect(reporting["commands"]).toEqual({ emit: "observ emit", on_fail: "observ fail" });
+  });
+
+  it("strips extends from the merged result", () => {
+    const base = { software: "cursor", version: 1 };
+    const project = { extends: "./base.yaml", software: "cursor", version: 1 };
+    const result = mergeBinding(base, project);
+    expect(result["extends"]).toBeUndefined();
+  });
+
+  it("preserves passthrough fields from base and project", () => {
+    const base = { software: "cursor", version: 1, "x-base-meta": "from-base" };
+    const project = {
+      extends: "./base.yaml",
+      software: "cursor",
+      version: 1,
+      "x-proj-meta": "from-proj",
+    };
+    const result = mergeBinding(base, project);
+    expect(result["x-base-meta"]).toBe("from-base");
+    expect(result["x-proj-meta"]).toBe("from-proj");
+  });
+});


### PR DESCRIPTION
## Summary

- Implement `extends` for software binding files, mirroring the DSL-level extends mechanism
- Binding files can now inherit `guardrail_impl`, `outputs`, and `reporting` from a base binding and add/override with project-specific entries
- Solves the problem where multiple bindings for the same software produced separate output files instead of a single merged artifact
- All DSL merge operators (`$append`, `$prepend`, `$insert_after`, `$replace`, `$remove`) work within binding extends

## Changes

| File | Change |
|------|--------|
| `src/config/binding-merger.ts` | New — `mergeBinding()` reusing DSL merger primitives |
| `src/config/binding-loader.ts` | Resolve `extends` chains recursively before schema validation |
| `src/resolver/merger.ts` | Export `deepMergeEntities` and `mergeEntityMaps` for reuse |
| `src/resolver/index.ts` | Add exports |
| `test/config/binding-merger.test.ts` | 11 unit tests for mergeBinding |
| `test/config/binding-loader.test.ts` | 10 integration tests for binding extends |
| `README.md` | Document binding inheritance |
| `docs/spec/guardrail-di.md` | Expand §10.2 with full implementation spec |
| `package.json` | Bump 0.11.0 → 0.11.1 |

## Test plan

- [x] All 422 existing tests pass
- [x] 21 new tests covering: disjoint merge, same-key override, output merge, chained extends, circular detection, directory resolution, `$append` operator, reporting inheritance, passthrough fields

Made with [Cursor](https://cursor.com)