### PR TITLE
feat: add DSL completeness score command

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Design regressions become testable.
 * **YAML safety linting** for reserved word collision detection across YAML 1.1/1.2
 * **`x-extensions` declarations** for documenting project-specific custom extension fields
 * **`resolve --expand-defaults`** to materialize all Zod schema defaults in output
+* **DSL completeness scoring** with 7 dimensions, text/JSON output, and `--threshold` CI gate
 * **JSON Schema for editor support and external tooling**
 * **CI-friendly workflow checks**
 
@@ -843,6 +844,7 @@ npx agent-contracts
 | `agent-contracts validate [path]` | Validate schema and references                         |
 | `agent-contracts lint [path]`     | Run semantic lint                                      |
 | `agent-contracts render`          | Render outputs from config                             |
+| `agent-contracts score [path]`    | Calculate DSL completeness score                       |
 | `agent-contracts generate guardrails` | Generate guardrail artifacts from bindings       |
 | `agent-contracts check`           | Run resolve → validate → lint → render --check         |
 
@@ -857,6 +859,26 @@ If `-c` / `--config` is specified, the DSL path from the config file is used.
 | `--expand-defaults` | Expand all Zod default values in output. Fields like `required_validations: []`, `tags: []`, and `can_read_artifacts: []` are written explicitly instead of being silently applied by schema defaults. |
 | `-c, --config <path>` | Path to `agent-contracts.config.yaml` |
 
+#### `score` options
+
+| Option | Description |
+|--------|-------------|
+| `--format <text\|json>` | Output format (default: `text`) |
+| `--threshold <number>` | Minimum score; exit 1 if below (for CI gates) |
+| `-c, --config <path>` | Path to `agent-contracts.config.yaml` |
+
+The score command evaluates 7 dimensions:
+
+| Dimension | What it measures | Weight |
+|-----------|-----------------|--------|
+| Artifact validation coverage | % of artifacts with non-empty `required_validations` | High |
+| Task validation coverage | % of tasks with at least one entry in `validations` | High |
+| Guardrail policy coverage | % of guardrails referenced by at least one policy rule | Medium |
+| Workflow validation integration | % of blocking validations referenced in workflow steps or tasks | High |
+| Schema completeness | % of optional fields filled (description, rationale, trigger, etc.) | Low |
+| Cross-reference bidirectionality | % of agent↔artifact, agent↔tool refs that are reciprocated | Medium |
+| Guardrail scope resolution | % of guardrail scope entries that resolve to existing entities | Medium |
+
 ### Common usage
 
 ````bash
@@ -864,6 +886,9 @@ agent-contracts resolve
 agent-contracts resolve --expand-defaults --format json
 agent-contracts validate
 agent-contracts lint --strict
+agent-contracts score
+agent-contracts score -c agent-contracts.config.yaml --threshold 70
+agent-contracts score --format json
 agent-contracts render -c agent-contracts.config.yaml
 agent-contracts render -c agent-contracts.config.yaml --check
 agent-contracts check -c agent-contracts.config.yaml --strict
@@ -1249,6 +1274,16 @@ Checks:
 #### `--strict` mode
 
 When `--strict` is passed to `lint` or `check`, warnings are treated as failures (exit code 1). This is particularly relevant for artifact-centric validation rules — empty `required_validations`, orphaned validation wiring, and incomplete task coverage are all warnings that become blocking under `--strict`.
+
+### Completeness scoring
+
+`agent-contracts score` provides a quantitative assessment of the DSL's completeness. While `validate` checks structural correctness (pass/fail) and `lint` checks semantic quality (warnings/errors), `score` produces a **numeric metric** (0–100) covering validation coverage, schema completeness, cross-reference consistency, and more.
+
+Use `--threshold` in CI to enforce a minimum quality bar:
+
+````bash
+agent-contracts score -c config.yaml --threshold 70
+````
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -9,6 +9,7 @@ import { lintCommand } from "./commands/lint.js";
 import { renderCommand } from "./commands/render.js";
 import { checkCommand } from "./commands/check.js";
 import { generateGuardrailsCommand } from "./commands/generate-guardrails.js";
