### PR TITLE
fix: add relatedValidations to agent/task/tool prompt contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -999,10 +999,10 @@ Each `context` type provides a different rendering scope:
 | Context | Scope | Output | Key variables |
 |---------|-------|--------|---------------|
 | `system` | Single file | `output` as-is | `system`, `dsl`, `guardrailEnforcement`\*, `bindings`\* |
-| `agent` | Per agent | `{agent.id}` in output path | `agent`, `receivableTasks`, `delegatableTasks`, `relatedArtifacts`, `relatedTools`, `relatedHandoffTypes`, `mergedBehavior`, `dsl` |
-| `task` | Per task | `{task.id}` in output path | `task`, `targetAgent`, `dsl` |
-| `artifact` | Per artifact | `{artifact.id}` in output path | `artifact`, `relatedTools`, `relatedValidations`, `producerAgents`, `consumerAgents`, `editorAgents`, `createdInWorkflows`, `dsl` |
-| `tool` | Per tool | `{tool.id}` in output path | `tool`, `invokableAgents`, `inputArtifactDetails`, `outputArtifactDetails`, `dsl` |
+| `agent` | Per agent | `{agent.id}` in output path | `agent`, `receivableTasks`, `delegatableTasks`, `relatedArtifacts`, `relatedTools`, `relatedHandoffTypes`, `mergedBehavior`, `relatedGuardrails`, `relatedValidations`, `dsl` |
+| `task` | Per task | `{task.id}` in output path | `task`, `targetAgent`, `relatedGuardrails`, `relatedValidations`, `dsl` |
+| `artifact` | Per artifact | `{artifact.id}` in output path | `artifact`, `relatedTools`, `relatedValidations`, `relatedGuardrails`, `producerAgents`, `consumerAgents`, `editorAgents`, `createdInWorkflows`, `dsl` |
+| `tool` | Per tool | `{tool.id}` in output path | `tool`, `invokableAgents`, `inputArtifactDetails`, `outputArtifactDetails`, `relatedGuardrails`, `relatedValidations`, `dsl` |
 | `validation` | Per validation | `{validation.id}` in output path | `validation`, `dsl` |
 | `handoff_type` | Per handoff type | `{handoff_type.id}` in output path | `handoff_type`, `relatedTasks`, `dsl` |
 | `workflow` | Per workflow phase | `{workflow.id}` in output path | `workflow`, `relatedAgents`, `relatedTasks`, `relatedTools`, `relatedArtifacts`, `relatedValidations`, `dsl` |
@@ -1027,6 +1027,23 @@ Each `context` type provides a different rendering scope:
 * `producerAgents` / `consumerAgents` / `editorAgents` — resolved agent records
 * `createdInWorkflows` — workflow phases where this artifact is written
 
+**`agent` context** provides merged behavioral specs and cross-references:
+
+* `relatedGuardrails` — guardrails bound via `agent.guardrails[]` or guardrail `scope.agents[]`, merged and deduplicated
+* `relatedValidations` — validations from `agent.can_perform_validations`, resolved into full entries (kind, target_artifact, executor_type, blocking)
+
+**`task` context** provides execution details:
+
+* `relatedGuardrails` — guardrails bound via `task.guardrails[]` or guardrail `scope.tasks[]`
+* `relatedValidations` — validations from `task.validations[]`, resolved into full entries
+
+**`tool` context** provides invocation and artifact details:
+
+* `relatedGuardrails` — guardrails bound via `tool.guardrails[]` or guardrail `scope.tools[]`
+* `relatedValidations` — validations where `executor_type` is `"tool"` and `executor` matches this tool ID
+* `invokableAgents` — agents listed in `invokable_by`
+* `inputArtifactDetails` / `outputArtifactDetails` — resolved artifact records
+
 **`system` context** includes binding-aware guardrail enforcement data when `bindings` and `active_guardrail_policy` are configured:
 
 * `guardrailEnforcement` — array of enforcement entries, each with `guardrail_id`, `description`, `severity`, `action`, scoped entities (`scoped_agents`, `scoped_tasks`, `scoped_workflows`, `scoped_tools`, `scoped_artifacts`), `allow_override`, `override_requires`, `trigger` (from binding matcher type), and `escalation`
