### PR TITLE
feat: patch merge for binding outputs & source file copy (#13, #14)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/sample/agent-contracts/bindings/cursor.yaml
+++ b/sample/agent-contracts/bindings/cursor.yaml
@@ -79,6 +79,9 @@ outputs:
 
   policy-bundle:
     target: "{cursor_root}/guardrails/policy.json"
-    mode: write
+    mode: patch
+    format: json
+    patch_strategy: deep_merge
+    array_merge_key: guardrail_id
     inline_template: |
-      {{json resolved_checks}}
+      {"checks":{{json resolved_checks}},"meta":{"cursor_binding":true}}

--- a/sample/agent-contracts/bindings/observability.yaml
+++ b/sample/agent-contracts/bindings/observability.yaml
@@ -23,6 +23,19 @@ outputs:
           - guardrail.check.matched
           - guardrail.outcome
 
+  policy-bundle:
+    target: "{cursor_root}/guardrails/policy.json"
+    mode: patch
+    format: json
+    patch_strategy: deep_merge
+    inline_template: |
+      {"meta":{"observability_binding":true}}
+
+  enrichment-script:
+    target: "{observability_root}/enrich.lua"
+    source: "scripts/enrich.lua"
+    executable: true
+
 reporting:
   commands:
     on_started: >-

--- a/sample/scripts/enrich.lua
+++ b/sample/scripts/enrich.lua
@@ -1,0 +1,10 @@
+-- Guardrail event enrichment script
+-- Deployed as-is by agent-contracts (no template processing)
+
+local function enrich(event)
+  event.enriched_at = os.time()
+  event.source = "agent-contracts"
+  return event
+end
+
+return { enrich = enrich }

--- a/src/guardrail-generator/generator.ts
+++ b/src/guardrail-generator/generator.ts
@@ -1,9 +1,11 @@
-import { readFile, writeFile, mkdir, chmod, unlink } from "node:fs/promises";
+import { readFile, writeFile, mkdir, chmod, unlink, copyFile } from "node:fs/promises";
 import { resolve, dirname } from "node:path";
 import Handlebars from "handlebars";
+import YAML from "yaml";
 import type { Dsl } from "../schema/index.js";
 import type { ResolvedConfig } from "../config/types.js";
 import type { LoadedBinding } from "../config/binding-loader.js";
+import type { BindingOutput } from "../schema/index.js";
 import type {
   GuardrailGenerationContext,
   GenerateResult,
@@ -30,6 +32,105 @@ Handlebars.registerHelper(
     return new Handlebars.SafeString(result);
   },
 );
+
+function isPlainObject(val: unknown): val is Record<string, unknown> {
+  return typeof val === "object" && val !== null && !Array.isArray(val);
+}
+
+function deepMergeArrays(
+  existing: unknown[],
+  incoming: unknown[],
+  mergeKey?: string,
+): unknown[] {
+  if (!mergeKey) return [...existing, ...incoming];
+  const merged = [...existing];
+  for (const item of incoming) {
+    if (isPlainObject(item) && mergeKey in item) {
+      const idx = merged.findIndex(
+        (e) => isPlainObject(e) && e[mergeKey] === item[mergeKey],
+      );
+      if (idx >= 0) {
+        merged[idx] = item;
+      } else {
+        merged.push(item);
+      }
+    } else {
+      merged.push(item);
+    }
+  }
+  return merged;
+}
+
+function deepMerge(
+  existing: unknown,
+  incoming: unknown,
+  arrayMergeKey?: string,
+): unknown {
+  if (Array.isArray(existing) && Array.isArray(incoming)) {
+    return deepMergeArrays(existing, incoming, arrayMergeKey);
+  }
+  if (isPlainObject(existing) && isPlainObject(incoming)) {
+    const result: Record<string, unknown> = { ...existing };
+    for (const [key, val] of Object.entries(incoming)) {
+      result[key] = key in result
+        ? deepMerge(result[key], val, arrayMergeKey)
+        : val;
+    }
+    return result;
+  }
+  return incoming;
+}
+
+function parseContent(raw: string, format: string): unknown {
+  if (format === "json") return JSON.parse(raw);
+  if (format === "yaml") return YAML.parse(raw);
+  throw new Error(`Unsupported format for patch parsing: ${format}`);
+}
+
+function serializeContent(data: unknown, format: string): string {
+  if (format === "json") return JSON.stringify(data, null, 2) + "\n";
+  if (format === "yaml") return YAML.stringify(data);
+  throw new Error(`Unsupported format for patch serialization: ${format}`);
+}
+
+async function applyPatch(
+  targetPath: string,
+  patchContent: string,
+  outputDef: BindingOutput,
+): Promise<string> {
+  const format = outputDef.format ?? "json";
+
+  if (format === "text") {
+    let existing = "";
+    try {
+      existing = await readFile(targetPath, "utf8");
+    } catch { /* first write */ }
+    return existing + patchContent;
+  }
+
+  const patchData = parseContent(patchContent, format);
+
+  let existingData: unknown;
+  try {
+    const existingRaw = await readFile(targetPath, "utf8");
+    existingData = parseContent(existingRaw, format);
+  } catch {
+    return serializeContent(patchData, format);
+  }
+
+  const strategy = outputDef.patch_strategy ?? "deep_merge";
+  if (strategy === "append" && Array.isArray(existingData)) {
+    const merged = deepMergeArrays(
+      existingData,
+      Array.isArray(patchData) ? patchData : [patchData],
+      outputDef.array_merge_key,
+    );
+    return serializeContent(merged, format);
+  }
+
+  const merged = deepMerge(existingData, patchData, outputDef.array_merge_key);
+  return serializeContent(merged, format);
+}
 
 export interface GenerateGuardrailsOptions {
   dsl: Dsl;
@@ -133,13 +234,39 @@ export async function generateGuardrails(
 
       const targetPath = resolve(config.configDir, pathResult.resolved);
 
-      // Get template content
+      // --- source: file copy without template processing ---
+      if (outputDef.source) {
+        const sourcePath = resolve(config.configDir, outputDef.source);
+        if (!dryRun) {
+          try {
+            await mkdir(dirname(targetPath), { recursive: true });
+            await copyFile(sourcePath, targetPath);
+            if (outputDef.executable) {
+              await chmod(targetPath, 0o755);
+            }
+          } catch (err) {
+            const code = (err as NodeJS.ErrnoException).code;
+            if (code === "ENOENT") {
+              diagnostics.push({
+                path: `binding.${binding.software}.outputs.${outputId}`,
+                message: `Source file not found: ${sourcePath}`,
+                severity: "error",
+              });
+              continue;
+            }
+            throw err;
+          }
+        }
+        outputFiles.push(targetPath);
+        continue;
+      }
+
+      // --- template / inline_template rendering ---
       let templateContent: string;
       if (outputDef.inline_template) {
         templateContent = outputDef.inline_template;
       } else if (outputDef.template) {
         if (outputDef.template.startsWith("builtin:")) {
-          // Builtin templates are not yet implemented — skip with info
           diagnostics.push({
             path: `binding.${binding.software}.outputs.${outputId}`,
             message: `Builtin template "${outputDef.template}" is not yet implemented — skipping`,
@@ -161,13 +288,14 @@ export async function generateGuardrails(
       } else {
         diagnostics.push({
           path: `binding.${binding.software}.outputs.${outputId}`,
-          message: "Output has neither template nor inline_template",
+          message: "Output has neither template, inline_template, nor source",
           severity: "error",
         });
         continue;
       }
 
       const shouldSkipEmpty = outputDef.skip_empty === true;
+      const isPatch = outputDef.mode === "patch";
 
       // If group_by is set, render once per group
       if (outputDef.group_by) {
@@ -189,16 +317,20 @@ export async function generateGuardrails(
             current_group: groupKey,
           };
           const compiled = Handlebars.compile(templateContent, { noEscape: true });
-          const output = compiled(groupCtx);
+          const rendered = compiled(groupCtx);
 
           const groupTarget = resolve(targetPath, groupKey);
 
-          if (shouldSkipEmpty && output.trim().length === 0) {
+          if (shouldSkipEmpty && rendered.trim().length === 0) {
             if (!dryRun) {
               try { await unlink(groupTarget); } catch { /* not found */ }
             }
             continue;
           }
+
+          const output = isPatch && !dryRun
+            ? await applyPatch(groupTarget, rendered, outputDef)
+            : rendered;
 
           if (!dryRun) {
             await mkdir(dirname(groupTarget), { recursive: true });
@@ -211,13 +343,17 @@ export async function generateGuardrails(
         }
       } else {
         const compiled = Handlebars.compile(templateContent, { noEscape: true });
-        const output = compiled(ctx);
+        const rendered = compiled(ctx);
 
-        if (shouldSkipEmpty && output.trim().length === 0) {
+        if (shouldSkipEmpty && rendered.trim().length === 0) {
           if (!dryRun) {
             try { await unlink(targetPath); } catch { /* not found */ }
           }
         } else {
+          const output = isPatch && !dryRun
+            ? await applyPatch(targetPath, rendered, outputDef)
+            : rendered;
+
           if (!dryRun) {
             await mkdir(dirname(targetPath), { recursive: true });
             await writeFile(targetPath, output, "utf8");

--- a/src/schema/binding.ts
+++ b/src/schema/binding.ts
@@ -45,15 +45,23 @@ export const BindingOutputSchema = z
     target: z.string(),
     template: z.string().optional(),
     inline_template: z.string().optional(),
+    source: z.string().optional(),
     mode: z.enum(["write", "patch"]).default("write"),
+    format: z.enum(["json", "yaml", "text"]).optional(),
+    patch_strategy: z.enum(["deep_merge", "append"]).optional(),
+    array_merge_key: z.string().optional(),
     group_by: z.string().optional(),
     executable: z.boolean().optional(),
     skip_empty: z.boolean().optional(),
   })
   .passthrough()
   .refine(
-    (data) => !(data.template && data.inline_template),
-    { message: "template and inline_template are mutually exclusive" },
+    (data) => {
+      const count = [data.template, data.inline_template, data.source]
+        .filter(Boolean).length;
+      return count === 1 || count === 0;
+    },
+    { message: "Only one of template, inline_template, or source may be specified" },
   );
 export type BindingOutput = z.infer<typeof BindingOutputSchema>;
 

--- a/test/guardrail-generator/generator.test.ts
+++ b/test/guardrail-generator/generator.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { LoadedBinding } from "../../src/config/binding-loader.js";
 import type { ResolvedConfig } from "../../src/config/types.js";
@@ -202,7 +202,7 @@ describe("generateGuardrails diagnostics", () => {
       expect.objectContaining({
         path: "binding.app.outputs.out",
         severity: "error",
-        message: "Output has neither template nor inline_template",
+        message: "Output has neither template, inline_template, nor source",
       }),
     );
   });
@@ -501,5 +501,339 @@ describe("generateGuardrails reporting context", () => {
     expect(result.outputFiles).toEqual([join(hooks, "report.txt")]);
     const body = await readFile(join(hooks, "report.txt"), "utf8");
     expect(body).toBe("observ emit {{id}}|false|4242");
+  });
+});
+
+describe("generateGuardrails source copy (issue #14)", () => {
+  it("copies source file to target without template processing", async () => {
+    const configDir = await newConfigDir();
+    const hooks = join(configDir, "hooks");
+    const dsl = minimalDsl();
+    const config = baseResolvedConfig(configDir);
+    const sourceContent = "#!/usr/bin/env lua\nprint('hello {{not a template}}')\n";
+    await mkdir(join(configDir, "scripts"), { recursive: true });
+    await writeFile(join(configDir, "scripts/enrich.lua"), sourceContent);
+    const lb = bindingWithOutputs(configDir, "app", {
+      out: {
+        target: "{hooks}/enrich.lua",
+        source: "scripts/enrich.lua",
+      },
+    });
+
+    const result = await generateGuardrails({
+      dsl,
+      config,
+      loadedBindings: [lb],
+    });
+
+    expect(result.outputFiles).toEqual([join(hooks, "enrich.lua")]);
+    const body = await readFile(join(hooks, "enrich.lua"), "utf8");
+    expect(body).toBe(sourceContent);
+  });
+
+  it("applies executable flag on source copy", async () => {
+    const configDir = await newConfigDir();
+    const dsl = minimalDsl();
+    const config = baseResolvedConfig(configDir);
+    await writeFile(join(configDir, "run.sh"), "#!/bin/sh\necho ok\n");
+    const lb = bindingWithOutputs(configDir, "app", {
+      out: {
+        target: "{hooks}/run.sh",
+        source: "run.sh",
+        executable: true,
+      },
+    });
+
+    const result = await generateGuardrails({
+      dsl,
+      config,
+      loadedBindings: [lb],
+    });
+
+    const out = result.outputFiles[0]!;
+    const s = await stat(out);
+    if (process.platform !== "win32") {
+      expect(s.mode & 0o111).toBeTruthy();
+    }
+  });
+
+  it("returns error when source file not found", async () => {
+    const configDir = await newConfigDir();
+    const dsl = minimalDsl();
+    const config = baseResolvedConfig(configDir);
+    const lb = bindingWithOutputs(configDir, "app", {
+      out: {
+        target: "{hooks}/missing.lua",
+        source: "nonexistent.lua",
+      },
+    });
+
+    const result = await generateGuardrails({
+      dsl,
+      config,
+      loadedBindings: [lb],
+    });
+
+    expect(result.outputFiles).toEqual([]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        path: "binding.app.outputs.out",
+        severity: "error",
+        message: expect.stringContaining("Source file not found"),
+      }),
+    );
+  });
+
+  it("dryRun with source returns path but does not copy", async () => {
+    const configDir = await newConfigDir();
+    const hooks = join(configDir, "hooks");
+    const dsl = minimalDsl();
+    const config = baseResolvedConfig(configDir);
+    await writeFile(join(configDir, "src.txt"), "data");
+    const lb = bindingWithOutputs(configDir, "app", {
+      out: {
+        target: "{hooks}/dst.txt",
+        source: "src.txt",
+      },
+    });
+
+    const result = await generateGuardrails({
+      dsl,
+      config,
+      loadedBindings: [lb],
+      dryRun: true,
+    });
+
+    expect(result.outputFiles).toEqual([join(hooks, "dst.txt")]);
+    await expect(readFile(join(hooks, "dst.txt"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+});
+
+describe("generateGuardrails patch merge (issue #13)", () => {
+  it("deep-merges JSON when mode is patch", async () => {
+    const configDir = await newConfigDir();
+    const hooks = join(configDir, "hooks");
+    const dsl = minimalDsl();
+    const config = baseResolvedConfig(configDir);
+
+    await mkdir(hooks, { recursive: true });
+    await writeFile(
+      join(hooks, "config.json"),
+      JSON.stringify({ existing: true, nested: { a: 1 } }, null, 2),
+    );
+
+    const lb = bindingWithOutputs(configDir, "app", {
+      out: {
+        target: "{hooks}/config.json",
+        mode: "patch" as const,
+        format: "json" as const,
+        patch_strategy: "deep_merge" as const,
+        inline_template: '{"nested":{"b":2},"added":true}',
+      },
+    });
+
+    const result = await generateGuardrails({
+      dsl,
+      config,
+      loadedBindings: [lb],
+    });
+
+    expect(result.outputFiles).toEqual([join(hooks, "config.json")]);
+    const body = JSON.parse(await readFile(join(hooks, "config.json"), "utf8"));
+    expect(body.existing).toBe(true);
+    expect(body.nested).toEqual({ a: 1, b: 2 });
+    expect(body.added).toBe(true);
+  });
+
+  it("writes directly when target does not exist (first patch)", async () => {
+    const configDir = await newConfigDir();
+    const hooks = join(configDir, "hooks");
+    const dsl = minimalDsl();
+    const config = baseResolvedConfig(configDir);
+
+    const lb = bindingWithOutputs(configDir, "app", {
+      out: {
+        target: "{hooks}/new.json",
+        mode: "patch" as const,
+        format: "json" as const,
+        inline_template: '{"key":"value"}',
+      },
+    });
+
+    const result = await generateGuardrails({
+      dsl,
+      config,
+      loadedBindings: [lb],
+    });
+
+    expect(result.outputFiles).toEqual([join(hooks, "new.json")]);
+    const body = JSON.parse(await readFile(join(hooks, "new.json"), "utf8"));
+    expect(body).toEqual({ key: "value" });
+  });
+
+  it("deduplicates arrays by array_merge_key (idempotent)", async () => {
+    const configDir = await newConfigDir();
+    const hooks = join(configDir, "hooks");
+    const dsl = minimalDsl();
+    const config = baseResolvedConfig(configDir);
+
+    await mkdir(hooks, { recursive: true });
+    await writeFile(
+      join(hooks, "hooks.json"),
+      JSON.stringify({
+        hooks: [
+          { id: "hook-a", command: "old" },
+          { id: "hook-b", command: "keep" },
+        ],
+      }, null, 2),
+    );
+
+    const lb = bindingWithOutputs(configDir, "app", {
+      out: {
+        target: "{hooks}/hooks.json",
+        mode: "patch" as const,
+        format: "json" as const,
+        patch_strategy: "deep_merge" as const,
+        array_merge_key: "id",
+        inline_template: '{"hooks":[{"id":"hook-a","command":"updated"},{"id":"hook-c","command":"new"}]}',
+      },
+    });
+
+    await generateGuardrails({
+      dsl,
+      config,
+      loadedBindings: [lb],
+    });
+
+    const body = JSON.parse(await readFile(join(hooks, "hooks.json"), "utf8"));
+    expect(body.hooks).toHaveLength(3);
+    expect(body.hooks[0]).toEqual({ id: "hook-a", command: "updated" });
+    expect(body.hooks[1]).toEqual({ id: "hook-b", command: "keep" });
+    expect(body.hooks[2]).toEqual({ id: "hook-c", command: "new" });
+
+    // Run again — idempotent
+    const result2 = await generateGuardrails({
+      dsl,
+      config,
+      loadedBindings: [lb],
+    });
+    expect(result2.diagnostics.filter((d) => d.severity === "error")).toHaveLength(0);
+    const body2 = JSON.parse(await readFile(join(hooks, "hooks.json"), "utf8"));
+    expect(body2.hooks).toHaveLength(3);
+  });
+
+  it("deep-merges YAML when format is yaml", async () => {
+    const configDir = await newConfigDir();
+    const hooks = join(configDir, "hooks");
+    const dsl = minimalDsl();
+    const config = baseResolvedConfig(configDir);
+
+    await mkdir(hooks, { recursive: true });
+    await writeFile(join(hooks, "config.yaml"), "existing: true\nnested:\n  a: 1\n");
+
+    const lb = bindingWithOutputs(configDir, "app", {
+      out: {
+        target: "{hooks}/config.yaml",
+        mode: "patch" as const,
+        format: "yaml" as const,
+        patch_strategy: "deep_merge" as const,
+        inline_template: "nested:\n  b: 2\nadded: true\n",
+      },
+    });
+
+    const result = await generateGuardrails({
+      dsl,
+      config,
+      loadedBindings: [lb],
+    });
+
+    expect(result.outputFiles).toEqual([join(hooks, "config.yaml")]);
+    const raw = await readFile(join(hooks, "config.yaml"), "utf8");
+    const parsed = await import("yaml").then((m) => m.parse(raw));
+    expect(parsed.existing).toBe(true);
+    expect(parsed.nested).toEqual({ a: 1, b: 2 });
+    expect(parsed.added).toBe(true);
+  });
+
+  it("appends text when format is text", async () => {
+    const configDir = await newConfigDir();
+    const hooks = join(configDir, "hooks");
+    const dsl = minimalDsl();
+    const config = baseResolvedConfig(configDir);
+
+    await mkdir(hooks, { recursive: true });
+    await writeFile(join(hooks, "log.txt"), "line1\n");
+
+    const lb = bindingWithOutputs(configDir, "app", {
+      out: {
+        target: "{hooks}/log.txt",
+        mode: "patch" as const,
+        format: "text" as const,
+        inline_template: "line2\n",
+      },
+    });
+
+    const result = await generateGuardrails({
+      dsl,
+      config,
+      loadedBindings: [lb],
+    });
+
+    expect(result.outputFiles).toEqual([join(hooks, "log.txt")]);
+    const body = await readFile(join(hooks, "log.txt"), "utf8");
+    expect(body).toBe("line1\nline2\n");
+  });
+
+  it("appends arrays without merge key", async () => {
+    const configDir = await newConfigDir();
+    const hooks = join(configDir, "hooks");
+    const dsl = minimalDsl();
+    const config = baseResolvedConfig(configDir);
+
+    await mkdir(hooks, { recursive: true });
+    await writeFile(
+      join(hooks, "items.json"),
+      JSON.stringify({ items: ["a", "b"] }, null, 2),
+    );
+
+    const lb = bindingWithOutputs(configDir, "app", {
+      out: {
+        target: "{hooks}/items.json",
+        mode: "patch" as const,
+        format: "json" as const,
+        patch_strategy: "deep_merge" as const,
+        inline_template: '{"items":["c","d"]}',
+      },
+    });
+
+    await generateGuardrails({ dsl, config, loadedBindings: [lb] });
+
+    const body = JSON.parse(await readFile(join(hooks, "items.json"), "utf8"));
+    expect(body.items).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("defaults format to json when not specified in patch mode", async () => {
+    const configDir = await newConfigDir();
+    const hooks = join(configDir, "hooks");
+    const dsl = minimalDsl();
+    const config = baseResolvedConfig(configDir);
+
+    await mkdir(hooks, { recursive: true });
+    await writeFile(join(hooks, "f.json"), '{"a":1}');
+
+    const lb = bindingWithOutputs(configDir, "app", {
+      out: {
+        target: "{hooks}/f.json",
+        mode: "patch" as const,
+        inline_template: '{"b":2}',
+      },
+    });
+
+    await generateGuardrails({ dsl, config, loadedBindings: [lb] });
+
+    const body = JSON.parse(await readFile(join(hooks, "f.json"), "utf8"));
+    expect(body).toEqual({ a: 1, b: 2 });
   });
 });

--- a/test/schema/guardrail.test.ts
+++ b/test/schema/guardrail.test.ts
@@ -332,6 +332,16 @@ describe("BindingOutputSchema", () => {
     expect(o.mode).toBe("patch");
   });
 
+  it("parses with source (file copy)", () => {
+    const o = BindingOutputSchema.parse({
+      target: "out.lua",
+      source: "scripts/enrich.lua",
+    });
+    expect(o.source).toBe("scripts/enrich.lua");
+    expect(o.template).toBeUndefined();
+    expect(o.inline_template).toBeUndefined();
+  });
+
   it("rejects both template AND inline_template (mutual exclusion refine)", () => {
     const r = BindingOutputSchema.safeParse({
       target: "t",
@@ -339,6 +349,79 @@ describe("BindingOutputSchema", () => {
       inline_template: "b",
     });
     expect(r.success).toBe(false);
+  });
+
+  it("rejects template AND source together", () => {
+    const r = BindingOutputSchema.safeParse({
+      target: "t",
+      template: "a",
+      source: "b",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects inline_template AND source together", () => {
+    const r = BindingOutputSchema.safeParse({
+      target: "t",
+      inline_template: "a",
+      source: "b",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects all three specified", () => {
+    const r = BindingOutputSchema.safeParse({
+      target: "t",
+      template: "a",
+      inline_template: "b",
+      source: "c",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("parses patch mode with format and patch_strategy", () => {
+    const o = BindingOutputSchema.parse({
+      target: "config.json",
+      template: "patch.json.hbs",
+      mode: "patch",
+      format: "json",
+      patch_strategy: "deep_merge",
+    });
+    expect(o.mode).toBe("patch");
+    expect(o.format).toBe("json");
+    expect(o.patch_strategy).toBe("deep_merge");
+  });
+
+  it("parses patch mode with array_merge_key", () => {
+    const o = BindingOutputSchema.parse({
+      target: "hooks.json",
+      inline_template: "[]",
+      mode: "patch",
+      format: "json",
+      patch_strategy: "deep_merge",
+      array_merge_key: "id",
+    });
+    expect(o.array_merge_key).toBe("id");
+  });
+
+  it("accepts format yaml", () => {
+    const o = BindingOutputSchema.parse({
+      target: "config.yaml",
+      inline_template: "x",
+      mode: "patch",
+      format: "yaml",
+    });
+    expect(o.format).toBe("yaml");
+  });
+
+  it("accepts format text", () => {
+    const o = BindingOutputSchema.parse({
+      target: "log.txt",
+      inline_template: "x",
+      mode: "patch",
+      format: "text",
+    });
+    expect(o.format).toBe("text");
   });
 
   it("parses with group_by and executable", () => {


### PR DESCRIPTION
## Summary

- **Issue #13**: Implement format-aware patch merge for binding outputs — `mode: "patch"` now deep-merges JSON/YAML or appends text, with `array_merge_key` for idempotent array deduplication
- **Issue #14**: Add `source` field for file-copy binding outputs — copies files as-is without Handlebars template processing, mutually exclusive with `template`/`inline_template`
- Version bump to 0.12.1

## Changes

### Schema (`src/schema/binding.ts`)
- New fields: `source`, `format`, `patch_strategy`, `array_merge_key`
- Refinement updated to enforce exactly-one-of-three (`template`, `inline_template`, `source`)

### Generator (`src/guardrail-generator/generator.ts`)
- Patch merge logic: `deep_merge` for objects, array append with optional dedup by merge key
- Source copy: raw file copy via `copyFile()` with `executable` chmod support
- Supports JSON, YAML, and text formats

### Tests
- 8 new schema tests, 11 new generator tests (source copy + patch merge scenarios)
- All 525 tests pass

### Sample
- Updated `cursor.yaml` and `observability.yaml` to demonstrate multi-binding patch merge on shared `policy.json`
- Added `scripts/enrich.lua` as source copy example

Closes #13, Closes #14

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [x] `npm test` — 525 tests pass (23 test files)
- [x] `npm pack --dry-run` — package contents verified

Made with [Cursor](https://cursor.com)