### PR TITLE
feat: guardrail coverage matrix with binding-aware render

### DIFF
--- a/README.md
+++ b/README.md
@@ -998,7 +998,7 @@ Each `context` type provides a different rendering scope:
 
 | Context | Scope | Output | Key variables |
 |---------|-------|--------|---------------|
-| `system` | Single file | `output` as-is | `system`, `dsl` |
+| `system` | Single file | `output` as-is | `system`, `dsl`, `guardrailEnforcement`\*, `bindings`\* |
 | `agent` | Per agent | `{agent.id}` in output path | `agent`, `receivableTasks`, `delegatableTasks`, `relatedArtifacts`, `relatedTools`, `relatedHandoffTypes`, `mergedBehavior`, `dsl` |
 | `task` | Per task | `{task.id}` in output path | `task`, `targetAgent`, `dsl` |
 | `artifact` | Per artifact | `{artifact.id}` in output path | `artifact`, `relatedTools`, `relatedValidations`, `producerAgents`, `consumerAgents`, `editorAgents`, `createdInWorkflows`, `dsl` |
@@ -1026,6 +1026,18 @@ Each `context` type provides a different rendering scope:
 * `relatedValidations` — validations targeting this artifact
 * `producerAgents` / `consumerAgents` / `editorAgents` — resolved agent records
 * `createdInWorkflows` — workflow phases where this artifact is written
+
+**`system` context** includes binding-aware guardrail enforcement data when `bindings` and `active_guardrail_policy` are configured:
+
+* `guardrailEnforcement` — array of enforcement entries, each with `guardrail_id`, `description`, `severity`, `action`, scoped entities (`scoped_agents`, `scoped_tasks`, `scoped_workflows`, `scoped_tools`, `scoped_artifacts`), `allow_override`, `override_requires`, `trigger` (from binding matcher type), and `escalation`
+* `bindings` — array of loaded `SoftwareBinding` objects
+
+These fields are only populated when the config specifies `bindings` and `active_guardrail_policy`. Existing templates that do not reference these fields are unaffected.
+
+**Matrix helpers** are available in `context: system` templates:
+
+* `guardrailCoverageMatrix` — generates a Guardrail Coverage Matrix table (guardrail × severity × action × scoped entities × trigger × override × escalation)
+* `taskGuardrailMatrix` — generates a Task × Guardrail cross-reference table showing which action applies to each task
 
 **`tool` context** resolves agent and artifact references:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.11.8",