@@ -1038,11 +1055,6 @@ These fields are only populated when the config specifies `bindings` and `active
 
 * `guardrailCoverageMatrix` — generates a Guardrail Coverage Matrix table (guardrail × severity × action × scoped entities × trigger × override × escalation)
 * `taskGuardrailMatrix` — generates a Task × Guardrail cross-reference table showing which action applies to each task
-
-**`tool` context** resolves agent and artifact references:
-
-* `invokableAgents` — agents listed in `invokable_by`
-* `inputArtifactDetails` / `outputArtifactDetails` — resolved artifact records
 
 ### Handlebars helpers
 
@@ -1306,6 +1318,7 @@ Checks:
 * artifact ownership — `produces_artifact`/`reads_artifact` in execution steps vs. artifact producers/editors/consumers
 * tool commands — `commands[].reads`/`commands[].writes` reference valid artifacts and align with `output_artifacts`
 * semantic validation phase coverage — warns when `semantic` or `fidelity` validations only appear in late workflow phases (e.g., audit) but not earlier phases (e.g., specify, plan)
+* validation executor context wiring — warns when a validation's executor (agent or tool) exists in the DSL but the validation is not surfaced in the executor's prompt context
 * YAML safety — warns when YAML 1.1 reserved words (`on`, `yes`, `no`, `true`, `false`, etc.) are used in positions where they may be misinterpreted by non-1.2 parsers
 * naming/style issues through Spectral rules
 

--- a/docs/spec/guardrail-di.md
+++ b/docs/spec/guardrail-di.md
@@ -64,6 +64,8 @@ effectiveGuardrails(entityType, entityId) =
 
 Resolved guardrails are injected into each entity's `PerEntityContext.relatedGuardrails` so templates can render them into prompts.
 
+A parallel mechanism exists for validations: `resolveEntityValidations()` resolves validation IDs into `EntityValidationEntry[]` and injects them as `relatedValidations` into agent, task, and tool contexts. See Issue #19.
+
 | Existing | Purpose | Guardrail Relation |
 |----------|---------|-------------------|
 | `agents[].rules` | Per-agent behavioral rules (mandatory/recommended/optional) | Guardrails are cross-cutting constraints that also support entity-side binding |
@@ -803,6 +805,7 @@ binding.guardrail_impl.{key} → guardrails
 | `binding-template-conflict` | error | A binding output specifies both `template` and `inline_template` |
 | `binding-template-missing` | error | A binding output specifies neither `template` nor `inline_template` |
 | `binding-path-unresolved` | error | A binding target uses `{name}` but config has no matching `paths` entry |
+| `validation-executor-no-context` | warning | A validation executor (agent/tool) exists in the DSL but the validation is not listed in the executor's prompt context |
 
 ### 7.2 Existing Rule Interactions
 

--- a/sample/templates/agent-prompt.md.hbs
+++ b/sample/templates/agent-prompt.md.hbs
@@ -18,6 +18,10 @@
     relatedHandoffTypes  - Record<kind, HandoffType> related to this agent's tasks/handoffs
     relatedGuardrails    - Array of EntityGuardrailEntry (guardrail_id, description,
                            rationale, tags, source, severity, action)
+    relatedValidations   - Array of EntityValidationEntry (validation_id, kind,
+                           target_artifact, executor_type, blocking, produces_evidence)
+                           for validations this agent is configured to run
+                           (from can_perform_validations)
     mergedBehavior       - Agent + all receivable tasks merged:
                            responsibilities, constraints, rules, anti_patterns,
                            escalation_criteria, execution_steps, completion_criteria
@@ -136,6 +140,16 @@
 |----|-------------|----------|--------|
 {{#each relatedGuardrails}}
 | {{this.guardrail_id}} | {{this.description}} | {{this.severity}} | {{this.action}} |
+{{/each}}
+{{/if}}
+
+{{#if relatedValidations.length}}
+## Validations You Execute
+
+| ID | Kind | Target Artifact | Blocking |
+|----|------|-----------------|----------|
+{{#each relatedValidations}}
+| {{this.validation_id}} | {{this.kind}} | {{this.target_artifact}} | {{this.blocking}} |
 {{/each}}
 {{/if}}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,9 @@ export {
   type MergedBehavioralSpec,
   type DelegatableTaskView,
   type EntityGuardrailEntry,
+  type EntityValidationEntry,
   resolveEffectiveGuardrails,
+  resolveEntityValidations,
 } from "./renderer/index.js";
 export {
   loadBindings,

--- a/src/linter/index.ts
+++ b/src/linter/index.ts
@@ -12,3 +12,4 @@ export { yamlReservedKeySafetyRule } from "./rules/yaml-reserved-key-safety.js";
 export { artifactRequiredValidationWiringRule } from "./rules/artifact-required-validation-wiring.js";
 export { taskOutputValidationCompletenessRule } from "./rules/task-output-validation-completeness.js";
 export { entityGuardrailUndefinedRule, entityNoGuardrailsRule, guardrailOrphanedRule } from "./rules/entity-guardrail-binding.js";
+export { validationExecutorNoContextRule } from "./rules/validation-executor-no-context.js";

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -16,6 +16,7 @@ import {
   entityNoGuardrailsRule,
   guardrailOrphanedRule,
 } from "./rules/entity-guardrail-binding.js";
+import { validationExecutorNoContextRule } from "./rules/validation-executor-no-context.js";
 
 const builtinRules: LintRule[] = [
   validationCoverageRule,
@@ -32,6 +33,7 @@ const builtinRules: LintRule[] = [
   entityGuardrailUndefinedRule,
   entityNoGuardrailsRule,
   guardrailOrphanedRule,
+  validationExecutorNoContextRule,
 ];
 
 export function lint(

--- a/src/linter/rules/validation-executor-no-context.ts
+++ b/src/linter/rules/validation-executor-no-context.ts
@@ -1,0 +1,44 @@
+import type { Dsl } from "../../schema/index.js";
+import type { LintRule, LintDiagnostic } from "../types.js";
+
+/**
+ * Validation declares an executor, but the executor's prompt context would not
+ * list this validation: agent must declare it in can_perform_validations; tool
+ * must exist in the DSL (tool context reverse-resolves all tool-executor validations).
+ */
+export const validationExecutorNoContextRule: LintRule = {
+  id: "validation-executor-no-context",
+  description:
+    "Validation executor is not wired so the validation appears in the executor's rendered context",
+
+  run(dsl: Dsl): LintDiagnostic[] {
+    const diagnostics: LintDiagnostic[] = [];
+
+    for (const [validationId, val] of Object.entries(dsl.validations)) {
+      if (val.executor_type === "agent") {
+        const agent = dsl.agents[val.executor];
+        if (!agent) continue;
+        const allowed = new Set(agent.can_perform_validations ?? []);
+        if (!allowed.has(validationId)) {
+          diagnostics.push({
+            ruleId: "validation-executor-no-context",
+            severity: "warning",
+            path: `agents.${val.executor}.can_perform_validations`,
+            message: `Validation "${validationId}" is executed by agent "${val.executor}" but is not listed in can_perform_validations, so it will be missing from that agent's prompt context`,
+          });
+        }
+      } else if (val.executor_type === "tool") {
+        if (!dsl.tools[val.executor]) {
+          diagnostics.push({
+            ruleId: "validation-executor-no-context",
+            severity: "warning",
+            path: `validations.${validationId}.executor`,
+            message: `Validation "${validationId}" references tool executor "${val.executor}" which is not defined in tools`,
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/src/renderer/context.ts
+++ b/src/renderer/context.ts
@@ -10,7 +10,6 @@ import type {
   Policy,
   Guardrail,
   GuardrailPolicy,
-  GuardrailPolicyRule,
   System,
   SoftwareBinding,
 } from "../schema/index.js";
@@ -66,10 +65,20 @@ export interface EntityGuardrailEntry {
   action?: string;
 }
 
+export interface EntityValidationEntry {
+  validation_id: string;
+  kind: string;
+  target_artifact: string;
+  executor_type: string;
+  blocking: boolean;
+  produces_evidence?: string;
+}
+
 export interface PerTaskContext {
   task: Task & { id: string };
   targetAgent: (Agent & { id: string }) | null;
   relatedGuardrails: EntityGuardrailEntry[];
+  relatedValidations: EntityValidationEntry[];
   dsl: Dsl;
   [key: string]: unknown;
 }
@@ -93,6 +102,7 @@ export interface PerToolContext {
   inputArtifactDetails: Dsl["artifacts"];
   outputArtifactDetails: Dsl["artifacts"];
   relatedGuardrails: EntityGuardrailEntry[];
+  relatedValidations: EntityValidationEntry[];
   dsl: Dsl;
   [key: string]: unknown;
 }
@@ -171,6 +181,7 @@ export interface PerAgentContext {
   relatedHandoffTypes: Dsl["handoff_types"];
   mergedBehavior: MergedBehavioralSpec;
   relatedGuardrails: EntityGuardrailEntry[];
+  relatedValidations: EntityValidationEntry[];
   dsl: Dsl;
   [key: string]: unknown;
 }
@@ -314,6 +325,61 @@ export function resolveEffectiveGuardrails(
   return entries;
 }
 
+function validationToEntityEntry(
+  validationId: string,
+  validation: Validation,
+): EntityValidationEntry {
+  return {
+    validation_id: validationId,
+    kind: validation.kind,
+    target_artifact: validation.target_artifact,
+    executor_type: validation.executor_type,
+    blocking: validation.blocking,
+    produces_evidence: validation.produces_evidence,
+  };
+}
+
+/**
+ * Resolves validation IDs for an agent, task, or tool into full entries for prompts.
+ * For tools, includes validations where executor_type is "tool" and executor is the tool id.
+ */
+export function resolveEntityValidations(
+  dsl: Dsl,
+  entityType: "agents" | "tasks" | "tools",
+  entityId: string,
+): EntityValidationEntry[] {
+  if (entityType === "agents") {
+    const agent = dsl.agents[entityId];
+    if (!agent) return [];
+    const entries: EntityValidationEntry[] = [];
+    for (const vid of agent.can_perform_validations ?? []) {
+      const v = dsl.validations[vid];
+      if (v) entries.push(validationToEntityEntry(vid, v));
+    }
+    return entries;
+  }
+
+  if (entityType === "tasks") {
+    const task = dsl.tasks[entityId];
+    if (!task) return [];
+    const entries: EntityValidationEntry[] = [];
+    for (const vid of task.validations ?? []) {
+      const v = dsl.validations[vid];
+      if (v) entries.push(validationToEntityEntry(vid, v));
+    }
+    return entries;
+  }
+
+  const entries: EntityValidationEntry[] = [];
+  for (const [vid, v] of Object.entries(dsl.validations)) {
+    if (v.executor_type === "tool" && v.executor === entityId) {
+      entries.push(validationToEntityEntry(vid, v));
+    }
+  }
+  entries.sort((a, b) => a.validation_id.localeCompare(b.validation_id));
+  return entries;
+}
+
 export function buildTaskContext(
   dsl: Dsl,
   taskId: string,
@@ -325,7 +391,8 @@ export function buildTaskContext(
     ? ({ ...agentDef, id: taskDef.target_agent } as Agent & { id: string })
     : null;
   const relatedGuardrails = resolveEffectiveGuardrails(dsl, "tasks", taskId);
-  return { task, targetAgent, relatedGuardrails, dsl };
+  const relatedValidations = resolveEntityValidations(dsl, "tasks", taskId);
+  return { task, targetAgent, relatedGuardrails, relatedValidations, dsl };
 }
 
 export function buildArtifactContext(
@@ -419,6 +486,7 @@ export function buildToolContext(
   };
 
   const relatedGuardrails = resolveEffectiveGuardrails(dsl, "tools", toolId);
+  const relatedValidations = resolveEntityValidations(dsl, "tools", toolId);
 
   return {
     tool,
@@ -426,6 +494,7 @@ export function buildToolContext(
     inputArtifactDetails: pickArtifacts(toolDef.input_artifacts),
     outputArtifactDetails: pickArtifacts(toolDef.output_artifacts),
     relatedGuardrails,
+    relatedValidations,
     dsl,
   };
 }
@@ -739,6 +808,7 @@ export function buildPerAgentContext(
   const rawReceivableTasks = receivableTasks.map(({ id: _id, ...rest }) => rest as Task);
   const mergedBehavior = mergeBehavioralSpec(agent, rawReceivableTasks);
   const relatedGuardrails = resolveEffectiveGuardrails(dsl, "agents", agentId);
+  const relatedValidations = resolveEntityValidations(dsl, "agents", agentId);
 
   return {
     agent,
@@ -750,6 +820,7 @@ export function buildPerAgentContext(
     relatedHandoffTypes,
     mergedBehavior,
     relatedGuardrails,
+    relatedValidations,
     dsl,
   };
 }

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -32,5 +32,7 @@ export {
   type DelegatableTaskView,
   type GuardrailEnforcementEntry,
   type EntityGuardrailEntry,
+  type EntityValidationEntry,
   resolveEffectiveGuardrails,
+  resolveEntityValidations,
 } from "./context.js";

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -16,10 +16,12 @@ const bindingsOutputDir = join(import.meta.dirname, "../__cli_output_bindings__"
 
 async function run(
   args: string[],
+  options?: { cwd?: string },
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   try {
     const { stdout, stderr } = await exec("node", [cliPath, ...args], {
       timeout: 10000,
+      cwd: options?.cwd,
     });
     return { stdout, stderr, exitCode: 0 };
   } catch (err) {
@@ -156,7 +158,8 @@ describe("agent-contracts render", () => {
   });
 
   it("exits 1 without config", async () => {
-    const { exitCode, stderr } = await run(["render"]);
+    const { tmpdir } = await import("node:os");
+    const { exitCode, stderr } = await run(["render"], { cwd: tmpdir() });
     expect(exitCode).toBe(1);
     expect(stderr).toContain("not found");
   });

--- a/test/config-loader.test.ts
+++ b/test/config-loader.test.ts
@@ -37,8 +37,14 @@ describe("loadConfig", () => {
   });
 
   it("returns null for default non-existent config", async () => {
-    const result = await loadConfig(undefined);
-    expect(result).toBeNull();
+    const originalCwd = process.cwd();
+    process.chdir(TEMP_DIR);
+    try {
+      const result = await loadConfig(undefined);
+      expect(result).toBeNull();
+    } finally {
+      process.chdir(originalCwd);
+    }
   });
 
   it("rejects invalid YAML", async () => {

--- a/test/context-builders.test.ts
+++ b/test/context-builders.test.ts
@@ -13,6 +13,7 @@ import {
   buildGuardrailContext,
   buildGuardrailPolicyContext,
 } from "../src/renderer/context.js";
+import type { EntityValidationEntry } from "../src/renderer/context.js";
 
 function createMinimalDsl(): Dsl {
   return {
@@ -161,6 +162,38 @@ describe("buildPerAgentContext", () => {
     expect(ctx.receivableTasks.length).toBeGreaterThan(0);
     expect(ctx.relatedTools).toHaveProperty("lint");
   });
+
+  it("includes relatedValidations from can_perform_validations as full entries", () => {
+    const dsl = createMinimalDsl();
+    const ctx = buildPerAgentContext(dsl, { ...dsl.agents["reviewer"], id: "reviewer" });
+    expect(ctx.relatedValidations).toHaveLength(1);
+    const entry: EntityValidationEntry = ctx.relatedValidations[0];
+    expect(entry.validation_id).toBe("code-review");
+    expect(entry.kind).toBe("semantic");
+    expect(entry.target_artifact).toBe("source-code");
+    expect(entry.executor_type).toBe("agent");
+    expect(entry.blocking).toBe(true);
+  });
+
+  it("has empty relatedValidations when agent runs no validations", () => {
+    const dsl = createMinimalDsl();
+    const ctx = buildPerAgentContext(dsl, { ...dsl.agents["dev"], id: "dev" });
+    expect(ctx.relatedValidations).toHaveLength(0);
+  });
+
+  it("skips non-existent validation IDs in can_perform_validations", () => {
+    const dsl = createMinimalDsl();
+    const patched = {
+      ...dsl,
+      agents: {
+        ...dsl.agents,
+        dev: { ...dsl.agents.dev, can_perform_validations: ["not-a-validation", "code-review"] },
+      },
+    };
+    const ctx = buildPerAgentContext(patched, { ...patched.agents["dev"], id: "dev" });
+    expect(ctx.relatedValidations).toHaveLength(1);
+    expect(ctx.relatedValidations[0].validation_id).toBe("code-review");
+  });
 });
 
 describe("buildTaskContext", () => {
@@ -172,6 +205,40 @@ describe("buildTaskContext", () => {
     expect(ctx.targetAgent).not.toBeNull();
     expect(ctx.targetAgent!.id).toBe("dev");
     expect(ctx.dsl).toBe(dsl);
+  });
+
+  it("includes relatedValidations from task.validations as full entries", () => {
+    const dsl = createMinimalDsl();
+    const extended = {
+      ...dsl,
+      validations: {
+        ...dsl.validations,
+        "pre-merge-check": {
+          target_artifact: "source-code",
+          kind: "mechanical" as const,
+          executor_type: "agent" as const,
+          executor: "dev",
+          blocking: false,
+        },
+      },
+      tasks: {
+        ...dsl.tasks,
+        "implement-feature": {
+          ...dsl.tasks["implement-feature"],
+          validations: ["code-review", "pre-merge-check", "missing-val"],
+        },
+      },
+    };
+    const ctx = buildTaskContext(extended, "implement-feature");
+    expect(ctx.relatedValidations).toHaveLength(2);
+    const ids = ctx.relatedValidations.map((e) => e.validation_id).sort();
+    expect(ids).toEqual(["code-review", "pre-merge-check"]);
+  });
+
+  it("has empty relatedValidations when task lists no validations", () => {
+    const dsl = createMinimalDsl();
+    const ctx = buildTaskContext(dsl, "review-code");
+    expect(ctx.relatedValidations).toHaveLength(0);
   });
 });
 
@@ -232,6 +299,34 @@ describe("buildToolContext", () => {
     const ctx = buildToolContext(dsl, "lint");
     expect(ctx.inputArtifactDetails).toHaveProperty("source-code");
     expect(Object.keys(ctx.outputArtifactDetails)).toHaveLength(0);
+  });
+
+  it("includes relatedValidations for validations where this tool is executor", () => {
+    const dsl = createMinimalDsl();
+    const extended = {
+      ...dsl,
+      validations: {
+        ...dsl.validations,
+        "static-lint-gate": {
+          target_artifact: "source-code",
+          kind: "mechanical" as const,
+          executor_type: "tool" as const,
+          executor: "lint",
+          blocking: true,
+        },
+      },
+    };
+    const ctx = buildToolContext(extended, "lint");
+    expect(ctx.relatedValidations).toHaveLength(1);
+    expect(ctx.relatedValidations[0].validation_id).toBe("static-lint-gate");
+    expect(ctx.relatedValidations[0].executor_type).toBe("tool");
+    expect(ctx.relatedValidations[0].target_artifact).toBe("source-code");
+  });
+
+  it("has empty relatedValidations when no tool-executor validations reference the tool", () => {
+    const dsl = createMinimalDsl();
+    const ctx = buildToolContext(dsl, "lint");
+    expect(ctx.relatedValidations).toHaveLength(0);
   });
 });
 

--- a/test/validation-executor-context.test.ts
+++ b/test/validation-executor-context.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { DslSchema, type Dsl } from "../src/schema/index.js";
+import { lint } from "../src/linter/linter.js";
+import { validationExecutorNoContextRule } from "../src/linter/rules/validation-executor-no-context.js";
+import { resolveEntityValidations } from "../src/renderer/context.js";
+
+function makeDsl(partial: Partial<Record<string, unknown>>): Dsl {
+  return DslSchema.parse({
+    version: 1,
+    system: { id: "s", name: "S", default_workflow_order: ["implement"] },
+    ...partial,
+  });
+}
+
+describe("resolveEntityValidations", () => {
+  it("resolves tool validations in stable id order", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      tools: { t1: { kind: "cli", invokable_by: ["a1"] } },
+      validations: {
+        zlast: {
+          target_artifact: "x",
+          kind: "mechanical",
+          executor_type: "tool",
+          executor: "t1",
+          blocking: true,
+        },
+        afirst: {
+          target_artifact: "x",
+          kind: "mechanical",
+          executor_type: "tool",
+          executor: "t1",
+          blocking: false,
+        },
+      },
+    });
+    const entries = resolveEntityValidations(dsl, "tools", "t1");
+    expect(entries.map((e) => e.validation_id)).toEqual(["afirst", "zlast"]);
+  });
+});
+
+describe("validation-executor-no-context lint rule", () => {
+  it("warns when agent executor exists but can_perform_validations omits the validation", () => {
+    const dsl = makeDsl({
+      agents: { reviewer: { role_name: "R", purpose: "P", can_perform_validations: [] } },
+      validations: {
+        "code-review": {
+          target_artifact: "source-code",
+          kind: "semantic",
+          executor_type: "agent",
+          executor: "reviewer",
+          blocking: true,
+        },
+      },
+    });
+    const diags = validationExecutorNoContextRule.run(dsl);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].severity).toBe("warning");
+    expect(diags[0].ruleId).toBe("validation-executor-no-context");
+    expect(diags[0].path).toBe("agents.reviewer.can_perform_validations");
+  });
+
+  it("is clean when the agent lists the validation in can_perform_validations", () => {
+    const dsl = makeDsl({
+      agents: {
+        reviewer: { role_name: "R", purpose: "P", can_perform_validations: ["code-review"] },
+      },
+      validations: {
+        "code-review": {
+          target_artifact: "source-code",
+          kind: "semantic",
+          executor_type: "agent",
+          executor: "reviewer",
+          blocking: true,
+        },
+      },
+    });
+    const diags = validationExecutorNoContextRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("warns when tool executor is not defined in tools", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      tools: { t1: { kind: "cli", invokable_by: ["a1"] } },
+      validations: {
+        "gate": {
+          target_artifact: "x",
+          kind: "mechanical",
+          executor_type: "tool",
+          executor: "no-such-tool",
+          blocking: true,
+        },
+      },
+    });
+    const diags = validationExecutorNoContextRule.run(dsl);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].path).toBe("validations.gate.executor");
+  });
+
+  it("is clean for tool executor when the tool exists", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      tools: { t1: { kind: "cli", invokable_by: ["a1"] } },
+      validations: {
+        "gate": {
+          target_artifact: "x",
+          kind: "mechanical",
+          executor_type: "tool",
+          executor: "t1",
+          blocking: true,
+        },
+      },
+    });
+    const diags = validationExecutorNoContextRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+});
+
+describe("lint() integration", () => {
+  it("includes validation-executor-no-context when agent wiring is wrong", () => {
+    const dsl = makeDsl({
+      agents: { reviewer: { role_name: "R", purpose: "P", can_perform_validations: [] } },
+      validations: {
+        v1: {
+          target_artifact: "a",
+          kind: "mechanical",
+          executor_type: "agent",
+          executor: "reviewer",
+          blocking: false,
+        },
+      },
+    });
+    const diags = lint(dsl);
+    expect(diags.some((d) => d.ruleId === "validation-executor-no-context")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #19 — Validation execution context was missing from agent/task/tool prompts.

- **`EntityValidationEntry`** interface and **`resolveEntityValidations()`** function added to `src/renderer/context.ts`, following the same pattern as `relatedGuardrails` from #18
- **`PerAgentContext.relatedValidations`**: resolves `can_perform_validations` IDs into full validation objects (kind, target_artifact, executor_type, blocking, produces_evidence)
- **`PerTaskContext.relatedValidations`**: resolves `task.validations` IDs into full entries
- **`PerToolContext.relatedValidations`**: reverse-resolves all validations where `executor_type === "tool"` and `executor` matches the tool ID
- **Template**: "Validations You Execute" table section added to `agent-prompt.md.hbs`
- **Lint rule**: `validation-executor-no-context` warns when an agent executor is not listed in `can_perform_validations`, or when a tool executor does not exist in the DSL
- **Test fix**: Pre-existing CWD-dependent test failures in config-loader and CLI tests resolved (tests now isolate working directory)

`PerArtifactContext.relatedValidations` is unchanged (already works as `Dsl["validations"]` records).

## Test plan

- [x] 582 tests pass (all existing + new tests)
- [x] `buildPerAgentContext` resolves `can_perform_validations` into full `EntityValidationEntry[]`
- [x] `buildTaskContext` resolves `task.validations` into full entries
- [x] `buildToolContext` reverse-resolves tool-executor validations
- [x] Non-existent validation IDs are gracefully skipped
- [x] Empty `relatedValidations` when no validations apply
- [x] Lint rule detects missing `can_perform_validations` wiring
- [x] Lint rule detects non-existent tool executor
- [x] `lint()` integration includes the new rule
- [x] Test Police audit: PASS (no CRITICAL violations)

Made with [Cursor](https://cursor.com)