### PR TITLE
fix: YAML safety — reserved word collision lint, routing_key alias, expand-defaults, x-extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,12 +221,13 @@ A **Workflow** defines a phase-level execution sequence:
 * `entry_conditions`
 * `trigger`
 * `external_participants` — actors/participants outside the agent system (e.g., User, external advisory)
-* ordered steps (handoff, validation, decision)
+* ordered steps (delegate, gate, validation, decision)
 
 Workflow steps support additional properties:
 
 * `group` — consecutive steps with the same group are rendered as `par` (parallel) blocks in sequence diagrams
-* `retry` (handoff steps only) — defines a conditional retry loop with `condition`, `fix_task`, and optional `revalidate_task`
+* `retry` (delegate steps) — defines a conditional retry loop with `condition`, `fix_task`, and optional `revalidate_task`
+* `routing_key` (decision steps) — the field that determines branch selection. The legacy field `on` is still accepted but deprecated due to YAML 1.1 reserved word collision
 
 ### Guardrail
 
@@ -305,6 +306,9 @@ Design regressions become testable.
 * **Software bindings** (DI) for tool-specific guardrail implementation (Cursor, Git, GitHub)
 * **Guardrail generation** from DSL + policy + bindings via `generate guardrails`
 * **Flexible file splitting** via `$ref` (replacement), `$refs` (import + deep-merge), and JSON Pointer `$ref` (in-document)
+* **YAML safety linting** for reserved word collision detection across YAML 1.1/1.2
+* **`x-extensions` declarations** for documenting project-specific custom extension fields
+* **`resolve --expand-defaults`** to materialize all Zod schema defaults in output
 * **JSON Schema for editor support and external tooling**
 * **CI-friendly workflow checks**
 
@@ -342,6 +346,16 @@ guardrails: {}
 guardrail_policies: {}
 components:
   schemas: {}
+
+# Optional: declare project-specific x-* extensions
+x-extensions:
+  x-flags:
+    type: array
+    items: string
+    description: "CLI flags for tool commands"
+  x-check-script:
+    type: string
+    description: "Path to hook check script"
 ````
 
 This makes definitions easy to merge, extend, and reference by stable identifiers.
@@ -572,6 +586,23 @@ tasks:
 `x-` prefixed custom properties work at any nesting level — including inside
 `execution_steps`, `rules`, `workflow.steps`, and other nested objects.
 
+### `x-extensions` declarations
+
+Projects can optionally declare their custom `x-*` extension fields in the DSL using `x-extensions`. This makes extensions discoverable and self-documenting:
+
+````yaml
+x-extensions:
+  x-flags:
+    type: array
+    items: string
+    description: "CLI flags for tool commands"
+  x-check-script:
+    type: string
+    description: "Path to hook check script"
+````
+
+Each key must start with `x-` (validated at schema level). The `type`, `items`, and `description` fields describe the expected shape. This declaration is informational today; future versions may validate `x-*` field values against their declared schemas.
+
 ---
 
 ## Example: Artifact definition
@@ -602,20 +633,19 @@ workflow:
       - User story or feature request received
     trigger: "User invokes /speckit.specify or asks to create a feature spec."
     steps:
-      - type: handoff
-        handoff_kind: delegation
+      - type: delegate
         task: specify-feature
         from_agent: main-architect
       - type: validation
-        validation_id: spec-semantic-review
+        validation: spec-semantic-review
       - type: decision
-        agent: main-architect
-        options:
-          - label: approve
-            next_workflow: plan
-          - label: revise
-            retry_from_step: 0
+        routing_key: evidence-gate-verdict.verdict
+        branches:
+          PASS: [plan]
+          REVISE: [specify-feature]
 ````
