### PR TITLE
feat: artifact-centric validation binding lint rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1234,7 +1234,9 @@ Checks:
 Checks:
 
 * bidirectional consistency
-* validation coverage
+* validation coverage — warns when artifacts lack validations or have empty `required_validations` (fails under `--strict`)
+* artifact-required-validation wiring — verifies every entry in `artifact.required_validations` exists, targets the correct artifact, and is referenced in a workflow step or task
+* task-output-validation completeness — checks that tasks producing artifacts (via `execution_steps.produces_artifact` or agent `can_write_artifacts`) cover those artifacts' `required_validations`
 * workflow graph completeness
 * merge integrity
 * read-only write violations
@@ -1243,6 +1245,10 @@ Checks:
 * tool commands — `commands[].reads`/`commands[].writes` reference valid artifacts and align with `output_artifacts`
 * YAML safety — warns when YAML 1.1 reserved words (`on`, `yes`, `no`, `true`, `false`, etc.) are used in positions where they may be misinterpreted by non-1.2 parsers
 * naming/style issues through Spectral rules
+
+#### `--strict` mode
+
+When `--strict` is passed to `lint` or `check`, warnings are treated as failures (exit code 1). This is particularly relevant for artifact-centric validation rules — empty `required_validations`, orphaned validation wiring, and incomplete task coverage are all warnings that become blocking under `--strict`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/linter/index.ts
+++ b/src/linter/index.ts
@@ -9,3 +9,5 @@ export { artifactOwnershipRule } from "./rules/artifact-ownership.js";
 export { toolCommandsRule } from "./rules/tool-commands.js";
 export { guardrailPolicyCoverageRule } from "./rules/guardrail-policy-coverage.js";
 export { yamlReservedKeySafetyRule } from "./rules/yaml-reserved-key-safety.js";
+export { artifactRequiredValidationWiringRule } from "./rules/artifact-required-validation-wiring.js";
+export { taskOutputValidationCompletenessRule } from "./rules/task-output-validation-completeness.js";

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -8,6 +8,8 @@ import { artifactOwnershipRule } from "./rules/artifact-ownership.js";
 import { toolCommandsRule } from "./rules/tool-commands.js";
 import { guardrailPolicyCoverageRule } from "./rules/guardrail-policy-coverage.js";
 import { yamlReservedKeySafetyRule } from "./rules/yaml-reserved-key-safety.js";
