### PR TITLE
chore: add test CLI output dirs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ coverage/
 !.env.example
 *.tsbuildinfo
 sample/output/
+test/__cli_output__/
+test/__cli_output_bindings__/
 .cursor/
 .aidev/
 .aidev.json


### PR DESCRIPTION
Add `test/__cli_output__/` and `test/__cli_output_bindings__/` to .gitignore. These are temporary directories created by CLI render tests.

Made with [Cursor](https://cursor.com)