+  "version": "0.12.0",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/sample/templates/guardrail-matrix.md.hbs
+++ b/sample/templates/guardrail-matrix.md.hbs
@@ -1,0 +1,42 @@
+{{!--
+  Template: guardrail-matrix.md.hbs
+  Context:  SystemContext (context: "system")
+
+  Requires binding-aware render (bindings + active_guardrail_policy in config).
+  When no bindings are loaded, guardrailEnforcement is undefined and the
+  matrix sections render as empty.
+
+  Available variables:
+    system                - System object
+    dsl                   - Full DSL object
+    guardrailEnforcement  - Array of enforcement entries (when bindings loaded)
+    bindings              - Array of SoftwareBinding objects (when bindings loaded)
+
+  Matrix helpers:
+    guardrailCoverageMatrix  - Generates full coverage matrix table
+    taskGuardrailMatrix      - Generates task × guardrail cross-reference table
+--}}
+# Guardrail Coverage — {{system.name}}
+
+{{#if guardrailEnforcement}}
+## Guardrail Coverage Matrix
+
+{{{guardrailCoverageMatrix}}}
+
+## Task × Guardrail Matrix
+
+{{{taskGuardrailMatrix}}}
+
+{{else}}
+> No guardrail enforcement data available. Configure `bindings` and `active_guardrail_policy` in your config to enable this view.
+{{/if}}
+
+{{#if (notEmpty dsl.guardrails)}}
+## Guardrail Definitions
+
+| ID | Description | Tags | Rationale |
+|----|-------------|------|-----------|
+{{#each dsl.guardrails}}
+| {{@key}} | {{this.description}} | {{join this.tags ", "}} | {{this.rationale}} |
+{{/each}}
+{{/if}}

--- a/src/cli/commands/render.ts
+++ b/src/cli/commands/render.ts
@@ -1,8 +1,8 @@
 import { Command } from "commander";
-import { loadConfig, ConfigLoadError } from "../../config/index.js";
+import { loadConfig, loadBindings, ConfigLoadError } from "../../config/index.js";
 import { resolve, substituteVars } from "../../resolver/index.js";
 import { validateSchema } from "../../validator/index.js";
-import { renderFromConfig, checkDriftFromConfig } from "../../renderer/index.js";
+import { renderFromConfig, checkDriftFromConfig, type RenderOptions } from "../../renderer/index.js";
 
 export const renderCommand = new Command("render")
   .description("Render resolved DSL with Handlebars templates (requires config)")
@@ -33,10 +33,20 @@ export const renderCommand = new Command("render")
           process.exit(1);
         }
 
+        let renderOptions: RenderOptions | undefined;
+        if (config.bindings.length > 0) {
+          const loadedBindings = await loadBindings(config.bindings);
+          renderOptions = {
+            loadedBindings,
+            activeGuardrailPolicy: config.activeGuardrailPolicy,
+          };
+        }
+
         if (opts.check) {
           const drift = await checkDriftFromConfig(
             schemaResult.data!,
             config.renders,
+            renderOptions,
           );
 
           if (drift.hasDrift) {
@@ -54,6 +64,7 @@ export const renderCommand = new Command("render")
           const files = await renderFromConfig(
             schemaResult.data!,
             config.renders,
+            renderOptions,
           );
 
           if (!opts.quiet) {

--- a/src/renderer/context.ts
+++ b/src/renderer/context.ts
@@ -10,9 +10,12 @@ import type {
   Policy,
   Guardrail,
   GuardrailPolicy,
+  GuardrailPolicyRule,
   System,
+  SoftwareBinding,
 } from "../schema/index.js";
 import { resolveAllOf } from "../schema/index.js";
+import type { LoadedBinding } from "../config/binding-loader.js";
 
 export interface GlobalContext {
   system: Dsl["system"];
@@ -29,9 +32,27 @@ export interface GlobalContext {
   [key: string]: unknown;
 }
 
+export interface GuardrailEnforcementEntry {
+  guardrail_id: string;
+  description: string;
+  severity: string;
+  action: string;
+  scoped_agents: string[];
+  scoped_tasks: string[];
+  scoped_workflows: string[];
+  scoped_tools: string[];
+  scoped_artifacts: string[];
+  allow_override: boolean;
+  override_requires: string[];
+  trigger: string | null;
+  escalation: { target: string; condition?: string } | null;
+}
+
 export interface SystemContext {
   system: System;
   dsl: Dsl;
+  guardrailEnforcement?: GuardrailEnforcementEntry[];
+  bindings?: SoftwareBinding[];
   [key: string]: unknown;
 }
 
@@ -156,8 +177,70 @@ export function buildGlobalContext(dsl: Dsl): GlobalContext {
   };
 }
 
-export function buildSystemContext(dsl: Dsl): SystemContext {
-  return { system: dsl.system, dsl };
+export function buildSystemContext(
+  dsl: Dsl,
+  options?: { loadedBindings?: LoadedBinding[]; activeGuardrailPolicy?: string },
+): SystemContext {
+  const ctx: SystemContext = { system: dsl.system, dsl };
+
+  if (options?.loadedBindings && options.loadedBindings.length > 0) {
+    ctx.bindings = options.loadedBindings.map((lb) => lb.binding);
+
+    const policyName = options.activeGuardrailPolicy;
+    const policy = policyName ? dsl.guardrail_policies[policyName] : undefined;
+
+    if (policy) {
+      ctx.guardrailEnforcement = buildGuardrailEnforcement(dsl, policy, options.loadedBindings);
+    }
+  }
+
+  return ctx;
+}
+
+function buildGuardrailEnforcement(
+  dsl: Dsl,
+  policy: GuardrailPolicy,
+  loadedBindings: LoadedBinding[],
+): GuardrailEnforcementEntry[] {
+  const entries: GuardrailEnforcementEntry[] = [];
+
+  const bindingTriggers = new Map<string, string>();
+  for (const lb of loadedBindings) {
+    const impl = lb.binding.guardrail_impl ?? {};
+    for (const [guardrailId, gi] of Object.entries(impl)) {
+      for (const check of gi.checks) {
+        if (check.matcher) {
+          bindingTriggers.set(guardrailId, check.matcher.type);
+        }
+      }
+    }
+  }
+
+  for (const rule of policy.rules) {
+    const guardrail = dsl.guardrails[rule.guardrail];
+    if (!guardrail) continue;
+
+    const scope = guardrail.scope ?? {};
+    entries.push({
+      guardrail_id: rule.guardrail,
+      description: guardrail.description,
+      severity: rule.severity,
+      action: rule.action,
+      scoped_agents: scope.agents ?? [],
+      scoped_tasks: scope.tasks ?? [],
+      scoped_workflows: scope.workflows ?? [],
+      scoped_tools: scope.tools ?? [],
+      scoped_artifacts: scope.artifacts ?? [],
+      allow_override: rule.allow_override,
+      override_requires: rule.override_requires ?? [],
+      trigger: bindingTriggers.get(rule.guardrail) ?? null,
+      escalation: rule.escalation
+        ? { target: rule.escalation.target, condition: rule.escalation.condition }
+        : null,
+    });
+  }
+
+  return entries;
 }
 
 export function buildTaskContext(

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,6 +1,7 @@
 export {
   renderFromConfig,
   checkDriftFromConfig,
+  type RenderOptions,
 } from "./renderer.js";
 export {
   buildGlobalContext,
@@ -29,4 +30,5 @@ export {
   type PerGuardrailPolicyContext,
   type MergedBehavioralSpec,
   type DelegatableTaskView,
+  type GuardrailEnforcementEntry,
 } from "./context.js";

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -4,6 +4,7 @@ import Handlebars from "handlebars";
 import type { Dsl } from "../schema/index.js";
 import { resolveAllOf } from "../schema/index.js";
 import type { ResolvedRenderTarget, ContextType } from "../config/types.js";
+import type { LoadedBinding } from "../config/binding-loader.js";
 import {
   buildPerAgentContext,
   buildSystemContext,
@@ -250,6 +251,63 @@ Handlebars.registerHelper(
   },
 );
 
+Handlebars.registerHelper(
+  "guardrailCoverageMatrix",
+  function (this: Record<string, unknown>): string {
+    const enforcement = this["guardrailEnforcement"] as Array<Record<string, unknown>> | undefined;
+    if (!enforcement || enforcement.length === 0) return "";
+
+    const header = "| Guardrail | Severity | Action | Agents | Tasks | Workflows | Tools | Artifacts | Trigger | Override | Escalation |";
+    const divider = "|-----------|----------|--------|--------|-------|-----------|-------|-----------|---------|----------|------------|";
+    const rows = enforcement.map((e) => {
+      const agents = (e["scoped_agents"] as string[])?.join(", ") || "—";
+      const tasks = (e["scoped_tasks"] as string[])?.join(", ") || "—";
+      const workflows = (e["scoped_workflows"] as string[])?.join(", ") || "—";
+      const tools = (e["scoped_tools"] as string[])?.join(", ") || "—";
+      const artifacts = (e["scoped_artifacts"] as string[])?.join(", ") || "—";
+      const trigger = (e["trigger"] as string) || "—";
+      const override = e["allow_override"] ? "yes" : "no";
+      const esc = e["escalation"] as Record<string, string> | null;
+      const escalation = esc ? esc["target"] : "—";
+      return `| ${e["guardrail_id"]} | ${e["severity"]} | ${e["action"]} | ${agents} | ${tasks} | ${workflows} | ${tools} | ${artifacts} | ${trigger} | ${override} | ${escalation} |`;
+    });
+
+    return [header, divider, ...rows].join("\n");
+  },
+);
+
+Handlebars.registerHelper(
+  "taskGuardrailMatrix",
+  function (this: Record<string, unknown>): string {
+    const dsl = this["dsl"] as Dsl | undefined;
+    const enforcement = this["guardrailEnforcement"] as Array<Record<string, unknown>> | undefined;
+    if (!dsl || !enforcement || enforcement.length === 0) return "";
+
+    const taskIds = Object.keys(dsl.tasks);
+    if (taskIds.length === 0) return "";
+
+    const guardrailIds = enforcement.map((e) => e["guardrail_id"] as string);
+    const header = `| Task | ${guardrailIds.join(" | ")} |`;
+    const divider = `|------|${guardrailIds.map(() => "------").join("|")}|`;
+
+    const rows = taskIds.map((taskId) => {
+      const cells = enforcement.map((e) => {
+        const scopedTasks = e["scoped_tasks"] as string[];
+        if (scopedTasks.length > 0 && !scopedTasks.includes(taskId)) return "n/a";
+        return e["action"] as string;
+      });
+      return `| ${taskId} | ${cells.join(" | ")} |`;
+    });
+
+    return [header, divider, ...rows].join("\n");
+  },
+);
+
+export interface RenderOptions {
+  loadedBindings?: LoadedBinding[];
+  activeGuardrailPolicy?: string;
+}
+
 function getDslSection(dsl: Dsl, context: ContextType): Record<string, unknown> {
   const sectionMap: Record<string, Record<string, unknown>> = {
     agent: dsl.agents,
@@ -333,6 +391,7 @@ async function removeIfExists(filePath: string): Promise<void> {
 export async function renderFromConfig(
   dsl: Dsl,
   renderTargets: ResolvedRenderTarget[],
+  options?: RenderOptions,
 ): Promise<string[]> {
   const outputFiles: string[] = [];
 
@@ -341,7 +400,7 @@ export async function renderFromConfig(
     const compiled = Handlebars.compile(templateContent, { noEscape: false });
 
     if (target.context === "system") {
-      const ctx = buildSystemContext(dsl);
+      const ctx = buildSystemContext(dsl, options);
       const output = compiled(ctx);
       if (target.skip_empty && isEffectivelyEmpty(output)) {
         await removeIfExists(target.output);
@@ -405,6 +464,7 @@ function checkExpectedVsExisting(
 export async function checkDriftFromConfig(
   dsl: Dsl,
   renderTargets: ResolvedRenderTarget[],
+  options?: RenderOptions,
 ): Promise<{ hasDrift: boolean; diffs: string[] }> {
   const diffs: string[] = [];
 
@@ -413,7 +473,7 @@ export async function checkDriftFromConfig(
     const compiled = Handlebars.compile(templateContent, { noEscape: false });
 
     if (target.context === "system") {
-      const ctx = buildSystemContext(dsl);
+      const ctx = buildSystemContext(dsl, options);
       const expected = compiled(ctx);
       await checkExpectedVsExisting(expected, target.output, target.skip_empty, diffs);
     } else {

--- a/test/context-builders.test.ts
+++ b/test/context-builders.test.ts
@@ -342,3 +342,88 @@ describe("buildGuardrailPolicyContext", () => {
     expect(ctx.dsl).toBe(dsl);
   });
 });
+
+describe("buildSystemContext with bindings", () => {
+  function createBindingLoadedBinding() {
+    return {
+      filePath: "/test/binding.yaml",
+      binding: {
+        software: "cursor",
+        version: 1 as const,
+        guardrail_impl: {
+          "no-force-push": {
+            checks: [
+              { matcher: { type: "command_regex" as const, pattern: "git push.*--force" }, message: "Force push blocked" },
+            ],
+          },
+        },
+      },
+    };
+  }
+
+  it("returns basic context when no bindings provided", () => {
+    const dsl = createMinimalDsl();
+    const ctx = buildSystemContext(dsl);
+    expect(ctx.guardrailEnforcement).toBeUndefined();
+    expect(ctx.bindings).toBeUndefined();
+  });
+
+  it("returns basic context when empty bindings provided", () => {
+    const dsl = createMinimalDsl();
+    const ctx = buildSystemContext(dsl, { loadedBindings: [] });
+    expect(ctx.guardrailEnforcement).toBeUndefined();
+    expect(ctx.bindings).toBeUndefined();
+  });
+
+  it("includes bindings in context when provided", () => {
+    const dsl = createMinimalDsl();
+    const lb = createBindingLoadedBinding();
+    const ctx = buildSystemContext(dsl, {
+      loadedBindings: [lb],
+      activeGuardrailPolicy: "default",
+    });
+    expect(ctx.bindings).toHaveLength(1);
+    expect(ctx.bindings![0].software).toBe("cursor");
+  });
+
+  it("builds guardrailEnforcement from policy + bindings", () => {
+    const dsl = createMinimalDsl();
+    const lb = createBindingLoadedBinding();
+    const ctx = buildSystemContext(dsl, {
+      loadedBindings: [lb],
+      activeGuardrailPolicy: "default",
+    });
+    expect(ctx.guardrailEnforcement).toBeDefined();
+    expect(ctx.guardrailEnforcement).toHaveLength(1);
+    const entry = ctx.guardrailEnforcement![0];
+    expect(entry.guardrail_id).toBe("no-force-push");
+    expect(entry.severity).toBe("critical");
+    expect(entry.action).toBe("block");
+    expect(entry.scoped_tools).toEqual(["lint"]);
+    expect(entry.trigger).toBe("command_regex");
+  });
+
+  it("skips guardrailEnforcement when no active policy", () => {
+    const dsl = createMinimalDsl();
+    const lb = createBindingLoadedBinding();
+    const ctx = buildSystemContext(dsl, {
+      loadedBindings: [lb],
+    });
+    expect(ctx.guardrailEnforcement).toBeUndefined();
+    expect(ctx.bindings).toHaveLength(1);
+  });
+
+  it("sets trigger to null when no binding implements the guardrail", () => {
+    const dsl = createMinimalDsl();
+    const lb = {
+      filePath: "/test/binding.yaml",
+      binding: { software: "cursor", version: 1 as const },
+    };
+    const ctx = buildSystemContext(dsl, {
+      loadedBindings: [lb],
+      activeGuardrailPolicy: "default",
+    });
+    expect(ctx.guardrailEnforcement).toHaveLength(1);
+    expect(ctx.guardrailEnforcement![0].trigger).toBeNull();
+  });
+});

--- a/test/renderer/renderer.test.ts
+++ b/test/renderer/renderer.test.ts
@@ -970,3 +970,130 @@ describe("linter: tool-commands", () => {
     expect(writeWarning).toBeDefined();
   });
 });
+
+describe("renderFromConfig with bindings", () => {
+  it("passes bindings to system context template", async () => {
+    const templatePath = join(outputDir, "binding-test.md.hbs");
+    const outputPath = join(outputDir, "binding-test.md");
+    mkdirSync(outputDir, { recursive: true });
+    writeFileSync(templatePath, "{{#if guardrailEnforcement}}HAS_ENFORCEMENT{{else}}NO_ENFORCEMENT{{/if}}", "utf8");
+
+    const dsl = DslSchema.parse({
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: ["implement"] },
+      guardrails: {
+        "no-force-push": { description: "No force push", scope: { tools: ["t1"] }, tags: [] },
+      },
+      guardrail_policies: {
+        main: { rules: [{ guardrail: "no-force-push", severity: "critical", action: "block" }] },
+      },
+    });
+
+    const targets: ResolvedRenderTarget[] = [
+      { template: templatePath, context: "system", output: outputPath },
+    ];
+
+    const loadedBindings = [{
+      filePath: "/test.yaml",
+      binding: {
+        software: "cursor",
+        version: 1 as const,
+        guardrail_impl: {
+          "no-force-push": {
+            checks: [{ matcher: { type: "command_regex" as const, pattern: "force" } }],
+          },
+        },
+      },
+    }];
+
+    const files = await renderFromConfig(dsl, targets, {
+      loadedBindings,
+      activeGuardrailPolicy: "main",
+    });
+
+    expect(files).toHaveLength(1);
+    const content = readFileSync(outputPath, "utf8");
+    expect(content).toBe("HAS_ENFORCEMENT");
+  });
+
+  it("renders without enforcement when no bindings", async () => {
+    const templatePath = join(outputDir, "no-binding-test.md.hbs");
+    const outputPath = join(outputDir, "no-binding-test.md");
+    mkdirSync(outputDir, { recursive: true });
+    writeFileSync(templatePath, "{{#if guardrailEnforcement}}HAS{{else}}NONE{{/if}}", "utf8");
+
+    const dsl = DslSchema.parse({
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: ["implement"] },
+    });
+
+    const targets: ResolvedRenderTarget[] = [
+      { template: templatePath, context: "system", output: outputPath },
+    ];
+
+    const files = await renderFromConfig(dsl, targets);
+    expect(files).toHaveLength(1);
+    const content = readFileSync(outputPath, "utf8");
+    expect(content).toBe("NONE");
+  });
+});
+
+describe("guardrailCoverageMatrix helper", () => {
+  it("generates markdown table from enforcement data", async () => {
+    const templatePath = join(outputDir, "matrix-test.md.hbs");
+    const outputPath = join(outputDir, "matrix-test.md");
+    mkdirSync(outputDir, { recursive: true });
+    writeFileSync(templatePath, "{{{guardrailCoverageMatrix}}}", "utf8");
+
+    const dsl = DslSchema.parse({
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: ["implement"] },
+      guardrails: {
+        "no-force-push": { description: "No force push", scope: { tools: ["editor"] }, tags: [] },
+      },
+      guardrail_policies: {
+        main: { rules: [{ guardrail: "no-force-push", severity: "critical", action: "block" }] },
+      },
+    });
+
+    const targets: ResolvedRenderTarget[] = [
+      { template: templatePath, context: "system", output: outputPath },
+    ];
+
+    const files = await renderFromConfig(dsl, targets, {
+      loadedBindings: [{
+        filePath: "/b.yaml",
+        binding: { software: "cursor", version: 1 as const },
+      }],
+      activeGuardrailPolicy: "main",
+    });
+
+    expect(files).toHaveLength(1);
+    const content = readFileSync(outputPath, "utf8");
+    expect(content).toContain("no-force-push");
+    expect(content).toContain("critical");
+    expect(content).toContain("block");
+    expect(content).toContain("editor");
+  });
+
+  it("returns empty string when no enforcement data", async () => {
+    const templatePath = join(outputDir, "empty-matrix.md.hbs");
+    const outputPath = join(outputDir, "empty-matrix.md");
+    mkdirSync(outputDir, { recursive: true });
+    writeFileSync(templatePath, "START{{{guardrailCoverageMatrix}}}END", "utf8");
+
+    const dsl = DslSchema.parse({
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: ["implement"] },
+    });
+
+    const targets: ResolvedRenderTarget[] = [
+      { template: templatePath, context: "system", output: outputPath },
+    ];
+
+    const files = await renderFromConfig(dsl, targets);
+    expect(files).toHaveLength(1);
+    const content = readFileSync(outputPath, "utf8");
+    expect(content).toBe("STARTEND");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3

- **Binding-aware render pipeline** — `render` CLI loads bindings when `config.bindings` is present and passes them to system-context templates
- **Enriched `buildSystemContext`** — produces `guardrailEnforcement` array (guardrail × severity × action × scoped entities × trigger × override × escalation) and `bindings` array when bindings + active policy are configured
- **`guardrailCoverageMatrix` helper** — generates full guardrail coverage matrix as markdown table
- **`taskGuardrailMatrix` helper** — generates task × guardrail cross-reference table
- **Sample template** — `sample/templates/guardrail-matrix.md.hbs` demonstrating matrix output
- **Documentation** — updated `system` context variables and matrix helpers in README
- **Tests** — 10 new tests covering context building with bindings and matrix helper rendering
- **Version bump** to 0.12.0

## Changes

| File | Change |
|------|--------|
| `src/renderer/context.ts` | `GuardrailEnforcementEntry` interface, enriched `buildSystemContext` |
| `src/renderer/renderer.ts` | `RenderOptions`, matrix Handlebars helpers, optional binding pass-through |
| `src/renderer/index.ts` | New exports |
| `src/cli/commands/render.ts` | Load bindings when configured |
| `sample/templates/guardrail-matrix.md.hbs` | New sample template |
| `README.md` | Binding-aware context documentation |
| `test/context-builders.test.ts` | 6 new tests |
| `test/renderer/renderer.test.ts` | 4 new tests |
| `package.json` | Version 0.12.0 |

## Test plan

- [x] All 506 tests pass
- [x] Typecheck passes
- [x] Existing render behavior unchanged when no bindings configured
