### PR TITLE
feat: extend validation kinds and front-load semantic verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,31 @@ Workflow steps support additional properties:
 * `retry` (delegate steps) — defines a conditional retry loop with `condition`, `fix_task`, and optional `revalidate_task`
 * `routing_key` (decision steps) — the field that determines branch selection. The legacy field `on` is still accepted but deprecated due to YAML 1.1 reserved word collision
 
+### Validation
+
+A **Validation** defines a verification step for an artifact:
+
+* `target_artifact` — the artifact being verified
+* `kind` — the type of verification (see below)
+* `executor_type` — `tool` (automated) or `agent` (agent-driven)
+* `executor` — the tool or agent that runs the validation
+* `blocking` — whether the validation must pass before proceeding
+* `produces_evidence` — optional artifact produced as evidence
+
+#### Validation kinds
+
+| Kind | Purpose | Example |
+|------|---------|---------|
+| `schema` | Structural schema check | JSON Schema validation, OpenAPI lint, SQL syntax |
+| `mechanical` | Automated tool check | CLI linters, diff checks, coverage reports |
+| `semantic` | Meaning-level review | Agent-based review of spec intent, plan coherence |
+| `approval` | Human/agent sign-off gate | Architect approval before implementation |
+| `provenance` | Source derivation verification | Confirm generated artifact derives from its canonical source (e.g., manifest from API contracts) |
+| `traceability` | Cross-artifact link completeness | Verify every spec requirement reaches contracts, tests, and code |
+| `fidelity` | Semantic faithfulness to source | Confirm tests actually verify spec intent, not just structural compliance |
+
+`schema` and `mechanical` are best suited for automated checks via tools. `semantic`, `fidelity`, and `approval` are typically agent-driven. `provenance` and `traceability` can be either tool or agent-based depending on the verification complexity.
+
 ### Guardrail
 
 A **Guardrail** declares a cross-cutting constraint:
@@ -1268,6 +1293,7 @@ Checks:
 * prerequisite readability
 * artifact ownership — `produces_artifact`/`reads_artifact` in execution steps vs. artifact producers/editors/consumers
 * tool commands — `commands[].reads`/`commands[].writes` reference valid artifacts and align with `output_artifacts`
+* semantic validation phase coverage — warns when `semantic` or `fidelity` validations only appear in late workflow phases (e.g., audit) but not earlier phases (e.g., specify, plan)
 * YAML safety — warns when YAML 1.1 reserved words (`on`, `yes`, `no`, `true`, `false`, etc.) are used in positions where they may be misinterpreted by non-1.2 parsers
 * naming/style issues through Spectral rules
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/sample/agent-contracts.yaml
+++ b/sample/agent-contracts.yaml
@@ -214,6 +214,35 @@ validations:
     executor: test-runner
     blocking: false
 
+  spec-semantic-review:
+    target_artifact: spec-doc
+    kind: semantic
+    executor_type: agent
+    executor: architect
+    blocking: true
+    produces_evidence: audit-report
+
+  spec-traceability-check:
+    target_artifact: spec-doc
+    kind: traceability
+    executor_type: tool
+    executor: code-editor
+    blocking: true
+
+  test-fidelity-check:
+    target_artifact: test-suite
+    kind: fidelity
+    executor_type: agent
+    executor: tester
+    blocking: true
+
+  codebase-provenance-check:
+    target_artifact: codebase
+    kind: provenance
+    executor_type: tool
+    executor: code-editor
+    blocking: true
+
 handoff_types:
   task-delegation:
     version: 1

--- a/schemas/dsl.schema.json
+++ b/schemas/dsl.schema.json
@@ -595,7 +595,10 @@
               "schema",
               "mechanical",
               "semantic",
