### PR TITLE
fix: pass renderOptions in check command to prevent false drift with bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -1,9 +1,9 @@
 import { Command } from "commander";
-import { loadConfig, ConfigLoadError } from "../../config/index.js";
+import { loadConfig, loadBindings, ConfigLoadError } from "../../config/index.js";
 import { resolve, substituteVars } from "../../resolver/index.js";
 import { validateSchema, checkReferences, validateHandoffSchemas } from "../../validator/index.js";
 import { lint, spectralLint } from "../../linter/index.js";
-import { checkDriftFromConfig } from "../../renderer/index.js";
+import { checkDriftFromConfig, type RenderOptions } from "../../renderer/index.js";
 import { formatDiagnostics, type OutputFormat } from "../format.js";
 
 export const checkCommand = new Command("check")
@@ -75,9 +75,19 @@ export const checkCommand = new Command("check")
           }
         }
 
+        let renderOptions: RenderOptions | undefined;
+        if (config.bindings.length > 0) {
+          const loadedBindings = await loadBindings(config.bindings);
+          renderOptions = {
+            loadedBindings,
+            activeGuardrailPolicy: config.activeGuardrailPolicy,
+          };
+        }
+
         const drift = await checkDriftFromConfig(
           schemaResult.data!,
           config.renders,
+          renderOptions,
         );
 
         if (drift.hasDrift) {

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -11,6 +11,8 @@ const outputDir = join(import.meta.dirname, "../__cli_output__");
 
 const minimalYaml = join(fixturesDir, "minimal/agent-contracts.yaml");
 const minimalConfig = join(fixturesDir, "minimal/agent-contracts.config.yaml");
+const bindingsConfig = join(fixturesDir, "with-bindings/agent-contracts.config.yaml");
+const bindingsOutputDir = join(import.meta.dirname, "../__cli_output_bindings__");
 
 async function run(
   args: string[],
@@ -32,6 +34,7 @@ async function run(
 
 afterAll(() => {
   if (existsSync(outputDir)) rmSync(outputDir, { recursive: true, force: true });
+  if (existsSync(bindingsOutputDir)) rmSync(bindingsOutputDir, { recursive: true, force: true });
 });
 
 describe("agent-contracts resolve", () => {
@@ -163,6 +166,13 @@ describe("agent-contracts check", () => {
   it("runs full pipeline and exits 0 on valid fixture", async () => {
     await run(["render", "--config", minimalConfig]);
     const { exitCode, stdout } = await run(["check", "--config", minimalConfig]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("passed");
+  });
+
+  it("passes with bindings (no false drift)", async () => {
+    await run(["render", "--config", bindingsConfig]);
+    const { exitCode, stdout } = await run(["check", "--config", bindingsConfig]);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("passed");
   });

--- a/test/fixtures/with-bindings/agent-contracts.config.yaml
+++ b/test/fixtures/with-bindings/agent-contracts.config.yaml
@@ -1,0 +1,9 @@
+dsl: ./agent-contracts.yaml
+
+bindings:
+  - ./binding.yaml
+
+renders:
+  - template: ./overview-with-bindings.md.hbs
+    context: system
+    output: ../../__cli_output_bindings__/overview.md

--- a/test/fixtures/with-bindings/agent-contracts.yaml
+++ b/test/fixtures/with-bindings/agent-contracts.yaml
@@ -1,0 +1,53 @@
+version: 1
+system:
+  id: bindings-test-system
+  name: Bindings Test System
+  default_workflow_order:
+    - implement
+
+agents:
+  implementer:
+    role_name: Implementer
+    purpose: Implements features
+    can_read_artifacts:
+      - codebase
+    can_write_artifacts:
+      - codebase
+    can_invoke_agents:
+      - implementer
+    can_return_handoffs:
+      - task-delegation
+
+tasks:
+  implement-feature:
+    description: Implement a feature
+    target_agent: implementer
+    allowed_from_agents:
+      - implementer
+    workflow: implement
+    input_artifacts:
+      - codebase
+    invocation_handoff: task-delegation
+    result_handoff: task-delegation
+
+artifacts:
+  codebase:
+    type: code
+    owner: implementer
+    producers:
+      - implementer
+    editors:
+      - implementer
+    consumers:
+      - implementer
+    states:
+      - draft
+
+tools: {}
+validations: {}
+handoff_types:
+  task-delegation:
+    version: 1
+    schema: {}
+workflow: {}
+policies: {}

--- a/test/fixtures/with-bindings/binding.yaml
+++ b/test/fixtures/with-bindings/binding.yaml
@@ -1,0 +1,2 @@
+software: cursor
+version: 1

--- a/test/fixtures/with-bindings/overview-with-bindings.md.hbs
+++ b/test/fixtures/with-bindings/overview-with-bindings.md.hbs
@@ -1,0 +1,15 @@
+# {{system.name}}
+
+{{#if bindings}}
+## Bindings
+
+{{#each bindings}}
+- {{this.software}}
+{{/each}}
+{{/if}}
+
+## Agents
+
+{{#each dsl.agents}}
+- {{@key}}: {{this.purpose}}
+{{/each}}


### PR DESCRIPTION
## Summary

- Fix false drift detection in `check` command when `bindings` are configured (#16)
- The `check` command was missing `renderOptions` (containing `loadedBindings` and `activeGuardrailPolicy`) when calling `checkDriftFromConfig`, causing templates that reference binding values to render differently and report false drift
- Bump version to v0.12.2

## Changes

- `src/cli/commands/check.ts`: Load bindings and pass `renderOptions` to `checkDriftFromConfig`, matching the existing pattern in `render.ts`
- `test/fixtures/with-bindings/`: New test fixture with a binding-aware template
- `test/cli/cli.test.ts`: Add regression test for `check` with bindings

Closes #16


Made with [Cursor](https://cursor.com)