### PR TITLE
fix: entity-side guardrail binding — prompt enforcement path (#18)

### DIFF
--- a/docs/spec/guardrail-di.md
+++ b/docs/spec/guardrail-di.md
@@ -49,12 +49,26 @@ cursor outputs  git outputs   observability outputs
 
 ### 1.3 Relationship to Existing Entities
 
-The current DSL has related but distinct concepts:
+Guardrails use a **bidirectional binding model** to associate with entities:
+
+1. **Scope-side binding** (`guardrails[].scope`): The guardrail declares which entities it applies to. This is the cross-cutting direction — one guardrail targets many entities.
+2. **Entity-side binding** (`entity.guardrails[]`): Each entity (agent, task, tool, artifact) declares which guardrails apply to it. This is the entity-specific direction — one entity opts into guardrails relevant to its context.
+
+The effective guardrails for an entity are the **union** of both directions, deduplicated. Each resolved entry tracks its `source`: `"entity"` (declared on the entity), `"scope"` (declared on the guardrail), or `"both"`.
+
+```
+effectiveGuardrails(entityType, entityId) =
+  Set(entity.guardrails ?? [])
+  ∪ Set(guardrailId for each guardrail where scope.{entityType} includes entityId)
+```
+
+Resolved guardrails are injected into each entity's `PerEntityContext.relatedGuardrails` so templates can render them into prompts.
 
 | Existing | Purpose | Guardrail Relation |
 |----------|---------|-------------------|
-| `agents[].rules` | Per-agent behavioral rules (mandatory/recommended/optional) | Guardrails are cross-cutting constraints, not agent-scoped |
+| `agents[].rules` | Per-agent behavioral rules (mandatory/recommended/optional) | Guardrails are cross-cutting constraints that also support entity-side binding |
 | `agents[].constraints` | Free-text agent constraints | Guardrails are machine-evaluable |
+| `agents[].guardrails` | Entity-side guardrail binding | References guardrail IDs; merged with scope-side bindings |
 | `policies` | Validation requirement policies (`when` → `requires_validations`) | `guardrail_policies` is a separate section for enforcement strategies |
 | `validations` | Artifact validation definitions | Validations check artifact quality; guardrails enforce process constraints |
 
@@ -140,6 +154,37 @@ guardrails:
     rationale: "Constitution X requires local verification before CI push"
     tags: [quality, testing]
 ```
+
+### 2.1.1 Entity-side `guardrails` field
+
+All entity schemas (`AgentSchema`, `TaskSchema`, `ToolSchema`, `ArtifactSchema`) accept an optional `guardrails: string[]` field referencing guardrail IDs. This is the entity-side of the bidirectional binding model described in §1.3.
+
+```typescript
+// Added to AgentSchema, TaskSchema, ToolSchema, ArtifactSchema:
+guardrails: z.array(z.string()).optional()
+```
+
+Enforcement parameters (severity, action) remain in `guardrail_policies` — the entity only declares **what** applies. `WorkflowSchema` is excluded — workflows orchestrate steps rather than being direct guardrail targets.
+
+```yaml
+agents:
+  implementer:
+    guardrails: [english-only-code, test-before-commit]
+
+tasks:
+  implement-feature:
+    guardrails: [ddl-workflow]
+
+tools:
+  code-editor:
+    guardrails: [no-force-push, no-rebase]
+
+artifacts:
+  codebase:
+    guardrails: [english-only-code, protect-generated-files]
+```
+
+For each entity, the effective guardrails are the union of `entity.guardrails[]` (entity-side) and `guardrails[].scope.{entity_type}` (scope-side), deduplicated. Each resolved entry tracks its `source`: `"entity"`, `"scope"`, or `"both"`. Results are injected into `PerEntityContext.relatedGuardrails` as `EntityGuardrailEntry[]`.
 
 ### 2.2 `guardrail_policies:` Section
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/sample/templates/agent-prompt.md.hbs
+++ b/sample/templates/agent-prompt.md.hbs
@@ -16,6 +16,8 @@
     relatedArtifacts     - Record<id, Artifact> this agent can read/write
     relatedTools         - Record<id, Tool> this agent can execute
     relatedHandoffTypes  - Record<kind, HandoffType> related to this agent's tasks/handoffs
+    relatedGuardrails    - Array of EntityGuardrailEntry (guardrail_id, description,
+                           rationale, tags, source, severity, action)
     mergedBehavior       - Agent + all receivable tasks merged:
                            responsibilities, constraints, rules, anti_patterns,
                            escalation_criteria, execution_steps, completion_criteria
@@ -124,6 +126,16 @@
 
 {{#each relatedTools}}
 - **{{@key}}** ({{this.kind}}): {{this.description}}
+{{/each}}
+{{/if}}
+
+{{#if relatedGuardrails.length}}
+## Guardrails
+
+| ID | Description | Severity | Action |
+|----|-------------|----------|--------|
+{{#each relatedGuardrails}}
+| {{this.guardrail_id}} | {{this.description}} | {{this.severity}} | {{this.action}} |
 {{/each}}
 {{/if}}
 

--- a/schemas/dsl.schema.json
+++ b/schemas/dsl.schema.json
@@ -207,6 +207,12 @@
               ],
               "additionalProperties": {}
             }
+          },
+          "guardrails": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
@@ -404,6 +410,12 @@
             "items": {
               "type": "string"
             }
+          },
+          "guardrails": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
@@ -470,6 +482,12 @@
           },
           "visibility": {
             "type": "string"
+          },
+          "guardrails": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
@@ -563,6 +581,12 @@
                 "writes"
               ],
               "additionalProperties": false
+            }
+          },
+          "guardrails": {
+            "type": "array",
+            "items": {
+              "type": "string"
             }
           }
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,8 @@ export {
   type PerGuardrailPolicyContext,
   type MergedBehavioralSpec,
   type DelegatableTaskView,
+  type EntityGuardrailEntry,
+  resolveEffectiveGuardrails,
 } from "./renderer/index.js";
 export {
   loadBindings,

--- a/src/linter/index.ts
+++ b/src/linter/index.ts
@@ -11,3 +11,4 @@ export { guardrailPolicyCoverageRule } from "./rules/guardrail-policy-coverage.j
 export { yamlReservedKeySafetyRule } from "./rules/yaml-reserved-key-safety.js";
 export { artifactRequiredValidationWiringRule } from "./rules/artifact-required-validation-wiring.js";
 export { taskOutputValidationCompletenessRule } from "./rules/task-output-validation-completeness.js";
+export { entityGuardrailUndefinedRule, entityNoGuardrailsRule, guardrailOrphanedRule } from "./rules/entity-guardrail-binding.js";

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -11,6 +11,11 @@ import { yamlReservedKeySafetyRule } from "./rules/yaml-reserved-key-safety.js";
 import { artifactRequiredValidationWiringRule } from "./rules/artifact-required-validation-wiring.js";
 import { taskOutputValidationCompletenessRule } from "./rules/task-output-validation-completeness.js";
 import { semanticValidationPhaseCoverageRule } from "./rules/semantic-validation-phase-coverage.js";
+import {
+  entityGuardrailUndefinedRule,
+  entityNoGuardrailsRule,
+  guardrailOrphanedRule,
+} from "./rules/entity-guardrail-binding.js";
 
 const builtinRules: LintRule[] = [
   validationCoverageRule,
@@ -24,6 +29,9 @@ const builtinRules: LintRule[] = [
   artifactRequiredValidationWiringRule,
   taskOutputValidationCompletenessRule,
   semanticValidationPhaseCoverageRule,
+  entityGuardrailUndefinedRule,
+  entityNoGuardrailsRule,
+  guardrailOrphanedRule,
 ];
 
 export function lint(

--- a/src/linter/rules/entity-guardrail-binding.ts
+++ b/src/linter/rules/entity-guardrail-binding.ts
@@ -1,0 +1,134 @@
+import type { Dsl } from "../../schema/index.js";
+import type { LintRule, LintDiagnostic } from "../types.js";
+
+export const entityGuardrailUndefinedRule: LintRule = {
+  id: "entity-guardrail-undefined",
+  description:
+    "Entity references a guardrail ID not defined in guardrails",
+
+  run(dsl: Dsl): LintDiagnostic[] {
+    const diagnostics: LintDiagnostic[] = [];
+    const guardrailIds = new Set(Object.keys(dsl.guardrails));
+
+    const sections: Array<{ name: string; entities: Record<string, { guardrails?: string[] }> }> = [
+      { name: "agents", entities: dsl.agents },
+      { name: "tasks", entities: dsl.tasks },
+      { name: "tools", entities: dsl.tools },
+      { name: "artifacts", entities: dsl.artifacts },
+    ];
+
+    for (const { name, entities } of sections) {
+      for (const [entityId, entity] of Object.entries(entities)) {
+        for (const ref of entity.guardrails ?? []) {
+          if (!guardrailIds.has(ref)) {
+            diagnostics.push({
+              ruleId: "entity-guardrail-undefined",
+              severity: "error",
+              path: `${name}.${entityId}.guardrails`,
+              message: `${name.slice(0, -1)} "${entityId}" references guardrail "${ref}" which is not defined in guardrails`,
+            });
+          }
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};
+
+export const entityNoGuardrailsRule: LintRule = {
+  id: "entity-no-guardrails",
+  description:
+    "Entity has no effective guardrails (neither entity-side nor scope-side)",
+
+  run(dsl: Dsl): LintDiagnostic[] {
+    const diagnostics: LintDiagnostic[] = [];
+
+    const scopeBindings: Record<string, Set<string>> = {
+      agents: new Set<string>(),
+      tasks: new Set<string>(),
+      tools: new Set<string>(),
+      artifacts: new Set<string>(),
+    };
+    for (const guardrail of Object.values(dsl.guardrails)) {
+      for (const key of Object.keys(scopeBindings)) {
+        const ids = guardrail.scope[key as keyof typeof guardrail.scope] as string[] | undefined;
+        if (ids) {
+          for (const id of ids) scopeBindings[key].add(id);
+        }
+      }
+    }
+
+    const sections: Array<{ name: string; entities: Record<string, { guardrails?: string[] }> }> = [
+      { name: "agents", entities: dsl.agents },
+      { name: "tasks", entities: dsl.tasks },
+      { name: "tools", entities: dsl.tools },
+      { name: "artifacts", entities: dsl.artifacts },
+    ];
+
+    for (const { name, entities } of sections) {
+      for (const [entityId, entity] of Object.entries(entities)) {
+        const hasEntitySide = (entity.guardrails ?? []).length > 0;
+        const hasScopeSide = scopeBindings[name].has(entityId);
+        if (!hasEntitySide && !hasScopeSide) {
+          diagnostics.push({
+            ruleId: "entity-no-guardrails",
+            severity: "info",
+            path: `${name}.${entityId}`,
+            message: `${name.slice(0, -1)} "${entityId}" has no effective guardrails`,
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};
+
+export const guardrailOrphanedRule: LintRule = {
+  id: "guardrail-orphaned",
+  description:
+    "Guardrail is not referenced by any entity and not bound to any entity via scope",
+
+  run(dsl: Dsl): LintDiagnostic[] {
+    const diagnostics: LintDiagnostic[] = [];
+
+    const referencedByEntities = new Set<string>();
+    const sections: Array<Record<string, { guardrails?: string[] }>> = [
+      dsl.agents,
+      dsl.tasks,
+      dsl.tools,
+      dsl.artifacts,
+    ];
+    for (const entities of sections) {
+      for (const entity of Object.values(entities)) {
+        for (const ref of entity.guardrails ?? []) {
+          referencedByEntities.add(ref);
+        }
+      }
+    }
+
+    for (const [guardrailId, guardrail] of Object.entries(dsl.guardrails)) {
+      const hasEntityRef = referencedByEntities.has(guardrailId);
+
+      const scope = guardrail.scope;
+      const hasScopeBinding =
+        (scope.agents?.length ?? 0) > 0 ||
+        (scope.tasks?.length ?? 0) > 0 ||
+        (scope.tools?.length ?? 0) > 0 ||
+        (scope.artifacts?.length ?? 0) > 0 ||
+        (scope.workflows?.length ?? 0) > 0;
+
+      if (!hasEntityRef && !hasScopeBinding) {
+        diagnostics.push({
+          ruleId: "guardrail-orphaned",
+          severity: "warning",
+          path: `guardrails.${guardrailId}`,
+          message: `Guardrail "${guardrailId}" is not referenced by any entity and has no scope bindings`,
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/src/renderer/context.ts
+++ b/src/renderer/context.ts
@@ -56,9 +56,20 @@ export interface SystemContext {
   [key: string]: unknown;
 }
 
+export interface EntityGuardrailEntry {
+  guardrail_id: string;
+  description: string;
+  rationale?: string;
+  tags: string[];
+  source: "entity" | "scope" | "both";
+  severity?: string;
+  action?: string;
+}
+
 export interface PerTaskContext {
   task: Task & { id: string };
   targetAgent: (Agent & { id: string }) | null;
+  relatedGuardrails: EntityGuardrailEntry[];
   dsl: Dsl;
   [key: string]: unknown;
 }
@@ -71,6 +82,7 @@ export interface PerArtifactContext {
   consumerAgents: Dsl["agents"];
   editorAgents: Dsl["agents"];
   createdInWorkflows: string[];
+  relatedGuardrails: EntityGuardrailEntry[];
   dsl: Dsl;
   [key: string]: unknown;
 }
@@ -80,6 +92,7 @@ export interface PerToolContext {
   invokableAgents: Dsl["agents"];
   inputArtifactDetails: Dsl["artifacts"];
   outputArtifactDetails: Dsl["artifacts"];
+  relatedGuardrails: EntityGuardrailEntry[];
   dsl: Dsl;
   [key: string]: unknown;
 }
@@ -157,6 +170,7 @@ export interface PerAgentContext {
   relatedTools: Dsl["tools"];
   relatedHandoffTypes: Dsl["handoff_types"];
   mergedBehavior: MergedBehavioralSpec;
+  relatedGuardrails: EntityGuardrailEntry[];
   dsl: Dsl;
   [key: string]: unknown;
 }
@@ -243,6 +257,63 @@ function buildGuardrailEnforcement(
   return entries;
 }
 
+type EntityType = "agents" | "tasks" | "tools" | "artifacts";
+
+export function resolveEffectiveGuardrails(
+  dsl: Dsl,
+  entityType: EntityType,
+  entityId: string,
+): EntityGuardrailEntry[] {
+  const entityDef = (dsl[entityType] as Record<string, { guardrails?: string[] }>)[entityId];
+  const entitySide = new Set<string>(entityDef?.guardrails ?? []);
+
+  const scopeSide = new Set<string>();
+  for (const [guardrailId, guardrail] of Object.entries(dsl.guardrails)) {
+    const scopeIds = guardrail.scope[entityType] as string[] | undefined;
+    if (scopeIds?.includes(entityId)) {
+      scopeSide.add(guardrailId);
+    }
+  }
+
+  const allIds = new Set([...entitySide, ...scopeSide]);
+
+  const activePolicyRules = new Map<string, { severity: string; action: string }>();
+  for (const policy of Object.values(dsl.guardrail_policies)) {
+    for (const rule of policy.rules) {
+      if (!activePolicyRules.has(rule.guardrail)) {
+        activePolicyRules.set(rule.guardrail, {
+          severity: rule.severity,
+          action: rule.action,
+        });
+      }
+    }
+  }
+
+  const entries: EntityGuardrailEntry[] = [];
+  for (const id of allIds) {
+    const guardrail = dsl.guardrails[id];
+    if (!guardrail) continue;
+
+    const fromEntity = entitySide.has(id);
+    const fromScope = scopeSide.has(id);
+    const source: "entity" | "scope" | "both" =
+      fromEntity && fromScope ? "both" : fromEntity ? "entity" : "scope";
+
+    const policyInfo = activePolicyRules.get(id);
+    entries.push({
+      guardrail_id: id,
+      description: guardrail.description,
+      rationale: guardrail.rationale,
+      tags: guardrail.tags,
+      source,
+      severity: policyInfo?.severity,
+      action: policyInfo?.action,
+    });
+  }
+
+  return entries;
+}
+
 export function buildTaskContext(
   dsl: Dsl,
   taskId: string,
@@ -253,7 +324,8 @@ export function buildTaskContext(
   const targetAgent = agentDef
     ? ({ ...agentDef, id: taskDef.target_agent } as Agent & { id: string })
     : null;
-  return { task, targetAgent, dsl };
+  const relatedGuardrails = resolveEffectiveGuardrails(dsl, "tasks", taskId);
+  return { task, targetAgent, relatedGuardrails, dsl };
 }
 
 export function buildArtifactContext(
@@ -311,6 +383,8 @@ export function buildArtifactContext(
     }
   }
 
+  const relatedGuardrails = resolveEffectiveGuardrails(dsl, "artifacts", artifactId);
+
   return {
     artifact,
     relatedTools,
@@ -319,6 +393,7 @@ export function buildArtifactContext(
     consumerAgents,
     editorAgents,
     createdInWorkflows,
+    relatedGuardrails,
     dsl,
   };
 }
@@ -343,11 +418,14 @@ export function buildToolContext(
     return result;
   };
 
+  const relatedGuardrails = resolveEffectiveGuardrails(dsl, "tools", toolId);
+
   return {
     tool,
     invokableAgents,
     inputArtifactDetails: pickArtifacts(toolDef.input_artifacts),
     outputArtifactDetails: pickArtifacts(toolDef.output_artifacts),
+    relatedGuardrails,
     dsl,
   };
 }
@@ -660,6 +738,7 @@ export function buildPerAgentContext(
 
   const rawReceivableTasks = receivableTasks.map(({ id: _id, ...rest }) => rest as Task);
   const mergedBehavior = mergeBehavioralSpec(agent, rawReceivableTasks);
+  const relatedGuardrails = resolveEffectiveGuardrails(dsl, "agents", agentId);
 
   return {
     agent,
@@ -670,6 +749,7 @@ export function buildPerAgentContext(
     relatedTools,
     relatedHandoffTypes,
     mergedBehavior,
+    relatedGuardrails,
     dsl,
   };
 }

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -31,4 +31,6 @@ export {
   type MergedBehavioralSpec,
   type DelegatableTaskView,
   type GuardrailEnforcementEntry,
+  type EntityGuardrailEntry,
+  resolveEffectiveGuardrails,
 } from "./context.js";

--- a/src/schema/agent.ts
+++ b/src/schema/agent.ts
@@ -52,6 +52,7 @@ export const AgentSchema = z
     anti_patterns: z.array(z.string()).optional(),
     escalation_criteria: z.array(EscalationCriterionSchema).optional(),
     prerequisites: z.array(PrerequisiteSchema).optional(),
+    guardrails: z.array(z.string()).optional(),
   })
   .passthrough();
 export type Agent = z.infer<typeof AgentSchema>;

--- a/src/schema/artifact.ts
+++ b/src/schema/artifact.ts
@@ -11,6 +11,7 @@ export const ArtifactSchema = z
     states: z.array(z.string()),
     required_validations: z.array(z.string()).default([]),
     visibility: z.string().optional(),
+    guardrails: z.array(z.string()).optional(),
   })
   .passthrough();
 export type Artifact = z.infer<typeof ArtifactSchema>;

--- a/src/schema/task.ts
+++ b/src/schema/task.ts
@@ -36,6 +36,7 @@ export const TaskSchema = z
     anti_patterns: z.array(z.string()).optional(),
     escalation_criteria: z.array(EscalationCriterionSchema).optional(),
     validations: z.array(z.string()).default([]),
+    guardrails: z.array(z.string()).optional(),
   })
   .passthrough();
 export type Task = z.infer<typeof TaskSchema>;

--- a/src/schema/tool.ts
+++ b/src/schema/tool.ts
@@ -18,6 +18,7 @@ export const ToolSchema = z
     invokable_by: z.array(z.string()),
     side_effects: z.array(z.string()).default([]),
     commands: z.array(CommandSchema).default([]),
+    guardrails: z.array(z.string()).optional(),
   })
   .passthrough();
 export type Tool = z.infer<typeof ToolSchema>;

--- a/src/scorer/scorer.ts
+++ b/src/scorer/scorer.ts
@@ -270,6 +270,60 @@ function crossReferenceBidirectionality(dsl: Dsl): DimensionResult {
   };
 }
 
+function entityGuardrailCoverage(dsl: Dsl): DimensionResult {
+  const entitySections: Array<{ name: string; entities: Record<string, { guardrails?: string[] }> }> = [
+    { name: "agents", entities: dsl.agents },
+    { name: "tasks", entities: dsl.tasks },
+    { name: "tools", entities: dsl.tools },
+    { name: "artifacts", entities: dsl.artifacts },
+  ];
+
+  const scopeBindings: Record<string, Set<string>> = {
+    agents: new Set<string>(),
+    tasks: new Set<string>(),
+    tools: new Set<string>(),
+    artifacts: new Set<string>(),
+  };
+  for (const guardrail of Object.values(dsl.guardrails)) {
+    for (const key of Object.keys(scopeBindings)) {
+      const ids = guardrail.scope[key as keyof typeof guardrail.scope] as string[] | undefined;
+      if (ids) {
+        for (const id of ids) scopeBindings[key].add(id);
+      }
+    }
+  }
+
+  let total = 0;
+  let covered = 0;
+  const missing: string[] = [];
+
+  for (const { name, entities } of entitySections) {
+    for (const [entityId, entity] of Object.entries(entities)) {
+      total++;
+      const hasEntitySide = (entity.guardrails ?? []).length > 0;
+      const hasScopeSide = scopeBindings[name].has(entityId);
+      if (hasEntitySide || hasScopeSide) {
+        covered++;
+      } else {
+        missing.push(`${name}.${entityId}`);
+      }
+    }
+  }
+
+  return {
+    id: "entity-guardrail-coverage",
+    label: "Entity guardrail coverage",
+    score: covered,
+    total,
+    percent: pct(covered, total),
+    weight: 1,
+    recommendations:
+      missing.length > 0
+        ? [`${missing.length} entities without guardrails: ${missing.slice(0, 5).join(", ")}${missing.length > 5 ? `, ... (${missing.length - 5} more)` : ""}`]
+        : [],
+  };
+}
+
 function guardrailScopeResolution(dsl: Dsl): DimensionResult {
   let totalRefs = 0;
   let resolvedRefs = 0;
@@ -324,6 +378,7 @@ export function score(dsl: Dsl): ScoreResult {
     schemaCompleteness(dsl),
     crossReferenceBidirectionality(dsl),
     guardrailScopeResolution(dsl),
+    entityGuardrailCoverage(dsl),
   ];
 
   const totalWeight = dimensions.reduce((s, d) => s + d.weight, 0);

--- a/src/validator/reference-resolver.ts
+++ b/src/validator/reference-resolver.ts
@@ -244,6 +244,38 @@ export function checkReferences(dsl: Dsl): ReferenceDiagnostic[] {
     }
   }
 
+  for (const [id, agent] of Object.entries(dsl.agents)) {
+    if (agent.guardrails) {
+      for (const ref of agent.guardrails) {
+        checkExists(ref, guardrailIds, "guardrails", `agents.${id}.guardrails`, "entity-guardrail-ref-not-found");
+      }
+    }
+  }
+
+  for (const [id, task] of Object.entries(dsl.tasks)) {
+    if (task.guardrails) {
+      for (const ref of task.guardrails) {
+        checkExists(ref, guardrailIds, "guardrails", `tasks.${id}.guardrails`, "entity-guardrail-ref-not-found");
+      }
+    }
+  }
+
+  for (const [id, tool] of Object.entries(dsl.tools)) {
+    if (tool.guardrails) {
+      for (const ref of tool.guardrails) {
+        checkExists(ref, guardrailIds, "guardrails", `tools.${id}.guardrails`, "entity-guardrail-ref-not-found");
+      }
+    }
+  }
+
+  for (const [id, art] of Object.entries(dsl.artifacts)) {
+    if (art.guardrails) {
+      for (const ref of art.guardrails) {
+        checkExists(ref, guardrailIds, "guardrails", `artifacts.${id}.guardrails`, "entity-guardrail-ref-not-found");
+      }
+    }
+  }
+
   for (const [id, guardrail] of Object.entries(dsl.guardrails)) {
     if (guardrail.scope.agents) {
       for (const ref of guardrail.scope.agents) {

--- a/test/entity-guardrail-binding.test.ts
+++ b/test/entity-guardrail-binding.test.ts
@@ -1,0 +1,553 @@
+import { describe, it, expect } from "vitest";
+import { DslSchema, type Dsl } from "../src/schema/index.js";
+import { checkReferences } from "../src/validator/reference-resolver.js";
+import { lint } from "../src/linter/linter.js";
+import {
+  entityGuardrailUndefinedRule,
+  entityNoGuardrailsRule,
+  guardrailOrphanedRule,
+} from "../src/linter/rules/entity-guardrail-binding.js";
+import { score } from "../src/scorer/scorer.js";
+import {
+  resolveEffectiveGuardrails,
+  buildPerAgentContext,
+  buildTaskContext,
+  buildToolContext,
+  buildArtifactContext,
+} from "../src/renderer/context.js";
+
+function makeDsl(partial: Partial<Record<string, unknown>>): Dsl {
+  return DslSchema.parse({
+    version: 1,
+    system: { id: "s", name: "S", default_workflow_order: ["implement"] },
+    ...partial,
+  });
+}
+
+// -- Schema acceptance --
+
+describe("entity guardrails schema field", () => {
+  it("accepts optional guardrails on agents", () => {
+    const dsl = makeDsl({
+      agents: {
+        a1: { role_name: "R", purpose: "P", guardrails: ["g1"] },
+      },
+      guardrails: { g1: { description: "d", scope: {} } },
+    });
+    expect(dsl.agents.a1.guardrails).toEqual(["g1"]);
+  });
+
+  it("accepts optional guardrails on tasks", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_return_handoffs: ["h", "r"] } },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1", allowed_from_agents: ["a1"],
+          workflow: "implement", input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          guardrails: ["g1"],
+        },
+      },
+      handoff_types: { h: { version: 1, schema: {} }, r: { version: 1, schema: {} } },
+      guardrails: { g1: { description: "d", scope: {} } },
+    });
+    expect(dsl.tasks.t1.guardrails).toEqual(["g1"]);
+  });
+
+  it("accepts optional guardrails on tools", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      tools: { t1: { kind: "cli", invokable_by: ["a1"], guardrails: ["g1"] } },
+      guardrails: { g1: { description: "d", scope: {} } },
+    });
+    expect(dsl.tools.t1.guardrails).toEqual(["g1"]);
+  });
+
+  it("accepts optional guardrails on artifacts", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: {
+          type: "code", owner: "a1", producers: ["a1"], editors: ["a1"],
+          consumers: ["a1"], states: ["draft"], guardrails: ["g1"],
+        },
+      },
+      guardrails: { g1: { description: "d", scope: {} } },
+    });
+    expect(dsl.artifacts.art1.guardrails).toEqual(["g1"]);
+  });
+
+  it("defaults to undefined when guardrails not provided", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+    });
+    expect(dsl.agents.a1.guardrails).toBeUndefined();
+  });
+});
+
+// -- Bidirectional resolution --
+
+describe("resolveEffectiveGuardrails", () => {
+  it("returns entity-side guardrails", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", guardrails: ["g1"] } },
+      guardrails: { g1: { description: "d", scope: {} } },
+    });
+    const result = resolveEffectiveGuardrails(dsl, "agents", "a1");
+    expect(result).toHaveLength(1);
+    expect(result[0].guardrail_id).toBe("g1");
+    expect(result[0].source).toBe("entity");
+  });
+
+  it("returns scope-side guardrails", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      guardrails: { g1: { description: "d", scope: { agents: ["a1"] } } },
+    });
+    const result = resolveEffectiveGuardrails(dsl, "agents", "a1");
+    expect(result).toHaveLength(1);
+    expect(result[0].guardrail_id).toBe("g1");
+    expect(result[0].source).toBe("scope");
+  });
+
+  it("returns both-side guardrails with source=both", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", guardrails: ["g1"] } },
+      guardrails: { g1: { description: "d", scope: { agents: ["a1"] } } },
+    });
+    const result = resolveEffectiveGuardrails(dsl, "agents", "a1");
+    expect(result).toHaveLength(1);
+    expect(result[0].guardrail_id).toBe("g1");
+    expect(result[0].source).toBe("both");
+  });
+
+  it("deduplicates union of entity-side and scope-side", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", guardrails: ["g1", "g2"] } },
+      guardrails: {
+        g1: { description: "d1", scope: { agents: ["a1"] } },
+        g2: { description: "d2", scope: {} },
+        g3: { description: "d3", scope: { agents: ["a1"] } },
+      },
+    });
+    const result = resolveEffectiveGuardrails(dsl, "agents", "a1");
+    expect(result).toHaveLength(3);
+    const ids = result.map((e) => e.guardrail_id).sort();
+    expect(ids).toEqual(["g1", "g2", "g3"]);
+    expect(result.find((e) => e.guardrail_id === "g1")!.source).toBe("both");
+    expect(result.find((e) => e.guardrail_id === "g2")!.source).toBe("entity");
+    expect(result.find((e) => e.guardrail_id === "g3")!.source).toBe("scope");
+  });
+
+  it("returns empty array when no guardrails", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+    });
+    const result = resolveEffectiveGuardrails(dsl, "agents", "a1");
+    expect(result).toHaveLength(0);
+  });
+
+  it("includes policy severity and action when available", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", guardrails: ["g1"] } },
+      guardrails: { g1: { description: "d", scope: {}, rationale: "reason", tags: ["safety"] } },
+      guardrail_policies: {
+        default: { rules: [{ guardrail: "g1", severity: "critical", action: "block" }] },
+      },
+    });
+    const result = resolveEffectiveGuardrails(dsl, "agents", "a1");
+    expect(result[0].severity).toBe("critical");
+    expect(result[0].action).toBe("block");
+    expect(result[0].rationale).toBe("reason");
+    expect(result[0].tags).toEqual(["safety"]);
+  });
+
+  it("skips entity references to non-existent guardrails", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", guardrails: ["nonexistent"] } },
+    });
+    const result = resolveEffectiveGuardrails(dsl, "agents", "a1");
+    expect(result).toHaveLength(0);
+  });
+
+  it("works for tasks", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_return_handoffs: ["h", "r"] } },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1", allowed_from_agents: ["a1"],
+          workflow: "implement", input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          guardrails: ["g1"],
+        },
+      },
+      handoff_types: { h: { version: 1, schema: {} }, r: { version: 1, schema: {} } },
+      guardrails: { g1: { description: "d", scope: { tasks: ["t1"] } } },
+    });
+    const result = resolveEffectiveGuardrails(dsl, "tasks", "t1");
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe("both");
+  });
+
+  it("works for tools", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      tools: { t1: { kind: "cli", invokable_by: ["a1"], guardrails: ["g1"] } },
+      guardrails: { g1: { description: "d", scope: {} } },
+    });
+    const result = resolveEffectiveGuardrails(dsl, "tools", "t1");
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe("entity");
+  });
+
+  it("works for artifacts", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: {
+          type: "code", owner: "a1", producers: ["a1"], editors: ["a1"],
+          consumers: ["a1"], states: ["draft"],
+        },
+      },
+      guardrails: { g1: { description: "d", scope: { artifacts: ["art1"] } } },
+    });
+    const result = resolveEffectiveGuardrails(dsl, "artifacts", "art1");
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe("scope");
+  });
+});
+
+// -- Context builders with relatedGuardrails --
+
+describe("context builders include relatedGuardrails", () => {
+  it("buildPerAgentContext includes relatedGuardrails", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", guardrails: ["g1"] } },
+      guardrails: { g1: { description: "d", scope: { agents: ["a1"] } } },
+    });
+    const ctx = buildPerAgentContext(dsl, { ...dsl.agents.a1, id: "a1" });
+    expect(ctx.relatedGuardrails).toHaveLength(1);
+    expect(ctx.relatedGuardrails[0].guardrail_id).toBe("g1");
+    expect(ctx.relatedGuardrails[0].source).toBe("both");
+  });
+
+  it("buildTaskContext includes relatedGuardrails", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_return_handoffs: ["h", "r"] } },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1", allowed_from_agents: ["a1"],
+          workflow: "implement", input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          guardrails: ["g1"],
+        },
+      },
+      handoff_types: { h: { version: 1, schema: {} }, r: { version: 1, schema: {} } },
+      guardrails: { g1: { description: "d", scope: {} } },
+    });
+    const ctx = buildTaskContext(dsl, "t1");
+    expect(ctx.relatedGuardrails).toHaveLength(1);
+    expect(ctx.relatedGuardrails[0].source).toBe("entity");
+  });
+
+  it("buildToolContext includes relatedGuardrails", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      tools: { t1: { kind: "cli", invokable_by: ["a1"] } },
+      guardrails: { g1: { description: "d", scope: { tools: ["t1"] } } },
+    });
+    const ctx = buildToolContext(dsl, "t1");
+    expect(ctx.relatedGuardrails).toHaveLength(1);
+    expect(ctx.relatedGuardrails[0].source).toBe("scope");
+  });
+
+  it("buildArtifactContext includes relatedGuardrails", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: {
+          type: "code", owner: "a1", producers: ["a1"], editors: ["a1"],
+          consumers: ["a1"], states: ["draft"], guardrails: ["g1"],
+        },
+      },
+      guardrails: { g1: { description: "d", scope: {} } },
+    });
+    const ctx = buildArtifactContext(dsl, "art1");
+    expect(ctx.relatedGuardrails).toHaveLength(1);
+    expect(ctx.relatedGuardrails[0].source).toBe("entity");
+  });
+
+  it("context relatedGuardrails is empty when no guardrails", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+    });
+    const ctx = buildPerAgentContext(dsl, { ...dsl.agents.a1, id: "a1" });
+    expect(ctx.relatedGuardrails).toHaveLength(0);
+  });
+});
+
+// -- checkReferences --
+
+describe("checkReferences entity guardrail refs", () => {
+  it("reports invalid guardrail reference on agent", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", guardrails: ["nonexistent"] } },
+    });
+    const diags = checkReferences(dsl);
+    const found = diags.filter((d) => d.code === "entity-guardrail-ref-not-found");
+    expect(found).toHaveLength(1);
+    expect(found[0].path).toBe("agents.a1.guardrails");
+    expect(found[0].message).toContain("nonexistent");
+  });
+
+  it("reports invalid guardrail reference on task", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_return_handoffs: ["h", "r"] } },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1", allowed_from_agents: ["a1"],
+          workflow: "implement", input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          guardrails: ["bad"],
+        },
+      },
+      handoff_types: { h: { version: 1, schema: {} }, r: { version: 1, schema: {} } },
+    });
+    const diags = checkReferences(dsl);
+    const found = diags.filter((d) => d.code === "entity-guardrail-ref-not-found");
+    expect(found).toHaveLength(1);
+    expect(found[0].path).toBe("tasks.t1.guardrails");
+  });
+
+  it("reports invalid guardrail reference on tool", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      tools: { t1: { kind: "cli", invokable_by: ["a1"], guardrails: ["bad"] } },
+    });
+    const diags = checkReferences(dsl);
+    const found = diags.filter((d) => d.code === "entity-guardrail-ref-not-found");
+    expect(found).toHaveLength(1);
+    expect(found[0].path).toBe("tools.t1.guardrails");
+  });
+
+  it("reports invalid guardrail reference on artifact", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: {
+          type: "code", owner: "a1", producers: ["a1"], editors: ["a1"],
+          consumers: ["a1"], states: ["draft"], guardrails: ["bad"],
+        },
+      },
+    });
+    const diags = checkReferences(dsl);
+    const found = diags.filter((d) => d.code === "entity-guardrail-ref-not-found");
+    expect(found).toHaveLength(1);
+    expect(found[0].path).toBe("artifacts.art1.guardrails");
+  });
+
+  it("passes when guardrail references are valid", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", guardrails: ["g1"] } },
+      guardrails: { g1: { description: "d", scope: {} } },
+    });
+    const diags = checkReferences(dsl);
+    const found = diags.filter((d) => d.code === "entity-guardrail-ref-not-found");
+    expect(found).toHaveLength(0);
+  });
+});
+
+// -- Lint rules --
+
+describe("entity-guardrail-undefined lint rule", () => {
+  it("reports error when entity references undefined guardrail", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", guardrails: ["nonexistent"] } },
+    });
+    const diags = entityGuardrailUndefinedRule.run(dsl);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].severity).toBe("error");
+    expect(diags[0].message).toContain("nonexistent");
+  });
+
+  it("reports errors for all entity types", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", guardrails: ["bad1"], can_return_handoffs: ["h", "r"] } },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1", allowed_from_agents: ["a1"],
+          workflow: "implement", input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          guardrails: ["bad2"],
+        },
+      },
+      tools: { tool1: { kind: "cli", invokable_by: ["a1"], guardrails: ["bad3"] } },
+      artifacts: {
+        art1: {
+          type: "code", owner: "a1", producers: ["a1"], editors: ["a1"],
+          consumers: ["a1"], states: ["draft"], guardrails: ["bad4"],
+        },
+      },
+      handoff_types: { h: { version: 1, schema: {} }, r: { version: 1, schema: {} } },
+    });
+    const diags = entityGuardrailUndefinedRule.run(dsl);
+    expect(diags).toHaveLength(4);
+  });
+
+  it("clean when all references are valid", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", guardrails: ["g1"] } },
+      guardrails: { g1: { description: "d", scope: {} } },
+    });
+    const diags = entityGuardrailUndefinedRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+});
+
+describe("entity-no-guardrails lint rule", () => {
+  it("reports info when entity has no effective guardrails", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+    });
+    const diags = entityNoGuardrailsRule.run(dsl);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].severity).toBe("info");
+    expect(diags[0].message).toContain("a1");
+  });
+
+  it("clean when entity has entity-side guardrails", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", guardrails: ["g1"] } },
+      guardrails: { g1: { description: "d", scope: {} } },
+    });
+    const diags = entityNoGuardrailsRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("clean when entity has scope-side guardrails", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      guardrails: { g1: { description: "d", scope: { agents: ["a1"] } } },
+    });
+    const diags = entityNoGuardrailsRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+});
+
+describe("guardrail-orphaned lint rule", () => {
+  it("reports warning when guardrail is not referenced by any entity and has empty scope", () => {
+    const dsl = makeDsl({
+      guardrails: { g1: { description: "d", scope: {} } },
+    });
+    const diags = guardrailOrphanedRule.run(dsl);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].severity).toBe("warning");
+    expect(diags[0].message).toContain("g1");
+  });
+
+  it("clean when guardrail is referenced by entity", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", guardrails: ["g1"] } },
+      guardrails: { g1: { description: "d", scope: {} } },
+    });
+    const diags = guardrailOrphanedRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("clean when guardrail has scope bindings", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      guardrails: { g1: { description: "d", scope: { agents: ["a1"] } } },
+    });
+    const diags = guardrailOrphanedRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("clean when guardrail has workflow scope", () => {
+    const dsl = makeDsl({
+      guardrails: { g1: { description: "d", scope: { workflows: ["implement"] } } },
+    });
+    const diags = guardrailOrphanedRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+});
+
+// -- Scorer --
+
+describe("entity-guardrail-coverage scorer", () => {
+  it("scores 100% when all entities have guardrails", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", guardrails: ["g1"] } },
+      guardrails: { g1: { description: "d", scope: {} } },
+    });
+    const result = score(dsl);
+    const d = result.dimensions.find((d) => d.id === "entity-guardrail-coverage")!;
+    expect(d.percent).toBe(100);
+    expect(d.recommendations).toHaveLength(0);
+  });
+
+  it("scores 0% when no entities have guardrails", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+    });
+    const result = score(dsl);
+    const d = result.dimensions.find((d) => d.id === "entity-guardrail-coverage")!;
+    expect(d.percent).toBe(0);
+    expect(d.recommendations[0]).toContain("agents.a1");
+  });
+
+  it("counts scope-side guardrails as coverage", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      guardrails: { g1: { description: "d", scope: { agents: ["a1"] } } },
+    });
+    const result = score(dsl);
+    const d = result.dimensions.find((d) => d.id === "entity-guardrail-coverage")!;
+    expect(d.percent).toBe(100);
+  });
+
+  it("scores 100% for empty DSL", () => {
+    const dsl = makeDsl({});
+    const result = score(dsl);
+    const d = result.dimensions.find((d) => d.id === "entity-guardrail-coverage")!;
+    expect(d.percent).toBe(100);
+  });
+
+  it("scores mixed coverage correctly", () => {
+    const dsl = makeDsl({
+      agents: {
+        a1: { role_name: "R", purpose: "P", guardrails: ["g1"] },
+        a2: { role_name: "R", purpose: "P" },
+      },
+      guardrails: { g1: { description: "d", scope: {} } },
+    });
+    const result = score(dsl);
+    const d = result.dimensions.find((d) => d.id === "entity-guardrail-coverage")!;
+    expect(d.percent).toBe(50);
+    expect(d.score).toBe(1);
+    expect(d.total).toBe(2);
+  });
+});
+
+// -- Integration: lint() includes new rules --
+
+describe("lint() integration", () => {
+  it("includes entity-guardrail-undefined diagnostics", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", guardrails: ["nonexistent"] } },
+    });
+    const diags = lint(dsl);
+    expect(diags.some((d) => d.ruleId === "entity-guardrail-undefined")).toBe(true);
+  });
+
+  it("includes entity-no-guardrails diagnostics", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+    });
+    const diags = lint(dsl);
+    expect(diags.some((d) => d.ruleId === "entity-no-guardrails")).toBe(true);
+  });
+
+  it("includes guardrail-orphaned diagnostics", () => {
+    const dsl = makeDsl({
+      guardrails: { g1: { description: "d", scope: {} } },
+    });
+    const diags = lint(dsl);
+    expect(diags.some((d) => d.ruleId === "guardrail-orphaned")).toBe(true);
+  });
+});

--- a/test/scorer/scorer.test.ts
+++ b/test/scorer/scorer.test.ts
@@ -33,10 +33,10 @@ describe("score()", () => {
     expect(result.overall).toBeLessThanOrEqual(100);
   });
 
-  it("returns 7 dimensions", () => {
+  it("returns 8 dimensions", () => {
     const dsl = makeDsl({});
     const result = score(dsl);
-    expect(result.dimensions).toHaveLength(7);
+    expect(result.dimensions).toHaveLength(8);
   });
 
   it("returns 100 for an empty DSL (no entities = nothing to check)", () => {
@@ -341,7 +341,7 @@ describe("score on full fixture", () => {
     const result = score(dsl);
     expect(result.overall).toBeGreaterThanOrEqual(0);
     expect(result.overall).toBeLessThanOrEqual(100);
-    expect(result.dimensions).toHaveLength(7);
+    expect(result.dimensions).toHaveLength(8);
     for (const d of result.dimensions) {
       expect(d.percent).toBeGreaterThanOrEqual(0);
       expect(d.percent).toBeLessThanOrEqual(100);


### PR DESCRIPTION
## Summary

Closes #18 — entity-side guardrail binding so guardrails defined in the DSL reach entity prompts.

- Add optional `guardrails: string[]` to `AgentSchema`, `TaskSchema`, `ToolSchema`, `ArtifactSchema`
- Implement bidirectional resolution: union of entity-side `entity.guardrails[]` and scope-side `guardrails[].scope.{type}`, with `source` tracking (`"entity"` / `"scope"` / `"both"`)
- Inject `relatedGuardrails: EntityGuardrailEntry[]` into `PerAgentContext`, `PerTaskContext`, `PerToolContext`, `PerArtifactContext`
- Add `checkReferences()` validation for entity guardrail refs
- Add 3 lint rules: `entity-guardrail-undefined` (error), `entity-no-guardrails` (info), `guardrail-orphaned` (warning)
- Add `entity-guardrail-coverage` scorer dimension
- Add guardrails table rendering in `agent-prompt.md.hbs`
- Regenerate `dsl.schema.json`
- Update `docs/spec/guardrail-di.md` §1.3 and §2.1.1

## Test plan

- [x] 43 new tests covering schema, resolution, context builders, checkReferences, lint rules, scorer
- [x] All 569 tests pass
- [x] Typecheck passes
- [x] Build succeeds
- [x] Backward compatible — `guardrails` field is optional on all entities
