### PR TITLE
chore: add gitignore patterns for agent-kit-lite integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ coverage/
 *.tsbuildinfo
 sample/output/
 .cursor/
+.aidev/
+.aidev.json
+.observ/
+agent-contracts/
+agent-contracts.config.yaml
+setup-aidev.sh


### PR DESCRIPTION
## Summary

- agent-kit-lite (aidev-skeleton) のローカル統合ファイル用 gitignore パターンを追加
- `.aidev/`, `.aidev.json`, `agent-contracts/`, `agent-contracts.config.yaml`, `setup-aidev.sh`, `.observ/` を ignore 対象に

## Context

aidev-skeleton の agent-kit-lite テンプレートを開発者ローカルで利用するための準備。
これらのファイルは `.aidev` ダウンロード/同期ワークフローで管理され、リポジトリにはコミットしない方針。


Made with [Cursor](https://cursor.com)