+import { artifactRequiredValidationWiringRule } from "./rules/artifact-required-validation-wiring.js";
+import { taskOutputValidationCompletenessRule } from "./rules/task-output-validation-completeness.js";
 
 const builtinRules: LintRule[] = [
   validationCoverageRule,
@@ -18,6 +20,8 @@ const builtinRules: LintRule[] = [
   toolCommandsRule,
   guardrailPolicyCoverageRule,
   yamlReservedKeySafetyRule,
+  artifactRequiredValidationWiringRule,
+  taskOutputValidationCompletenessRule,
 ];
 
 export function lint(

--- a/src/linter/rules/artifact-required-validation-wiring.ts
+++ b/src/linter/rules/artifact-required-validation-wiring.ts
@@ -1,0 +1,62 @@
+import type { Dsl } from "../../schema/index.js";
+import type { LintRule, LintDiagnostic } from "../types.js";
+
+export const artifactRequiredValidationWiringRule: LintRule = {
+  id: "artifact-required-validation-wiring",
+  description:
+    "Every validation listed in artifact.required_validations must exist, target the artifact, and be referenced in a workflow step or task.",
+
+  run(dsl: Dsl): LintDiagnostic[] {
+    const diagnostics: LintDiagnostic[] = [];
+
+    const referencedValidations = new Set<string>();
+    for (const wf of Object.values(dsl.workflow)) {
+      for (const step of wf.steps) {
+        if (step.type === "validation") {
+          referencedValidations.add(step.validation);
+        }
+      }
+    }
+    for (const task of Object.values(dsl.tasks)) {
+      for (const valId of task.validations) {
+        referencedValidations.add(valId);
+      }
+    }
+
+    for (const [artId, art] of Object.entries(dsl.artifacts)) {
+      for (const reqValId of art.required_validations) {
+        const val = dsl.validations[reqValId];
+
+        if (!val) {
+          diagnostics.push({
+            ruleId: "artifact-required-validation-wiring",
+            severity: "error",
+            path: `artifacts.${artId}`,
+            message: `required_validation "${reqValId}" does not exist in validations`,
+          });
+          continue;
+        }
+
+        if (val.target_artifact !== artId) {
+          diagnostics.push({
+            ruleId: "artifact-required-validation-wiring",
+            severity: "error",
+            path: `artifacts.${artId}`,
+            message: `required_validation "${reqValId}" has target_artifact "${val.target_artifact}" instead of "${artId}"`,
+          });
+        }
+
+        if (!referencedValidations.has(reqValId)) {
+          diagnostics.push({
+            ruleId: "artifact-required-validation-wiring",
+            severity: "warning",
+            path: `artifacts.${artId}`,
+            message: `required_validation "${reqValId}" is defined but not referenced in any workflow step or task`,
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/src/linter/rules/task-output-validation-completeness.ts
+++ b/src/linter/rules/task-output-validation-completeness.ts
@@ -1,0 +1,52 @@
+import type { Dsl } from "../../schema/index.js";
+import type { LintRule, LintDiagnostic } from "../types.js";
+
+export const taskOutputValidationCompletenessRule: LintRule = {
+  id: "task-output-validation-completeness",
+  description:
+    "Tasks producing artifacts should cover those artifacts' required_validations in their validations list.",
+
+  run(dsl: Dsl): LintDiagnostic[] {
+    const diagnostics: LintDiagnostic[] = [];
+
+    for (const [taskId, task] of Object.entries(dsl.tasks)) {
+      const producedArtifacts = new Set<string>();
+
+      if (task.execution_steps) {
+        for (const step of task.execution_steps) {
+          if (step.produces_artifact) {
+            producedArtifacts.add(step.produces_artifact);
+          }
+        }
+      }
+
+      const agent = dsl.agents[task.target_agent];
+      if (agent) {
+        for (const artId of agent.can_write_artifacts) {
+          producedArtifacts.add(artId);
+        }
+      }
+
+      const taskValidations = new Set(task.validations);
+
+      for (const artId of producedArtifacts) {
+        const art = dsl.artifacts[artId];
+        if (!art || art.required_validations.length === 0) continue;
+
+        const missing = art.required_validations.filter(
+          (v) => !taskValidations.has(v),
+        );
+        if (missing.length > 0) {
+          diagnostics.push({
+            ruleId: "task-output-validation-completeness",
+            severity: "warning",
+            path: `tasks.${taskId}`,
+            message: `Task produces artifact "${artId}" which requires validations [${missing.join(", ")}] but task.validations does not include them`,
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/src/linter/rules/validation-coverage.ts
+++ b/src/linter/rules/validation-coverage.ts
@@ -17,6 +17,8 @@ export const validationCoverageRule: LintRule = {
       validationsByArtifact.get(val.target_artifact)!.add(val.kind);
     }
 
+    const strictArtifactTypes = ["code", "config", "schema"];
+
     for (const [artId, art] of Object.entries(dsl.artifacts)) {
       const kinds = validationsByArtifact.get(artId);
 
@@ -30,13 +32,23 @@ export const validationCoverageRule: LintRule = {
         continue;
       }
 
-      const mechanicalTypes = ["code", "config", "schema"];
-      if (mechanicalTypes.includes(art.type) && !kinds.has("mechanical") && !kinds.has("schema")) {
+      if (strictArtifactTypes.includes(art.type) && !kinds.has("mechanical") && !kinds.has("schema")) {
         diagnostics.push({
           ruleId: "validation-coverage",
           severity: "warning",
           path: `artifacts.${artId}`,
           message: `Artifact "${artId}" (type: ${art.type}) lacks mechanical or schema validation`,
+        });
+      }
+    }
+
+    for (const [artId, art] of Object.entries(dsl.artifacts)) {
+      if (art.required_validations.length === 0) {
+        diagnostics.push({
+          ruleId: "validation-coverage",
+          severity: "warning",
+          path: `artifacts.${artId}`,
+          message: `Artifact "${artId}" has empty required_validations`,
         });
       }
     }

--- a/test/linter/linter.test.ts
+++ b/test/linter/linter.test.ts
@@ -8,6 +8,8 @@ import { validationCoverageRule } from "../../src/linter/rules/validation-covera
 import { toolExecutionRule } from "../../src/linter/rules/tool-execution.js";
 import { taskAgentBindingRule } from "../../src/linter/rules/task-agent-binding.js";
 import { mergeIntegrityRule } from "../../src/linter/rules/merge-integrity.js";
+import { artifactRequiredValidationWiringRule } from "../../src/linter/rules/artifact-required-validation-wiring.js";
+import { taskOutputValidationCompletenessRule } from "../../src/linter/rules/task-output-validation-completeness.js";
 
 const fixturesDir = resolve(import.meta.dirname, "../fixtures");
 
@@ -56,7 +58,10 @@ describe("validationCoverageRule", () => {
     const dsl = makeDsl({
       agents: { a1: { role_name: "R", purpose: "P" } },
       artifacts: {
-        art1: { type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+        art1: {
+          type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"],
+          required_validations: ["v1"],
+        },
       },
       validations: {
         v1: { target_artifact: "art1", kind: "mechanical", executor_type: "tool", executor: "t1", blocking: true },
@@ -316,6 +321,342 @@ describe("mergeIntegrityRule", () => {
     const dsl = loadDsl("minimal/agent-contracts.yaml");
     const diags = mergeIntegrityRule.run(dsl);
     expect(diags).toHaveLength(0);
+  });
+});
+
+describe("validationCoverageRule – required_validations emptiness", () => {
+  it("warns when artifact has empty required_validations (non-strict type)", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: { type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      validations: {
+        v1: { target_artifact: "art1", kind: "approval", executor_type: "agent", executor: "a1", blocking: false },
+      },
+    });
+    const diags = validationCoverageRule.run(dsl);
+    const empty = diags.filter((d) => d.message.includes("empty required_validations"));
+    expect(empty.length).toBe(1);
+    expect(empty[0].severity).toBe("warning");
+  });
+
+  it("warns when code artifact has empty required_validations", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: { type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      validations: {
+        v1: { target_artifact: "art1", kind: "mechanical", executor_type: "tool", executor: "t1", blocking: true },
+      },
+      tools: { t1: { kind: "cli", invokable_by: ["a1"] } },
+    });
+    const diags = validationCoverageRule.run(dsl);
+    const empty = diags.filter((d) => d.message.includes("empty required_validations"));
+    expect(empty.length).toBe(1);
+    expect(empty[0].severity).toBe("warning");
+  });
+
+  it("warns when schema artifact has empty required_validations", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: { type: "schema", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      validations: {
+        v1: { target_artifact: "art1", kind: "schema", executor_type: "tool", executor: "t1", blocking: true },
+      },
+      tools: { t1: { kind: "cli", invokable_by: ["a1"] } },
+    });
+    const diags = validationCoverageRule.run(dsl);
+    const empty = diags.filter((d) => d.message.includes("empty required_validations"));
+    expect(empty.length).toBe(1);
+    expect(empty[0].severity).toBe("warning");
+  });
+
+  it("warns when config artifact has empty required_validations", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: { type: "config", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      validations: {
+        v1: { target_artifact: "art1", kind: "mechanical", executor_type: "tool", executor: "t1", blocking: true },
+      },
+      tools: { t1: { kind: "cli", invokable_by: ["a1"] } },
+    });
+    const diags = validationCoverageRule.run(dsl);
+    const empty = diags.filter((d) => d.message.includes("empty required_validations"));
+    expect(empty.length).toBe(1);
+    expect(empty[0].severity).toBe("warning");
+  });
+
+  it("no emptiness warning when required_validations is populated", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: {
+          type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"],
+          required_validations: ["v1"],
+        },
+      },
+      validations: {
+        v1: { target_artifact: "art1", kind: "mechanical", executor_type: "tool", executor: "t1", blocking: true },
+      },
+      tools: { t1: { kind: "cli", invokable_by: ["a1"] } },
+      workflow: { implement: { steps: [{ type: "validation", validation: "v1" }] } },
+    });
+    const diags = validationCoverageRule.run(dsl);
+    expect(diags.filter((d) => d.message.includes("empty required_validations"))).toHaveLength(0);
+  });
+});
+
+describe("artifactRequiredValidationWiringRule", () => {
+  it("errors when required_validation does not exist", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: {
+          type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"],
+          required_validations: ["nonexistent-val"],
+        },
+      },
+    });
+    const diags = artifactRequiredValidationWiringRule.run(dsl);
+    expect(diags.length).toBe(1);
+    expect(diags[0].severity).toBe("error");
+    expect(diags[0].message).toContain("does not exist");
+  });
+
+  it("errors when required_validation targets a different artifact", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: {
+          type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"],
+          required_validations: ["v1"],
+        },
+        art2: {
+          type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"],
+        },
+      },
+      validations: {
+        v1: { target_artifact: "art2", kind: "semantic", executor_type: "agent", executor: "a1", blocking: false },
+      },
+    });
+    const diags = artifactRequiredValidationWiringRule.run(dsl);
+    const mismatch = diags.filter((d) => d.message.includes("target_artifact"));
+    expect(mismatch.length).toBe(1);
+    expect(mismatch[0].severity).toBe("error");
+  });
+
+  it("warns when required_validation is not referenced in any workflow step or task", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: {
+          type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"],
+          required_validations: ["v1"],
+        },
+      },
+      validations: {
+        v1: { target_artifact: "art1", kind: "semantic", executor_type: "agent", executor: "a1", blocking: false },
+      },
+    });
+    const diags = artifactRequiredValidationWiringRule.run(dsl);
+    const unreferenced = diags.filter((d) => d.message.includes("not referenced"));
+    expect(unreferenced.length).toBe(1);
+    expect(unreferenced[0].severity).toBe("warning");
+  });
+
+  it("passes when required_validation is referenced in a workflow step", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: {
+          type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"],
+          required_validations: ["v1"],
+        },
+      },
+      validations: {
+        v1: { target_artifact: "art1", kind: "semantic", executor_type: "agent", executor: "a1", blocking: false },
+      },
+      workflow: { implement: { steps: [{ type: "validation", validation: "v1" }] } },
+    });
+    const diags = artifactRequiredValidationWiringRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("passes when required_validation is referenced in task.validations", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_return_handoffs: ["h", "r"] } },
+      artifacts: {
+        art1: {
+          type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"],
+          required_validations: ["v1"],
+        },
+      },
+      validations: {
+        v1: { target_artifact: "art1", kind: "semantic", executor_type: "agent", executor: "a1", blocking: false },
+      },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1", allowed_from_agents: ["a1"],
+          workflow: "implement", input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          validations: ["v1"],
+        },
+      },
+      handoff_types: { h: { version: 1, schema: {} }, r: { version: 1, schema: {} } },
+    });
+    const diags = artifactRequiredValidationWiringRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("passes with no diagnostics when required_validations is empty", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: { type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+    });
+    const diags = artifactRequiredValidationWiringRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+});
+
+describe("taskOutputValidationCompletenessRule", () => {
+  it("warns when task produces artifact with uncovered required_validations via execution_steps", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_return_handoffs: ["h", "r"] } },
+      artifacts: {
+        art1: {
+          type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"],
+          required_validations: ["v1", "v2"],
+        },
+      },
+      validations: {
+        v1: { target_artifact: "art1", kind: "mechanical", executor_type: "tool", executor: "t1", blocking: true },
+        v2: { target_artifact: "art1", kind: "semantic", executor_type: "agent", executor: "a1", blocking: false },
+      },
+      tools: { t1: { kind: "cli", invokable_by: ["a1"] } },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1", allowed_from_agents: ["a1"],
+          workflow: "implement", input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          execution_steps: [{ id: "s1", action: "code", produces_artifact: "art1" }],
+          validations: [],
+        },
+      },
+      handoff_types: { h: { version: 1, schema: {} }, r: { version: 1, schema: {} } },
+    });
+    const diags = taskOutputValidationCompletenessRule.run(dsl);
+    expect(diags.length).toBe(1);
+    expect(diags[0].severity).toBe("warning");
+    expect(diags[0].message).toContain("v1");
+    expect(diags[0].message).toContain("v2");
+  });
+
+  it("warns when task produces artifact via can_write_artifacts with uncovered validations", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_write_artifacts: ["art1"], can_return_handoffs: ["h", "r"] } },
+      artifacts: {
+        art1: {
+          type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"],
+          required_validations: ["v1"],
+        },
+      },
+      validations: {
+        v1: { target_artifact: "art1", kind: "mechanical", executor_type: "tool", executor: "t1", blocking: true },
+      },
+      tools: { t1: { kind: "cli", invokable_by: ["a1"] } },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1", allowed_from_agents: ["a1"],
+          workflow: "implement", input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          validations: [],
+        },
+      },
+      handoff_types: { h: { version: 1, schema: {} }, r: { version: 1, schema: {} } },
+    });
+    const diags = taskOutputValidationCompletenessRule.run(dsl);
+    expect(diags.length).toBe(1);
+    expect(diags[0].message).toContain("v1");
+  });
+
+  it("passes when task.validations covers all required_validations", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_write_artifacts: ["art1"], can_return_handoffs: ["h", "r"] } },
+      artifacts: {
+        art1: {
+          type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"],
+          required_validations: ["v1"],
+        },
+      },
+      validations: {
+        v1: { target_artifact: "art1", kind: "mechanical", executor_type: "tool", executor: "t1", blocking: true },
+      },
+      tools: { t1: { kind: "cli", invokable_by: ["a1"] } },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1", allowed_from_agents: ["a1"],
+          workflow: "implement", input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          validations: ["v1"],
+        },
+      },
+      handoff_types: { h: { version: 1, schema: {} }, r: { version: 1, schema: {} } },
+    });
+    const diags = taskOutputValidationCompletenessRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("passes when artifact has no required_validations", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_write_artifacts: ["art1"], can_return_handoffs: ["h", "r"] } },
+      artifacts: {
+        art1: { type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1", allowed_from_agents: ["a1"],
+          workflow: "implement", input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          validations: [],
+        },
+      },
+      handoff_types: { h: { version: 1, schema: {} }, r: { version: 1, schema: {} } },
+    });
+    const diags = taskOutputValidationCompletenessRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("warns with partial coverage – only some required_validations are missing", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_return_handoffs: ["h", "r"] } },
+      artifacts: {
+        art1: {
+          type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"],
+          required_validations: ["v1", "v2"],
+        },
+      },
+      validations: {
+        v1: { target_artifact: "art1", kind: "mechanical", executor_type: "tool", executor: "t1", blocking: true },
+        v2: { target_artifact: "art1", kind: "semantic", executor_type: "agent", executor: "a1", blocking: false },
+      },
+      tools: { t1: { kind: "cli", invokable_by: ["a1"] } },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1", allowed_from_agents: ["a1"],
+          workflow: "implement", input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          execution_steps: [{ id: "s1", action: "code", produces_artifact: "art1" }],
+          validations: ["v1"],
+        },
+      },
+      handoff_types: { h: { version: 1, schema: {} }, r: { version: 1, schema: {} } },
+    });
+    const diags = taskOutputValidationCompletenessRule.run(dsl);
+    expect(diags.length).toBe(1);
+    expect(diags[0].message).toContain("v2");
+    expect(diags[0].message).not.toContain("v1,");
   });
 });
 


### PR DESCRIPTION
## Summary

- Enhance `validation-coverage` rule to warn when artifacts have empty `required_validations`
- Add `artifact-required-validation-wiring` rule: verifies every entry in `artifact.required_validations` exists, targets the correct artifact, and is referenced in a workflow step or task
- Add `task-output-validation-completeness` rule: checks that tasks producing artifacts (via `execution_steps.produces_artifact` or agent `can_write_artifacts`) cover those artifacts' `required_validations`
- All new diagnostics are warnings that become blocking under `--strict`
- Bump version to 0.11.6

Closes #5

## Test plan

- [x] 16 new unit tests covering all three rules
- [x] Updated existing tests for new behavior
- [x] Full test suite (464 tests) passes
- [x] Build and typecheck pass

Made with [Cursor](https://cursor.com)