-              "approval"
+              "approval",
+              "provenance",
+              "traceability",
+              "fidelity"
             ]
           },
           "executor_type": {

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -10,6 +10,7 @@ import { guardrailPolicyCoverageRule } from "./rules/guardrail-policy-coverage.j
 import { yamlReservedKeySafetyRule } from "./rules/yaml-reserved-key-safety.js";
 import { artifactRequiredValidationWiringRule } from "./rules/artifact-required-validation-wiring.js";
 import { taskOutputValidationCompletenessRule } from "./rules/task-output-validation-completeness.js";
+import { semanticValidationPhaseCoverageRule } from "./rules/semantic-validation-phase-coverage.js";
 
 const builtinRules: LintRule[] = [
   validationCoverageRule,
@@ -22,6 +23,7 @@ const builtinRules: LintRule[] = [
   yamlReservedKeySafetyRule,
   artifactRequiredValidationWiringRule,
   taskOutputValidationCompletenessRule,
+  semanticValidationPhaseCoverageRule,
 ];
 
 export function lint(

--- a/src/linter/rules/semantic-validation-phase-coverage.ts
+++ b/src/linter/rules/semantic-validation-phase-coverage.ts
@@ -1,0 +1,78 @@
+import type { Dsl } from "../../schema/index.js";
+import type { LintRule, LintDiagnostic } from "../types.js";
+
+const SEMANTIC_KINDS = new Set(["semantic", "fidelity"]);
+
+export const semanticValidationPhaseCoverageRule: LintRule = {
+  id: "semantic-validation-phase-coverage",
+  description:
+    "Semantic and fidelity validations should appear in early workflow phases, not only in late phases.",
+
+  run(dsl: Dsl): LintDiagnostic[] {
+    const diagnostics: LintDiagnostic[] = [];
+
+    const semanticValIds = new Set<string>();
+    for (const [valId, val] of Object.entries(dsl.validations)) {
+      if (SEMANTIC_KINDS.has(val.kind)) {
+        semanticValIds.add(valId);
+      }
+    }
+
+    if (semanticValIds.size === 0) {
+      return diagnostics;
+    }
+
+    const phaseOrder = dsl.system.default_workflow_order;
+    if (phaseOrder.length < 2) {
+      return diagnostics;
+    }
+
+    const phaseValidations = new Map<string, Set<string>>();
+    for (const phase of phaseOrder) {
+      phaseValidations.set(phase, new Set());
+    }
+
+    for (const [phase, wf] of Object.entries(dsl.workflow)) {
+      if (!phaseValidations.has(phase)) continue;
+      for (const step of wf.steps) {
+        if (step.type === "validation" && semanticValIds.has(step.validation)) {
+          phaseValidations.get(phase)!.add(step.validation);
+        }
+      }
+    }
+
+    for (const task of Object.values(dsl.tasks)) {
+      const phase = task.workflow;
+      if (!phaseValidations.has(phase)) continue;
+      for (const valId of task.validations) {
+        if (semanticValIds.has(valId)) {
+          phaseValidations.get(phase)!.add(valId);
+        }
+      }
+    }
+
+    const earlyBoundary = Math.ceil(phaseOrder.length / 2);
+    const earlyPhases = phaseOrder.slice(0, earlyBoundary);
+    const latePhases = phaseOrder.slice(earlyBoundary);
+
+    const earlyHasAny = earlyPhases.some(
+      (p) => (phaseValidations.get(p)?.size ?? 0) > 0,
+    );
+    const lateWithSemantic = latePhases.filter(
+      (p) => (phaseValidations.get(p)?.size ?? 0) > 0,
+    );
+
+    if (!earlyHasAny && lateWithSemantic.length > 0) {
+      diagnostics.push({
+        ruleId: "semantic-validation-phase-coverage",
+        severity: "warning",
+        path: "validations",
+        message:
+          `Semantic validations are only referenced in workflow phases [${lateWithSemantic.join(", ")}]. ` +
+          `Consider adding semantic review to earlier phases [${earlyPhases.join(", ")}] to catch issues before implementation.`,
+      });
+    }
+
+    return diagnostics;
+  },
+};

--- a/src/schema/validation.ts
+++ b/src/schema/validation.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const ValidationSchema = z
   .object({
     target_artifact: z.string(),
-    kind: z.enum(["schema", "mechanical", "semantic", "approval"]),
+    kind: z.enum(["schema", "mechanical", "semantic", "approval", "provenance", "traceability", "fidelity"]),
     executor_type: z.enum(["tool", "agent"]),
     executor: z.string(),
     blocking: z.boolean(),

--- a/test/linter/linter.test.ts
+++ b/test/linter/linter.test.ts
@@ -10,6 +10,7 @@ import { taskAgentBindingRule } from "../../src/linter/rules/task-agent-binding.
 import { mergeIntegrityRule } from "../../src/linter/rules/merge-integrity.js";
 import { artifactRequiredValidationWiringRule } from "../../src/linter/rules/artifact-required-validation-wiring.js";
 import { taskOutputValidationCompletenessRule } from "../../src/linter/rules/task-output-validation-completeness.js";
+import { semanticValidationPhaseCoverageRule } from "../../src/linter/rules/semantic-validation-phase-coverage.js";
 
 const fixturesDir = resolve(import.meta.dirname, "../fixtures");
 

--- a/test/linter/semantic-validation-phase-coverage.test.ts
+++ b/test/linter/semantic-validation-phase-coverage.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from "vitest";
+import { DslSchema, type Dsl } from "../../src/schema/index.js";
+import { semanticValidationPhaseCoverageRule } from "../../src/linter/rules/semantic-validation-phase-coverage.js";
+
+function makeDsl(partial: Partial<Record<string, unknown>>): Dsl {
+  return DslSchema.parse({
+    version: 1,
+    system: { id: "s", name: "S", default_workflow_order: ["specify", "plan", "implement", "audit"] },
+    ...partial,
+  });
+}
+
+describe("semanticValidationPhaseCoverageRule", () => {
+  it("warns when semantic validations only appear in late phases", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_return_handoffs: ["h", "r"] } },
+      artifacts: {
+        art1: { type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      validations: {
+        "sem-review": { target_artifact: "art1", kind: "semantic", executor_type: "agent", executor: "a1", blocking: true },
+      },
+      workflow: {
+        audit: { steps: [{ type: "validation", validation: "sem-review" }] },
+      },
+    });
+    const diags = semanticValidationPhaseCoverageRule.run(dsl);
+    expect(diags.length).toBe(1);
+    expect(diags[0].severity).toBe("warning");
+    expect(diags[0].ruleId).toBe("semantic-validation-phase-coverage");
+    expect(diags[0].message).toContain("audit");
+    expect(diags[0].message).toContain("specify");
+  });
+
+  it("warns when fidelity validations only appear in late phases", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_return_handoffs: ["h", "r"] } },
+      artifacts: {
+        art1: { type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      validations: {
+        "fidelity-check": { target_artifact: "art1", kind: "fidelity", executor_type: "agent", executor: "a1", blocking: true },
+      },
+      workflow: {
+        audit: { steps: [{ type: "validation", validation: "fidelity-check" }] },
+      },
+    });
+    const diags = semanticValidationPhaseCoverageRule.run(dsl);
+    expect(diags.length).toBe(1);
+    expect(diags[0].message).toContain("audit");
+    expect(diags[0].message).toContain("specify");
+  });
+
+  it("passes when semantic validations appear in early phases", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_return_handoffs: ["h", "r"] } },
+      artifacts: {
+        art1: { type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      validations: {
+        "sem-review": { target_artifact: "art1", kind: "semantic", executor_type: "agent", executor: "a1", blocking: true },
+      },
+      workflow: {
+        specify: { steps: [{ type: "validation", validation: "sem-review" }] },
+      },
+    });
+    const diags = semanticValidationPhaseCoverageRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("passes when semantic validations appear in both early and late phases", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_return_handoffs: ["h", "r"] } },
+      artifacts: {
+        art1: { type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      validations: {
+        "sem-review": { target_artifact: "art1", kind: "semantic", executor_type: "agent", executor: "a1", blocking: true },
+      },
+      workflow: {
+        plan: { steps: [{ type: "validation", validation: "sem-review" }] },
+        audit: { steps: [{ type: "validation", validation: "sem-review" }] },
+      },
+    });
+    const diags = semanticValidationPhaseCoverageRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("passes when no semantic or fidelity validations exist", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: { type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      validations: {
+        "lint-check": { target_artifact: "art1", kind: "mechanical", executor_type: "tool", executor: "t1", blocking: true },
+      },
+    });
+    const diags = semanticValidationPhaseCoverageRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("passes when workflow order has fewer than 2 phases", () => {
+    const dsl = DslSchema.parse({
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: ["implement"] },
+      validations: {
+        "sem-review": { target_artifact: "art1", kind: "semantic", executor_type: "agent", executor: "a1", blocking: true },
+      },
+    });
+    const diags = semanticValidationPhaseCoverageRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("detects semantic validations referenced via task.validations in late phase", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_return_handoffs: ["h", "r"] } },
+      artifacts: {
+        art1: { type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      validations: {
+        "sem-review": { target_artifact: "art1", kind: "semantic", executor_type: "agent", executor: "a1", blocking: true },
+      },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1", allowed_from_agents: ["a1"],
+          workflow: "audit", input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          validations: ["sem-review"],
+        },
+      },
+      handoff_types: { h: { version: 1, schema: {} }, r: { version: 1, schema: {} } },
+    });
+    const diags = semanticValidationPhaseCoverageRule.run(dsl);
+    expect(diags.length).toBe(1);
+    expect(diags[0].message).toContain("audit");
+  });
+
+  it("passes when semantic validation is in task assigned to early phase", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_return_handoffs: ["h", "r"] } },
+      artifacts: {
+        art1: { type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      validations: {
+        "sem-review": { target_artifact: "art1", kind: "semantic", executor_type: "agent", executor: "a1", blocking: true },
+      },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1", allowed_from_agents: ["a1"],
+          workflow: "specify", input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          validations: ["sem-review"],
+        },
+      },
+      handoff_types: { h: { version: 1, schema: {} }, r: { version: 1, schema: {} } },
+    });
+    const diags = semanticValidationPhaseCoverageRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("handles provenance and traceability kinds without triggering this rule", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: { type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      validations: {
+        "prov-check": { target_artifact: "art1", kind: "provenance", executor_type: "tool", executor: "t1", blocking: true },
+        "trace-check": { target_artifact: "art1", kind: "traceability", executor_type: "tool", executor: "t1", blocking: true },
+      },
+      workflow: {
+        audit: { steps: [
+          { type: "validation", validation: "prov-check" },
+          { type: "validation", validation: "trace-check" },
+        ] },
+      },
+    });
+    const diags = semanticValidationPhaseCoverageRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/test/schema/schema.test.ts
+++ b/test/schema/schema.test.ts
@@ -142,7 +142,7 @@ describe("schema normal cases", () => {
   });
 
   it("parses ValidationSchema for each kind enum", () => {
-    const kinds = ["schema", "mechanical", "semantic", "approval"] as const;
+    const kinds = ["schema", "mechanical", "semantic", "approval", "provenance", "traceability", "fidelity"] as const;
     for (const kind of kinds) {
       expect(() =>
         ValidationSchema.parse({ ...minimalValidValidation, kind }),


### PR DESCRIPTION
## Summary

Closes #7

- **Extended `ValidationSchema.kind` enum** with `provenance`, `traceability`, `fidelity` to express richer verification intent
- **Added `semantic-validation-phase-coverage` lint rule** that warns when semantic/fidelity validations only appear in late workflow phases (e.g., audit) but not earlier phases (e.g., specify, plan)
- **Regenerated JSON Schema** (`schemas/dsl.schema.json`) with new enum values
- **Added sample validations** demonstrating the new kinds in `sample/agent-contracts.yaml`
- **Added documentation** — Validation concept section with kind usage table, lint rule description in Semantic lint section
- **Added tests** — schema tests for all 7 kinds, 9 new tests for the lint rule

## Changes

| File | Change |
|------|--------|
| `src/schema/validation.ts` | Extended `kind` enum |
| `schemas/dsl.schema.json` | Regenerated |
| `src/linter/rules/semantic-validation-phase-coverage.ts` | New lint rule |
| `src/linter/linter.ts` | Registered new rule |
| `sample/agent-contracts.yaml` | Added sample validations |
| `README.md` | Validation kinds documentation |
| `test/schema/schema.test.ts` | Updated enum test |
| `test/linter/semantic-validation-phase-coverage.test.ts` | New lint rule tests |
| `test/linter/linter.test.ts` | Import for new rule |
| `package.json` | Version bump to 0.11.8 |

## Test plan

- [x] All 496 tests pass
- [x] Typecheck passes
- [x] Build succeeds