+import { scoreCommand } from "./commands/score.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(resolve(__dirname, "../package.json"), "utf8"));
@@ -26,5 +27,6 @@ program.addCommand(lintCommand);
 program.addCommand(renderCommand);
 program.addCommand(checkCommand);
 program.addCommand(generateGuardrailsCommand);
+program.addCommand(scoreCommand);
 
 program.parse();

--- a/src/cli/commands/score.ts
+++ b/src/cli/commands/score.ts
@@ -1,0 +1,97 @@
+import { Command } from "commander";
+import { loadConfig, resolveDslPath } from "../../config/index.js";
+import { resolve, substituteVars } from "../../resolver/index.js";
+import { validateSchema } from "../../validator/index.js";
+import { score } from "../../scorer/index.js";
+import type { ScoreResult } from "../../scorer/index.js";
+import type { OutputFormat } from "../format.js";
+
+const DIR_DEFAULT = "agent-contracts.yaml";
+
+function formatText(result: ScoreResult): string {
+  const lines: string[] = [];
+  lines.push(`DSL Completeness Score: ${result.overall}/100`);
+  lines.push("");
+
+  for (const d of result.dimensions) {
+    const detail =
+      d.total > 0 ? ` (${d.score}/${d.total} ${d.id.split("-")[0]})` : "";
+    lines.push(
+      `  ${d.label.padEnd(40)} ${String(d.percent).padStart(3)}%${detail}`,
+    );
+  }
+
+  const allRecs = result.dimensions.flatMap((d) => d.recommendations);
+  if (allRecs.length > 0) {
+    lines.push("");
+    lines.push("Recommendations:");
+    for (const rec of allRecs) {
+      lines.push(`  - ${rec}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export const scoreCommand = new Command("score")
+  .description("Calculate DSL completeness score")
+  .argument("[dir]", "Path to agent-contracts.yaml", DIR_DEFAULT)
+  .option("-c, --config <path>", "Path to agent-contracts.config.yaml")
+  .option("--format <format>", "Output format (text|json)", "text")
+  .option("--threshold <number>", "Minimum score (exit 1 if below)", undefined)
+  .action(
+    async (
+      dir: string,
+      opts: {
+        config?: string;
+        format: OutputFormat;
+        threshold?: string;
+      },
+    ) => {
+      try {
+        const config = await loadConfig(opts.config);
+        const dslPath = resolveDslPath(dir, DIR_DEFAULT, config);
+        const resolved = await resolve(dslPath);
+        const data = config?.vars
+          ? substituteVars(resolved.data, config.vars)
+          : resolved.data;
+        const schemaResult = validateSchema(data);
+
+        if (!schemaResult.success) {
+          const issues = schemaResult.diagnostics
+            .map((d) => `  ${d.path}: ${d.message}`)
+            .join("\n");
+          process.stderr.write(`Schema validation failed:\n${issues}\n`);
+          process.exit(1);
+        }
+
+        const result = score(schemaResult.data!);
+
+        if (opts.format === "json") {
+          process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+        } else {
+          process.stdout.write(formatText(result) + "\n");
+        }
+
+        if (opts.threshold !== undefined) {
+          const threshold = parseInt(opts.threshold, 10);
+          if (isNaN(threshold)) {
+            process.stderr.write(
+              `Error: --threshold must be a number, got "${opts.threshold}"\n`,
+            );
+            process.exit(1);
+          }
+          if (result.overall < threshold) {
+            process.stderr.write(
+              `Score ${result.overall} is below threshold ${threshold}\n`,
+            );
+            process.exit(1);
+          }
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`Error: ${msg}\n`);
+        process.exit(1);
+      }
+    },
+  );

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export {
   RenderTargetSchema,
   ContextTypeSchema,
 } from "./config/index.js";
+export { score, type ScoreResult, type DimensionResult } from "./scorer/index.js";
 export {
   generateGuardrails,
   resolveChecks,

--- a/src/scorer/index.ts
+++ b/src/scorer/index.ts
@@ -1,0 +1,2 @@
+export { score } from "./scorer.js";
+export type { ScoreResult, DimensionResult } from "./types.js";

--- a/src/scorer/scorer.ts
+++ b/src/scorer/scorer.ts
@@ -1,0 +1,337 @@
+import type { Dsl } from "../schema/index.js";
+import type { DimensionResult, ScoreResult } from "./types.js";
+
+function pct(n: number, d: number): number {
+  return d === 0 ? 100 : Math.round((n / d) * 100);
+}
+
+function artifactValidationCoverage(dsl: Dsl): DimensionResult {
+  const entries = Object.entries(dsl.artifacts);
+  const total = entries.length;
+  const covered = entries.filter(
+    ([, a]) => a.required_validations.length > 0,
+  ).length;
+  const missing = entries
+    .filter(([, a]) => a.required_validations.length === 0)
+    .map(([id]) => id);
+
+  return {
+    id: "artifact-validation-coverage",
+    label: "Artifact validation coverage",
+    score: covered,
+    total,
+    percent: pct(covered, total),
+    weight: 3,
+    recommendations:
+      missing.length > 0
+        ? [`${missing.length} artifacts missing required_validations: ${missing.join(", ")}`]
+        : [],
+  };
+}
+
+function taskValidationCoverage(dsl: Dsl): DimensionResult {
+  const entries = Object.entries(dsl.tasks);
+  const total = entries.length;
+  const covered = entries.filter(([, t]) => t.validations.length > 0).length;
+  const missing = entries
+    .filter(([, t]) => t.validations.length === 0)
+    .map(([id]) => id);
+
+  return {
+    id: "task-validation-coverage",
+    label: "Task validation coverage",
+    score: covered,
+    total,
+    percent: pct(covered, total),
+    weight: 3,
+    recommendations:
+      missing.length > 0
+        ? [`${missing.length} tasks missing validations: ${missing.join(", ")}`]
+        : [],
+  };
+}
+
+function guardrailPolicyCoverage(dsl: Dsl): DimensionResult {
+  const guardrailIds = Object.keys(dsl.guardrails);
+  const total = guardrailIds.length;
+
+  const referenced = new Set<string>();
+  for (const policy of Object.values(dsl.guardrail_policies)) {
+    for (const rule of policy.rules) {
+      referenced.add(rule.guardrail);
+    }
+  }
+
+  const covered = guardrailIds.filter((id) => referenced.has(id)).length;
+  const missing = guardrailIds.filter((id) => !referenced.has(id));
+
+  return {
+    id: "guardrail-policy-coverage",
+    label: "Guardrail policy coverage",
+    score: covered,
+    total,
+    percent: pct(covered, total),
+    weight: 2,
+    recommendations:
+      missing.length > 0
+        ? [`${missing.length} guardrails not in any policy: ${missing.join(", ")}`]
+        : [],
+  };
+}
+
+function workflowValidationIntegration(dsl: Dsl): DimensionResult {
+  const blockingValidations = Object.entries(dsl.validations).filter(
+    ([, v]) => v.blocking,
+  );
+  const total = blockingValidations.length;
+
+  const referenced = new Set<string>();
+  for (const wf of Object.values(dsl.workflow)) {
+    for (const step of wf.steps) {
+      if (step.type === "validation") {
+        referenced.add(step.validation);
+      }
+    }
+  }
+  for (const task of Object.values(dsl.tasks)) {
+    for (const valId of task.validations) {
+      referenced.add(valId);
+    }
+  }
+
+  const covered = blockingValidations.filter(([id]) =>
+    referenced.has(id),
+  ).length;
+  const missing = blockingValidations
+    .filter(([id]) => !referenced.has(id))
+    .map(([id]) => id);
+
+  return {
+    id: "workflow-validation-integration",
+    label: "Workflow validation integration",
+    score: covered,
+    total,
+    percent: pct(covered, total),
+    weight: 3,
+    recommendations:
+      missing.length > 0
+        ? [`${missing.length} blocking validations not wired: ${missing.join(", ")}`]
+        : [],
+  };
+}
+
+const OPTIONAL_ENTITY_FIELDS: Record<string, { section: string; fields: string[] }> = {
+  agents: {
+    section: "agents",
+    fields: ["responsibilities", "constraints", "rules"],
+  },
+  tasks: {
+    section: "tasks",
+    fields: ["description", "responsibilities", "execution_steps", "completion_criteria"],
+  },
+  artifacts: {
+    section: "artifacts",
+    fields: ["description", "visibility"],
+  },
+  tools: {
+    section: "tools",
+    fields: ["description", "commands"],
+  },
+  workflow: {
+    section: "workflow",
+    fields: ["description", "trigger", "entry_conditions"],
+  },
+  guardrails: {
+    section: "guardrails",
+    fields: ["rationale", "tags"],
+  },
+};
+
+function hasNonEmpty(obj: Record<string, unknown>, field: string): boolean {
+  const val = obj[field];
+  if (val === undefined || val === null) return false;
+  if (typeof val === "string") return val.length > 0;
+  if (Array.isArray(val)) return val.length > 0;
+  return true;
+}
+
+function schemaCompleteness(dsl: Dsl): DimensionResult {
+  let totalSlots = 0;
+  let filledSlots = 0;
+  const lowSections: string[] = [];
+
+  for (const [sectionKey, meta] of Object.entries(OPTIONAL_ENTITY_FIELDS)) {
+    const entities = (dsl as Record<string, Record<string, Record<string, unknown>>>)[
+      meta.section
+    ];
+    if (!entities) continue;
+
+    let sectionTotal = 0;
+    let sectionFilled = 0;
+
+    for (const entity of Object.values(entities)) {
+      for (const field of meta.fields) {
+        sectionTotal++;
+        totalSlots++;
+        if (hasNonEmpty(entity, field)) {
+          sectionFilled++;
+          filledSlots++;
+        }
+      }
+    }
+
+    if (sectionTotal > 0 && pct(sectionFilled, sectionTotal) < 50) {
+      lowSections.push(sectionKey);
+    }
+  }
+
+  return {
+    id: "schema-completeness",
+    label: "Schema completeness",
+    score: filledSlots,
+    total: totalSlots,
+    percent: pct(filledSlots, totalSlots),
+    weight: 1,
+    recommendations:
+      lowSections.length > 0
+        ? [`Low optional field coverage in: ${lowSections.join(", ")}`]
+        : [],
+  };
+}
+
+function crossReferenceBidirectionality(dsl: Dsl): DimensionResult {
+  let totalChecks = 0;
+  let passedChecks = 0;
+  const issues: string[] = [];
+
+  for (const [agentId, agent] of Object.entries(dsl.agents)) {
+    for (const toolId of agent.can_execute_tools) {
+      totalChecks++;
+      const tool = dsl.tools[toolId];
+      if (tool && tool.invokable_by.includes(agentId)) {
+        passedChecks++;
+      } else {
+        issues.push(`agent ${agentId} → tool ${toolId}`);
+      }
+    }
+
+    for (const artId of agent.can_write_artifacts) {
+      totalChecks++;
+      const art = dsl.artifacts[artId];
+      if (
+        art &&
+        (art.producers.includes(agentId) || art.editors.includes(agentId))
+      ) {
+        passedChecks++;
+      } else {
+        issues.push(`agent ${agentId} → artifact ${artId} (write)`);
+      }
+    }
+
+    for (const artId of agent.can_read_artifacts) {
+      totalChecks++;
+      const art = dsl.artifacts[artId];
+      if (
+        art &&
+        (art.consumers.includes(agentId) ||
+          art.producers.includes(agentId) ||
+          art.editors.includes(agentId))
+      ) {
+        passedChecks++;
+      } else {
+        issues.push(`agent ${agentId} → artifact ${artId} (read)`);
+      }
+    }
+  }
+
+  for (const [toolId, tool] of Object.entries(dsl.tools)) {
+    for (const agentId of tool.invokable_by) {
+      totalChecks++;
+      const agent = dsl.agents[agentId];
+      if (agent && agent.can_execute_tools.includes(toolId)) {
+        passedChecks++;
+      } else {
+        issues.push(`tool ${toolId} → agent ${agentId}`);
+      }
+    }
+  }
+
+  return {
+    id: "cross-reference-bidirectionality",
+    label: "Cross-reference bidirectionality",
+    score: passedChecks,
+    total: totalChecks,
+    percent: pct(passedChecks, totalChecks),
+    weight: 2,
+    recommendations:
+      issues.length > 0
+        ? [`${issues.length} unreciprocated cross-references: ${issues.slice(0, 5).join(", ")}${issues.length > 5 ? `, ... (${issues.length - 5} more)` : ""}`]
+        : [],
+  };
+}
+
+function guardrailScopeResolution(dsl: Dsl): DimensionResult {
+  let totalRefs = 0;
+  let resolvedRefs = 0;
+  const unresolved: string[] = [];
+
+  const sectionMap: Record<string, Record<string, unknown>> = {
+    agents: dsl.agents,
+    tasks: dsl.tasks,
+    tools: dsl.tools,
+    artifacts: dsl.artifacts,
+    workflows: dsl.workflow,
+  };
+
+  for (const [guardrailId, guardrail] of Object.entries(dsl.guardrails)) {
+    const scope = guardrail.scope;
+    for (const [scopeKey, entityIds] of Object.entries(scope)) {
+      if (!Array.isArray(entityIds)) continue;
+      const section = sectionMap[scopeKey];
+      if (!section) continue;
+
+      for (const entityId of entityIds) {
+        totalRefs++;
+        if (section[entityId]) {
+          resolvedRefs++;
+        } else {
+          unresolved.push(`${guardrailId}.scope.${scopeKey}: ${entityId}`);
+        }
+      }
+    }
+  }
+
+  return {
+    id: "guardrail-scope-resolution",
+    label: "Guardrail scope resolution",
+    score: resolvedRefs,
+    total: totalRefs,
+    percent: pct(resolvedRefs, totalRefs),
+    weight: 2,
+    recommendations:
+      unresolved.length > 0
+        ? [`${unresolved.length} unresolved scope refs: ${unresolved.join(", ")}`]
+        : [],
+  };
+}
+
+export function score(dsl: Dsl): ScoreResult {
+  const dimensions = [
+    artifactValidationCoverage(dsl),
+    taskValidationCoverage(dsl),
+    guardrailPolicyCoverage(dsl),
+    workflowValidationIntegration(dsl),
+    schemaCompleteness(dsl),
+    crossReferenceBidirectionality(dsl),
+    guardrailScopeResolution(dsl),
+  ];
+
+  const totalWeight = dimensions.reduce((s, d) => s + d.weight, 0);
+  const weightedSum = dimensions.reduce(
+    (s, d) => s + d.percent * d.weight,
+    0,
+  );
+  const overall = totalWeight === 0 ? 100 : Math.round(weightedSum / totalWeight);
+
+  return { overall, dimensions };
+}

--- a/src/scorer/types.ts
+++ b/src/scorer/types.ts
@@ -1,0 +1,14 @@
+export interface DimensionResult {
+  id: string;
+  label: string;
+  score: number;
+  total: number;
+  percent: number;
+  weight: number;
+  recommendations: string[];
+}
+
+export interface ScoreResult {
+  overall: number;
+  dimensions: DimensionResult[];
+}

--- a/test/scorer/scorer.test.ts
+++ b/test/scorer/scorer.test.ts
@@ -1,0 +1,352 @@
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { describe, it, expect } from "vitest";
+import { DslSchema, type Dsl } from "../../src/schema/index.js";
+import { score } from "../../src/scorer/scorer.js";
+import type { ScoreResult } from "../../src/scorer/types.js";
+
+const fixturesDir = resolve(import.meta.dirname, "../fixtures");
+
+function loadDsl(rel: string): Dsl {
+  const data = parseYaml(readFileSync(join(fixturesDir, rel), "utf8"));
+  return DslSchema.parse(data);
+}
+
+function makeDsl(partial: Partial<Record<string, unknown>>): Dsl {
+  return DslSchema.parse({
+    version: 1,
+    system: { id: "s", name: "S", default_workflow_order: ["implement"] },
+    ...partial,
+  });
+}
+
+function dim(result: ScoreResult, id: string) {
+  return result.dimensions.find((d) => d.id === id)!;
+}
+
+describe("score()", () => {
+  it("returns overall score between 0 and 100", () => {
+    const dsl = makeDsl({});
+    const result = score(dsl);
+    expect(result.overall).toBeGreaterThanOrEqual(0);
+    expect(result.overall).toBeLessThanOrEqual(100);
+  });
+
+  it("returns 7 dimensions", () => {
+    const dsl = makeDsl({});
+    const result = score(dsl);
+    expect(result.dimensions).toHaveLength(7);
+  });
+
+  it("returns 100 for an empty DSL (no entities = nothing to check)", () => {
+    const dsl = makeDsl({});
+    const result = score(dsl);
+    expect(result.overall).toBe(100);
+  });
+});
+
+describe("artifact-validation-coverage", () => {
+  it("scores 0% when all artifacts have empty required_validations", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: { type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+        art2: { type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+    });
+    const d = dim(score(dsl), "artifact-validation-coverage");
+    expect(d.percent).toBe(0);
+    expect(d.score).toBe(0);
+    expect(d.total).toBe(2);
+    expect(d.recommendations.length).toBeGreaterThan(0);
+    expect(d.recommendations[0]).toContain("art1");
+  });
+
+  it("scores 100% when all artifacts have required_validations", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: {
+          type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"],
+          required_validations: ["v1"],
+        },
+      },
+      validations: {
+        v1: { target_artifact: "art1", kind: "mechanical", executor_type: "tool", executor: "t1", blocking: true },
+      },
+    });
+    const d = dim(score(dsl), "artifact-validation-coverage");
+    expect(d.percent).toBe(100);
+    expect(d.recommendations).toHaveLength(0);
+  });
+
+  it("scores 50% with mixed coverage", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: {
+          type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"],
+          required_validations: ["v1"],
+        },
+        art2: { type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      validations: {
+        v1: { target_artifact: "art1", kind: "mechanical", executor_type: "tool", executor: "t1", blocking: true },
+      },
+    });
+    const d = dim(score(dsl), "artifact-validation-coverage");
+    expect(d.percent).toBe(50);
+    expect(d.score).toBe(1);
+    expect(d.total).toBe(2);
+  });
+});
+
+describe("task-validation-coverage", () => {
+  it("scores 0% when no tasks have validations", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_return_handoffs: ["h", "r"] } },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1", allowed_from_agents: ["a1"],
+          workflow: "implement", input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+        },
+      },
+      handoff_types: { h: { version: 1, schema: {} }, r: { version: 1, schema: {} } },
+    });
+    const d = dim(score(dsl), "task-validation-coverage");
+    expect(d.percent).toBe(0);
+    expect(d.recommendations[0]).toContain("t1");
+  });
+
+  it("scores 100% when all tasks have validations", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_return_handoffs: ["h", "r"] } },
+      artifacts: { art1: { type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] } },
+      validations: {
+        v1: { target_artifact: "art1", kind: "mechanical", executor_type: "tool", executor: "t1", blocking: true },
+      },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1", allowed_from_agents: ["a1"],
+          workflow: "implement", input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          validations: ["v1"],
+        },
+      },
+      handoff_types: { h: { version: 1, schema: {} }, r: { version: 1, schema: {} } },
+    });
+    const d = dim(score(dsl), "task-validation-coverage");
+    expect(d.percent).toBe(100);
+    expect(d.recommendations).toHaveLength(0);
+  });
+});
+
+describe("guardrail-policy-coverage", () => {
+  it("scores 0% when guardrails are not covered by policies", () => {
+    const dsl = makeDsl({
+      guardrails: {
+        g1: { description: "d", scope: {} },
+      },
+    });
+    const d = dim(score(dsl), "guardrail-policy-coverage");
+    expect(d.percent).toBe(0);
+    expect(d.recommendations[0]).toContain("g1");
+  });
+
+  it("scores 100% when all guardrails have policy rules", () => {
+    const dsl = makeDsl({
+      guardrails: {
+        g1: { description: "d", scope: {} },
+      },
+      guardrail_policies: {
+        p1: { rules: [{ guardrail: "g1", severity: "warning", action: "warn" }] },
+      },
+    });
+    const d = dim(score(dsl), "guardrail-policy-coverage");
+    expect(d.percent).toBe(100);
+  });
+});
+
+describe("workflow-validation-integration", () => {
+  it("scores 0% when blocking validations are not wired", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: { art1: { type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] } },
+      validations: {
+        v1: { target_artifact: "art1", kind: "mechanical", executor_type: "tool", executor: "t1", blocking: true },
+      },
+    });
+    const d = dim(score(dsl), "workflow-validation-integration");
+    expect(d.percent).toBe(0);
+    expect(d.recommendations[0]).toContain("v1");
+  });
+
+  it("scores 100% when all blocking validations are referenced in tasks", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_return_handoffs: ["h", "r"] } },
+      artifacts: { art1: { type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] } },
+      validations: {
+        v1: { target_artifact: "art1", kind: "mechanical", executor_type: "tool", executor: "t1", blocking: true },
+      },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1", allowed_from_agents: ["a1"],
+          workflow: "implement", input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          validations: ["v1"],
+        },
+      },
+      handoff_types: { h: { version: 1, schema: {} }, r: { version: 1, schema: {} } },
+    });
+    const d = dim(score(dsl), "workflow-validation-integration");
+    expect(d.percent).toBe(100);
+  });
+
+  it("scores 100% when all blocking validations are referenced in workflow steps", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: { art1: { type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] } },
+      validations: {
+        v1: { target_artifact: "art1", kind: "mechanical", executor_type: "tool", executor: "t1", blocking: true },
+      },
+      workflow: { implement: { steps: [{ type: "validation", validation: "v1" }] } },
+    });
+    const d = dim(score(dsl), "workflow-validation-integration");
+    expect(d.percent).toBe(100);
+  });
+
+  it("ignores non-blocking validations", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: { art1: { type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] } },
+      validations: {
+        v1: { target_artifact: "art1", kind: "semantic", executor_type: "agent", executor: "a1", blocking: false },
+      },
+    });
+    const d = dim(score(dsl), "workflow-validation-integration");
+    expect(d.percent).toBe(100);
+    expect(d.total).toBe(0);
+  });
+});
+
+describe("schema-completeness", () => {
+  it("scores high when optional fields are filled", () => {
+    const dsl = makeDsl({
+      agents: {
+        a1: {
+          role_name: "R", purpose: "P",
+          responsibilities: ["resp1"],
+          constraints: ["c1"],
+          rules: [{ id: "r1", description: "d", severity: "mandatory" }],
+        },
+      },
+    });
+    const d = dim(score(dsl), "schema-completeness");
+    expect(d.percent).toBe(100);
+  });
+
+  it("scores lower when optional fields are empty", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+    });
+    const d = dim(score(dsl), "schema-completeness");
+    expect(d.percent).toBeLessThan(100);
+  });
+});
+
+describe("cross-reference-bidirectionality", () => {
+  it("scores 100% when all refs are reciprocated", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_execute_tools: ["t1"], can_write_artifacts: ["art1"] } },
+      tools: { t1: { kind: "cli", invokable_by: ["a1"] } },
+      artifacts: { art1: { type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] } },
+    });
+    const d = dim(score(dsl), "cross-reference-bidirectionality");
+    expect(d.percent).toBe(100);
+    expect(d.recommendations).toHaveLength(0);
+  });
+
+  it("detects unreciprocated agent→tool reference", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_execute_tools: ["t1"] } },
+      tools: { t1: { kind: "cli", invokable_by: [] } },
+    });
+    const d = dim(score(dsl), "cross-reference-bidirectionality");
+    expect(d.percent).toBeLessThan(100);
+    expect(d.recommendations[0]).toContain("agent a1");
+  });
+});
+
+describe("guardrail-scope-resolution", () => {
+  it("scores 100% when all scope entries resolve", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      tools: { t1: { kind: "cli", invokable_by: ["a1"] } },
+      guardrails: {
+        g1: { description: "d", scope: { agents: ["a1"], tools: ["t1"] } },
+      },
+    });
+    const d = dim(score(dsl), "guardrail-scope-resolution");
+    expect(d.percent).toBe(100);
+  });
+
+  it("detects unresolved scope references", () => {
+    const dsl = makeDsl({
+      guardrails: {
+        g1: { description: "d", scope: { agents: ["nonexistent"] } },
+      },
+    });
+    const d = dim(score(dsl), "guardrail-scope-resolution");
+    expect(d.percent).toBe(0);
+    expect(d.recommendations[0]).toContain("nonexistent");
+  });
+
+  it("scores 100% when no scope entries exist", () => {
+    const dsl = makeDsl({
+      guardrails: {
+        g1: { description: "d", scope: {} },
+      },
+    });
+    const d = dim(score(dsl), "guardrail-scope-resolution");
+    expect(d.percent).toBe(100);
+  });
+});
+
+describe("overall score weighting", () => {
+  it("weighted average reflects high-weight dimension failures", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_return_handoffs: ["h", "r"] } },
+      artifacts: {
+        art1: { type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      validations: {
+        v1: { target_artifact: "art1", kind: "mechanical", executor_type: "tool", executor: "t1", blocking: true },
+      },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1", allowed_from_agents: ["a1"],
+          workflow: "implement", input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+        },
+      },
+      handoff_types: { h: { version: 1, schema: {} }, r: { version: 1, schema: {} } },
+    });
+    const result = score(dsl);
+    expect(result.overall).toBeLessThan(100);
+    expect(result.overall).toBeGreaterThan(0);
+  });
+});
+
+describe("score on full fixture", () => {
+  it("produces a valid score for the full fixture", () => {
+    const dsl = loadDsl("full/agent-contracts.yaml");
+    const result = score(dsl);
+    expect(result.overall).toBeGreaterThanOrEqual(0);
+    expect(result.overall).toBeLessThanOrEqual(100);
+    expect(result.dimensions).toHaveLength(7);
+    for (const d of result.dimensions) {
+      expect(d.percent).toBeGreaterThanOrEqual(0);
+      expect(d.percent).toBeLessThanOrEqual(100);
+      expect(d.id).toBeTruthy();
+      expect(d.label).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add `agent-contracts score` command that calculates a quantitative DSL completeness score (0–100)
- 7 scoring dimensions: artifact validation coverage, task validation coverage, guardrail policy coverage, workflow validation integration, schema completeness, cross-reference bidirectionality, guardrail scope resolution
- Text and JSON output formats (`--format json`)
- `--threshold` option for CI gate usage (exit 1 if score is below threshold)
- Per-dimension breakdown with specific entity recommendations
- 23 new tests covering all dimensions and edge cases
- Bump version to 0.11.7

Closes #4

## Test plan

- [x] 23 unit tests for scorer (all dimensions, weighting, edge cases)
- [x] CLI tested manually: text output, JSON output, --threshold
- [x] Full test suite (487 tests) passes
- [x] Build and typecheck pass

Made with [Cursor](https://cursor.com)