+
+Decision steps use `routing_key` to specify the field that determines branching. The legacy `on` field is still accepted but deprecated — see [YAML safety](#yaml-safety) below.
 
 ---
 
@@ -819,10 +849,19 @@ npx agent-contracts
 The `[path]` argument defaults to `agent-contracts.yaml` in the current directory.
 If `-c` / `--config` is specified, the DSL path from the config file is used.
 
+#### `resolve` options
+
+| Option | Description |
+|--------|-------------|
+| `--format <text\|json>` | Output format (default: `text`) |
+| `--expand-defaults` | Expand all Zod default values in output. Fields like `required_validations: []`, `tags: []`, and `can_read_artifacts: []` are written explicitly instead of being silently applied by schema defaults. |
+| `-c, --config <path>` | Path to `agent-contracts.config.yaml` |
+
 ### Common usage
 
 ````bash
 agent-contracts resolve
+agent-contracts resolve --expand-defaults --format json
 agent-contracts validate
 agent-contracts lint --strict
 agent-contracts render -c agent-contracts.config.yaml
@@ -1153,6 +1192,34 @@ Checks:
 
 Custom properties with `x-` prefix are allowed on any object in the DSL — top-level entities (agents, tasks, artifacts, …), nested objects (rules, execution steps, workflow steps, …), and the root DSL itself.
 
+### YAML safety
+
+The DSL is expressed in YAML, which introduces risks from YAML 1.1's implicit type coercion. The `yaml-reserved-key-safety` lint rule warns when reserved words appear in positions that may be misinterpreted by non-1.2 parsers.
+
+The most notable case is the `on` field in decision steps. In YAML 1.1, bare `on` as a mapping key is interpreted as boolean `true`. While `agent-contracts` uses a YAML 1.2 parser internally, DSL consumers (CI tools, editors, other parsers) may use YAML 1.1 parsers.
+
+To address this:
+
+* Decision steps now support `routing_key` as the preferred field name (replacing `on`)
+* The legacy `on` field is still accepted for backward compatibility but triggers a lint warning
+* Branch keys like `yes`, `no`, `true`, `false` also trigger warnings
+
+````yaml
+# Preferred — safe across all YAML versions
+- type: decision
+  routing_key: evidence-gate-verdict.verdict
+  branches:
+    PASS: [release]
+    FAIL: [fix-violations]
+
+# Deprecated — works but triggers yaml-reserved-key-safety warning
+- type: decision
+  on: evidence-gate-verdict.verdict
+  branches:
+    PASS: [release]
+    FAIL: [fix-violations]
+````
+
 ### Reference integrity
 
 Checks:
@@ -1174,6 +1241,7 @@ Checks:
 * prerequisite readability
 * artifact ownership — `produces_artifact`/`reads_artifact` in execution steps vs. artifact producers/editors/consumers
 * tool commands — `commands[].reads`/`commands[].writes` reference valid artifacts and align with `output_artifacts`
+* YAML safety — warns when YAML 1.1 reserved words (`on`, `yes`, `no`, `true`, `false`, etc.) are used in positions where they may be misinterpreted by non-1.2 parsers
 * naming/style issues through Spectral rules
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-contracts",
-  "version": "0.11.2",
+  "version": "0.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-contracts",
-      "version": "0.11.2",
+      "version": "0.11.5",
       "license": "MIT",
       "dependencies": {
         "@stoplight/spectral-core": "^1.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/schemas/dsl.schema.json
+++ b/schemas/dsl.schema.json
@@ -841,6 +841,9 @@
                     "on": {
                       "type": "string"
                     },
+                    "routing_key": {
+                      "type": "string"
+                    },
                     "branches": {
                       "type": "object",
                       "propertyNames": {
@@ -859,7 +862,6 @@
                   },
                   "required": [
                     "type",
-                    "on",
                     "branches"
                   ],
                   "additionalProperties": {}
@@ -1125,6 +1127,30 @@
         "schemas"
       ],
       "additionalProperties": {}
+    },
+    "x-extensions": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "items": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "additionalProperties": false
+      }
     }
   },
   "required": [

--- a/src/cli/commands/resolve.ts
+++ b/src/cli/commands/resolve.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { loadConfig, resolveDslPath } from "../../config/index.js";
 import { resolve, substituteVars } from "../../resolver/index.js";
+import { expandDefaults } from "../../resolver/expand-defaults.js";
 import { stringify } from "yaml";
 
 const DIR_DEFAULT = "agent-contracts.yaml";
@@ -10,14 +11,18 @@ export const resolveCommand = new Command("resolve")
   .argument("[dir]", "Path to agent-contracts.yaml", DIR_DEFAULT)
   .option("-c, --config <path>", "Path to agent-contracts.config.yaml")
   .option("--format <format>", "Output format (text|json)", "text")
-  .action(async (dir: string, opts: { config?: string; format: string }) => {
+  .option("--expand-defaults", "Expand all Zod default values in output", false)
+  .action(async (dir: string, opts: { config?: string; format: string; expandDefaults: boolean }) => {
     try {
       const config = await loadConfig(opts.config);
       const dslPath = resolveDslPath(dir, DIR_DEFAULT, config);
       const result = await resolve(dslPath);
-      const data = config?.vars
+      let data = config?.vars
         ? substituteVars(result.data, config.vars)
         : result.data;
+      if (opts.expandDefaults) {
+        data = expandDefaults(data);
+      }
       if (opts.format === "json") {
         process.stdout.write(JSON.stringify(data, null, 2) + "\n");
       } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 export * from "./schema/index.js";
 export { loadDsl, DslLoadError, type LoadResult } from "./loader/index.js";
-export { resolve, mergeDsl, resolveBase, MergeError, BaseResolveError, type ResolveResult } from "./resolver/index.js";
+export { resolve, mergeDsl, resolveBase, expandDefaults, MergeError, BaseResolveError, type ResolveResult } from "./resolver/index.js";
 export { validateSchema, checkReferences, validateHandoffSchemas, type SchemaValidationResult, type DiagnosticMessage, type ReferenceDiagnostic } from "./validator/index.js";
-export { lint, builtinRules, spectralLint, type LintRule, type LintDiagnostic, type Severity } from "./linter/index.js";
+export { lint, builtinRules, spectralLint, yamlReservedKeySafetyRule, type LintRule, type LintDiagnostic, type Severity } from "./linter/index.js";
 export {
   renderFromConfig,
   checkDriftFromConfig,

--- a/src/linter/index.ts
+++ b/src/linter/index.ts
@@ -8,3 +8,4 @@ export { mergeIntegrityRule } from "./rules/merge-integrity.js";
 export { artifactOwnershipRule } from "./rules/artifact-ownership.js";
 export { toolCommandsRule } from "./rules/tool-commands.js";
 export { guardrailPolicyCoverageRule } from "./rules/guardrail-policy-coverage.js";
+export { yamlReservedKeySafetyRule } from "./rules/yaml-reserved-key-safety.js";

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -7,6 +7,7 @@ import { mergeIntegrityRule } from "./rules/merge-integrity.js";
 import { artifactOwnershipRule } from "./rules/artifact-ownership.js";
 import { toolCommandsRule } from "./rules/tool-commands.js";
 import { guardrailPolicyCoverageRule } from "./rules/guardrail-policy-coverage.js";
+import { yamlReservedKeySafetyRule } from "./rules/yaml-reserved-key-safety.js";
 
 const builtinRules: LintRule[] = [
   validationCoverageRule,
@@ -16,6 +17,7 @@ const builtinRules: LintRule[] = [
   artifactOwnershipRule,
   toolCommandsRule,
   guardrailPolicyCoverageRule,
+  yamlReservedKeySafetyRule,
 ];
 
 export function lint(

--- a/src/linter/rules/yaml-reserved-key-safety.ts
+++ b/src/linter/rules/yaml-reserved-key-safety.ts
@@ -1,0 +1,54 @@
+import type { Dsl } from "../../schema/index.js";
+import type { LintRule, LintDiagnostic } from "../types.js";
+
+const YAML_11_RESERVED_KEYS = new Set([
+  "on",
+  "off",
+  "yes",
+  "no",
+  "true",
+  "false",
+  "y",
+  "n",
+]);
+
+export const yamlReservedKeySafetyRule: LintRule = {
+  id: "yaml-reserved-key-safety",
+  description:
+    "Warns when YAML 1.1 reserved words are used as field values in positions where they may be misinterpreted by non-1.2 parsers",
+
+  run(dsl: Dsl): LintDiagnostic[] {
+    const diagnostics: LintDiagnostic[] = [];
+
+    for (const [wfKey, wf] of Object.entries(dsl.workflow)) {
+      for (let i = 0; i < wf.steps.length; i++) {
+        const step = wf.steps[i];
+        if (step.type !== "decision") continue;
+
+        if (step.on !== undefined && step.routing_key === undefined) {
+          diagnostics.push({
+            ruleId: "yaml-reserved-key-safety",
+            severity: "warning",
+            path: `workflow.${wfKey}.steps[${i}].on`,
+            message:
+              'Field name "on" is a YAML 1.1 reserved word and may be interpreted as boolean true by some parsers. Use "routing_key" instead.',
+          });
+        }
+
+        const branchKeys = Object.keys(step.branches);
+        for (const key of branchKeys) {
+          if (YAML_11_RESERVED_KEYS.has(key.toLowerCase())) {
+            diagnostics.push({
+              ruleId: "yaml-reserved-key-safety",
+              severity: "warning",
+              path: `workflow.${wfKey}.steps[${i}].branches.${key}`,
+              message: `Branch key "${key}" is a YAML 1.1 reserved word and may be interpreted as a boolean by some parsers. Consider quoting or renaming.`,
+            });
+          }
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/src/resolver/expand-defaults.ts
+++ b/src/resolver/expand-defaults.ts
@@ -1,0 +1,16 @@
+import { DslSchema } from "../schema/index.js";
+
+/**
+ * Parse the resolved DSL through Zod to fill all schema-defined default
+ * values, then return the fully-expanded plain object.
+ *
+ * If parsing fails (e.g. the DSL has validation errors), the original
+ * data is returned unchanged so that `resolve` remains non-destructive.
+ */
+export function expandDefaults(
+  data: Record<string, unknown>,
+): Record<string, unknown> {
+  const result = DslSchema.safeParse(data);
+  if (!result.success) return data;
+  return JSON.parse(JSON.stringify(result.data));
+}

--- a/src/resolver/index.ts
+++ b/src/resolver/index.ts
@@ -7,3 +7,4 @@ export {
 } from "./merger.js";
 export { resolve, type ResolveResult } from "./resolve.js";
 export { substituteVars, VarsSubstitutionError } from "./substitute-vars.js";
+export { expandDefaults } from "./expand-defaults.js";

--- a/src/schema/dsl.ts
+++ b/src/schema/dsl.ts
@@ -23,6 +23,18 @@ export const ComponentsSchema = z
   .passthrough();
 export type Components = z.infer<typeof ComponentsSchema>;
 
+/**
+ * Declaration of project-specific `x-*` extension fields.
+ * Each key must start with `x-` and describes the expected type/shape
+ * so that tooling can validate custom extensions in the future.
+ */
+export const XExtensionDeclSchema = z.object({
+  type: z.string(),
+  items: z.string().optional(),
+  description: z.string().optional(),
+});
+export type XExtensionDecl = z.infer<typeof XExtensionDeclSchema>;
+
 export const DslSchema = z
   .object({
     version: z.literal(1),
@@ -41,6 +53,9 @@ export const DslSchema = z
       .record(z.string(), GuardrailPolicySchema)
       .default({}),
     components: ComponentsSchema.default({ schemas: {} }),
+    "x-extensions": z
+      .record(z.string(), XExtensionDeclSchema)
+      .optional(),
   })
   .passthrough();
 export type Dsl = z.infer<typeof DslSchema>;

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -21,7 +21,7 @@ export {
   type Reporting,
   type SoftwareBinding,
 } from "./binding.js";
-export { ComponentsSchema, DslSchema, type Components, type Dsl } from "./dsl.js";
+export { ComponentsSchema, DslSchema, XExtensionDeclSchema, type Components, type Dsl, type XExtensionDecl } from "./dsl.js";
 export { HandoffTypeSchema, type HandoffType } from "./handoff-type.js";
 export {
   GuardrailPolicyRuleEscalationSchema,

--- a/src/schema/workflow.ts
+++ b/src/schema/workflow.ts
@@ -62,7 +62,9 @@ const WorkflowDecisionStepSchema = z
   .object({
     type: z.literal("decision"),
     description: z.string().optional(),
-    on: z.string(),
+    /** @deprecated Use `routing_key` instead. `on` is kept for backward compatibility. */
+    on: z.string().optional(),
+    routing_key: z.string().optional(),
     branches: z.record(z.string(), z.array(z.string())),
     group: z.string().optional(),
   })

--- a/src/validator/schema-validator.ts
+++ b/src/validator/schema-validator.ts
@@ -92,6 +92,54 @@ function checkCustomPropsRecursive(
 
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
+function checkXExtensionsKeys(
+  data: Record<string, unknown>,
+): DiagnosticMessage[] {
+  const extensions = data["x-extensions"];
+  if (typeof extensions !== "object" || extensions === null) return [];
+  const diagnostics: DiagnosticMessage[] = [];
+  for (const key of Object.keys(extensions as Record<string, unknown>)) {
+    if (!key.startsWith("x-")) {
+      diagnostics.push({
+        path: `x-extensions.${key}`,
+        message: `Extension key "${key}" must start with "x-" prefix.`,
+        code: "x-extension-key-prefix",
+      });
+    }
+  }
+  return diagnostics;
+}
+
+function checkDecisionStepRoutingKey(
+  data: Record<string, unknown>,
+): DiagnosticMessage[] {
+  const workflow = data["workflow"];
+  if (typeof workflow !== "object" || workflow === null) return [];
+  const diagnostics: DiagnosticMessage[] = [];
+  for (const [wfKey, wf] of Object.entries(
+    workflow as Record<string, unknown>,
+  )) {
+    if (typeof wf !== "object" || wf === null) continue;
+    const steps = (wf as Record<string, unknown>)["steps"];
+    if (!Array.isArray(steps)) continue;
+    for (let i = 0; i < steps.length; i++) {
+      const step = steps[i];
+      if (typeof step !== "object" || step === null) continue;
+      const s = step as Record<string, unknown>;
+      if (s["type"] !== "decision") continue;
+      if (s["routing_key"] === undefined && s["on"] === undefined) {
+        diagnostics.push({
+          path: `workflow.${wfKey}.steps[${i}]`,
+          message:
+            'Decision step requires "routing_key" (or deprecated "on"). Prefer "routing_key".',
+          code: "decision-missing-routing-key",
+        });
+      }
+    }
+  }
+  return diagnostics;
+}
+
 export function validateSchema(
   data: Record<string, unknown>,
 ): SchemaValidationResult {
@@ -109,6 +157,16 @@ export function validateSchema(
   const customPropDiagnostics = checkCustomPropsRecursive(data, DslSchema, "");
   if (customPropDiagnostics.length > 0) {
     return { success: false, diagnostics: customPropDiagnostics };
+  }
+
+  const decisionDiagnostics = checkDecisionStepRoutingKey(data);
+  if (decisionDiagnostics.length > 0) {
+    return { success: false, diagnostics: decisionDiagnostics };
+  }
+
+  const xExtDiagnostics = checkXExtensionsKeys(data);
+  if (xExtDiagnostics.length > 0) {
+    return { success: false, diagnostics: xExtDiagnostics };
   }
 
   return { success: true, data: result.data, diagnostics: [] };

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -55,6 +55,20 @@ describe("agent-contracts resolve", () => {
     expect(exitCode).toBe(1);
     expect(stderr).toContain("Error");
   });
+
+  it("--expand-defaults fills Zod default values", async () => {
+    const { stdout, exitCode } = await run([
+      "resolve", minimalYaml, "--expand-defaults", "--format", "json",
+    ]);
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(data.policies).toEqual({});
+    expect(data.guardrails).toEqual({});
+    expect(data.guardrail_policies).toEqual({});
+    const agent = data.agents?.implementer;
+    expect(agent).toBeDefined();
+    expect(agent.can_perform_validations).toEqual([]);
+  });
 });
 
 describe("agent-contracts validate", () => {

--- a/test/fixtures/full/agent-contracts.yaml
+++ b/test/fixtures/full/agent-contracts.yaml
@@ -272,7 +272,7 @@ workflow:
       - type: validation
         validation: code-lint
       - type: decision
-        on: evidence-gate-verdict.verdict
+        routing_key: evidence-gate-verdict.verdict
         branches:
           PASS: [continue]
           BLOCK: [stop]

--- a/test/linter/yaml-reserved-key-safety.test.ts
+++ b/test/linter/yaml-reserved-key-safety.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import { DslSchema, type Dsl } from "../../src/schema/index.js";
+import { yamlReservedKeySafetyRule } from "../../src/linter/rules/yaml-reserved-key-safety.js";
+
+function makeDsl(partial: Partial<Record<string, unknown>>): Dsl {
+  return DslSchema.parse({
+    version: 1,
+    system: { id: "s", name: "S", default_workflow_order: ["implement"] },
+    ...partial,
+  });
+}
+
+describe("yamlReservedKeySafetyRule", () => {
+  it("warns when decision step uses 'on' without 'routing_key'", () => {
+    const dsl = makeDsl({
+      workflow: {
+        implement: {
+          steps: [
+            {
+              type: "decision",
+              on: "some-field.verdict",
+              branches: { PASS: ["next"], FAIL: ["stop"] },
+            },
+          ],
+        },
+      },
+    });
+    const diags = yamlReservedKeySafetyRule.run(dsl);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].ruleId).toBe("yaml-reserved-key-safety");
+    expect(diags[0].severity).toBe("warning");
+    expect(diags[0].path).toBe("workflow.implement.steps[0].on");
+    expect(diags[0].message).toContain("routing_key");
+  });
+
+  it("does not warn when decision step uses 'routing_key'", () => {
+    const dsl = makeDsl({
+      workflow: {
+        implement: {
+          steps: [
+            {
+              type: "decision",
+              routing_key: "some-field.verdict",
+              branches: { PASS: ["next"], FAIL: ["stop"] },
+            },
+          ],
+        },
+      },
+    });
+    const diags = yamlReservedKeySafetyRule.run(dsl);
+    const onWarnings = diags.filter((d) => d.path.endsWith(".on"));
+    expect(onWarnings).toHaveLength(0);
+  });
+
+  it("does not warn about 'on' when 'routing_key' is also present", () => {
+    const dsl = makeDsl({
+      workflow: {
+        implement: {
+          steps: [
+            {
+              type: "decision",
+              on: "legacy.path",
+              routing_key: "some-field.verdict",
+              branches: { PASS: ["next"] },
+            },
+          ],
+        },
+      },
+    });
+    const diags = yamlReservedKeySafetyRule.run(dsl);
+    const onWarnings = diags.filter((d) => d.path.endsWith(".on"));
+    expect(onWarnings).toHaveLength(0);
+  });
+
+  it("warns on YAML reserved words in branch keys", () => {
+    const dsl = makeDsl({
+      workflow: {
+        implement: {
+          steps: [
+            {
+              type: "decision",
+              routing_key: "field.path",
+              branches: { yes: ["a"], no: ["b"] },
+            },
+          ],
+        },
+      },
+    });
+    const diags = yamlReservedKeySafetyRule.run(dsl);
+    const branchWarnings = diags.filter((d) => d.path.includes("branches"));
+    expect(branchWarnings).toHaveLength(2);
+    expect(branchWarnings[0].message).toContain("YAML 1.1 reserved word");
+  });
+
+  it("warns on case-insensitive YAML reserved branch keys", () => {
+    const dsl = makeDsl({
+      workflow: {
+        implement: {
+          steps: [
+            {
+              type: "decision",
+              routing_key: "field",
+              branches: { TRUE: ["a"], FALSE: ["b"], NORMAL: ["c"] },
+            },
+          ],
+        },
+      },
+    });
+    const diags = yamlReservedKeySafetyRule.run(dsl);
+    const branchWarnings = diags.filter((d) => d.path.includes("branches"));
+    expect(branchWarnings).toHaveLength(2);
+  });
+
+  it("returns no warnings when no decision steps exist", () => {
+    const dsl = makeDsl({
+      workflow: {
+        implement: {
+          steps: [
+            { type: "gate", gate_kind: "evidence-gate" },
+          ],
+        },
+      },
+    });
+    const diags = yamlReservedKeySafetyRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("scans multiple workflows", () => {
+    const dsl = makeDsl({
+      workflow: {
+        phase1: {
+          steps: [
+            {
+              type: "decision",
+              on: "field1",
+              branches: { A: ["a"] },
+            },
+          ],
+        },
+        phase2: {
+          steps: [
+            {
+              type: "decision",
+              on: "field2",
+              branches: { B: ["b"] },
+            },
+          ],
+        },
+      },
+    });
+    const diags = yamlReservedKeySafetyRule.run(dsl);
+    const onWarnings = diags.filter((d) => d.path.endsWith(".on"));
+    expect(onWarnings).toHaveLength(2);
+  });
+});

--- a/test/resolver/expand-defaults.test.ts
+++ b/test/resolver/expand-defaults.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { expandDefaults } from "../../src/resolver/expand-defaults.js";
+
+describe("expandDefaults", () => {
+  it("fills Zod default arrays on a minimal DSL", () => {
+    const data: Record<string, unknown> = {
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: [] },
+    };
+    const expanded = expandDefaults(data);
+    expect(expanded["agents"]).toEqual({});
+    expect(expanded["tasks"]).toEqual({});
+    expect(expanded["artifacts"]).toEqual({});
+    expect(expanded["tools"]).toEqual({});
+    expect(expanded["validations"]).toEqual({});
+    expect(expanded["handoff_types"]).toEqual({});
+    expect(expanded["workflow"]).toEqual({});
+    expect(expanded["policies"]).toEqual({});
+    expect(expanded["guardrails"]).toEqual({});
+    expect(expanded["guardrail_policies"]).toEqual({});
+  });
+
+  it("fills nested default arrays in agents", () => {
+    const data: Record<string, unknown> = {
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: [] },
+      agents: {
+        a1: { role_name: "R", purpose: "P" },
+      },
+    };
+    const expanded = expandDefaults(data);
+    const agent = (expanded["agents"] as Record<string, Record<string, unknown>>)["a1"];
+    expect(agent["can_read_artifacts"]).toEqual([]);
+    expect(agent["can_write_artifacts"]).toEqual([]);
+    expect(agent["can_execute_tools"]).toEqual([]);
+    expect(agent["can_invoke_agents"]).toEqual([]);
+    expect(agent["can_return_handoffs"]).toEqual([]);
+  });
+
+  it("fills workflow entry_conditions and external_participants defaults", () => {
+    const data: Record<string, unknown> = {
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: ["impl"] },
+      workflow: {
+        impl: {
+          steps: [{ type: "gate", gate_kind: "evidence-gate" }],
+        },
+      },
+    };
+    const expanded = expandDefaults(data);
+    const wf = (expanded["workflow"] as Record<string, Record<string, unknown>>)["impl"];
+    expect(wf["entry_conditions"]).toEqual([]);
+    expect(wf["external_participants"]).toEqual([]);
+  });
+
+  it("preserves existing values and does not overwrite them", () => {
+    const data: Record<string, unknown> = {
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: ["impl"] },
+      agents: {
+        a1: { role_name: "R", purpose: "P", can_read_artifacts: ["art1"] },
+      },
+    };
+    const expanded = expandDefaults(data);
+    const agent = (expanded["agents"] as Record<string, Record<string, unknown>>)["a1"];
+    expect(agent["can_read_artifacts"]).toEqual(["art1"]);
+  });
+
+  it("returns original data when schema parsing fails", () => {
+    const badData = { invalid: true } as unknown as Record<string, unknown>;
+    const result = expandDefaults(badData);
+    expect(result).toEqual(badData);
+  });
+});

--- a/test/schema/schema.test.ts
+++ b/test/schema/schema.test.ts
@@ -309,7 +309,7 @@ describe("WorkflowStepSchema discriminated union", () => {
     }
   });
 
-  it("parses decision step", () => {
+  it("parses decision step with on (deprecated)", () => {
     const s = WorkflowStepSchema.parse({
       type: "decision",
       on: "field.path",
@@ -319,6 +319,33 @@ describe("WorkflowStepSchema discriminated union", () => {
     if (s.type === "decision") {
       expect(s.on).toBe("field.path");
       expect(s.branches.B).toEqual([]);
+    }
+  });
+
+  it("parses decision step with routing_key", () => {
+    const s = WorkflowStepSchema.parse({
+      type: "decision",
+      routing_key: "field.path",
+      branches: { A: ["s1"], B: [] },
+    });
+    expect(s.type).toBe("decision");
+    if (s.type === "decision") {
+      expect(s.routing_key).toBe("field.path");
+      expect(s.branches.B).toEqual([]);
+    }
+  });
+
+  it("parses decision step with both on and routing_key", () => {
+    const s = WorkflowStepSchema.parse({
+      type: "decision",
+      on: "legacy.path",
+      routing_key: "field.path",
+      branches: { A: ["s1"] },
+    });
+    expect(s.type).toBe("decision");
+    if (s.type === "decision") {
+      expect(s.routing_key).toBe("field.path");
+      expect(s.on).toBe("legacy.path");
     }
   });
 

--- a/test/validator/validator.test.ts
+++ b/test/validator/validator.test.ts
@@ -777,3 +777,91 @@ describe("checkReferences — guardrail scope and policy references", () => {
     expect(grDiags).toHaveLength(0);
   });
 });
+
+describe("validateSchema — decision step routing_key", () => {
+  it("accepts decision step with routing_key", () => {
+    const data = {
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: ["impl"] },
+      workflow: {
+        impl: {
+          steps: [
+            { type: "decision", routing_key: "field.verdict", branches: { PASS: ["a"] } },
+          ],
+        },
+      },
+    };
+    const result = validateSchema(data);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts decision step with deprecated on", () => {
+    const data = {
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: ["impl"] },
+      workflow: {
+        impl: {
+          steps: [
+            { type: "decision", on: "field.verdict", branches: { PASS: ["a"] } },
+          ],
+        },
+      },
+    };
+    const result = validateSchema(data);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects decision step with neither on nor routing_key", () => {
+    const data = {
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: ["impl"] },
+      workflow: {
+        impl: {
+          steps: [
+            { type: "decision", branches: { PASS: ["a"] } },
+          ],
+        },
+      },
+    };
+    const result = validateSchema(data);
+    expect(result.success).toBe(false);
+    expect(result.diagnostics.some((d) => d.code === "decision-missing-routing-key")).toBe(true);
+  });
+});
+
+describe("validateSchema — x-extensions key validation", () => {
+  it("accepts x-extensions with x- prefixed keys", () => {
+    const data = {
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: [] },
+      "x-extensions": {
+        "x-flags": { type: "array", items: "string", description: "CLI flags" },
+        "x-check-script": { type: "string", description: "Hook check script path" },
+      },
+    };
+    const result = validateSchema(data);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects x-extensions with non-x- prefixed keys", () => {
+    const data = {
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: [] },
+      "x-extensions": {
+        "flags": { type: "array", description: "bad key" },
+      },
+    };
+    const result = validateSchema(data);
+    expect(result.success).toBe(false);
+    expect(result.diagnostics.some((d) => d.code === "x-extension-key-prefix")).toBe(true);
+  });
+
+  it("accepts DSL without x-extensions", () => {
+    const data = {
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: [] },
+    };
+    const result = validateSchema(data);
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Addresses all items in #6:

- **`yaml-reserved-key-safety` lint rule** — warns when YAML 1.1 reserved words (`on`, `yes`, `no`, `true`, `false`, etc.) appear in decision step fields where they may be misinterpreted by non-1.2 parsers
- **`routing_key` alias for `on`** (Option A, non-breaking) — decision steps now accept `routing_key` as preferred field; `on` remains accepted with deprecation warning via lint
- **`resolve --expand-defaults`** — materializes all Zod schema defaults in resolved output so teams can see the effective DSL without hidden defaults
- **`x-extensions` declaration** — optional section for documenting project-specific `x-*` fields with type/description, validated at schema level
- **README updated** — YAML safety section, routing_key migration guide, CLI options, x-extensions docs, features list

## Test plan

- [x] 448 tests pass (21 test files)
- [x] TypeScript typecheck clean
- [x] New tests for yaml-reserved-key-safety (7 cases)
- [x] New tests for expand-defaults (5 cases)
- [x] New validator tests for routing_key and x-extensions (6 cases)
- [x] Updated schema tests for routing_key parsing (3 cases)
- [x] CLI test for --expand-defaults
- [x] JSON schema regenerated

Closes #6

Made with [Cursor](https://cursor.com)