### PR TITLE
feat: add binding renders and DSL entity context for unified rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1166,7 +1166,7 @@ guardrail_policies:
 
 ### Software bindings
 
-Bindings define software-specific check implementations:
+Bindings define software-specific check implementations, output generation, and rendering:
 
 ````yaml
 # bindings/cursor.yaml
@@ -1188,6 +1188,19 @@ outputs:
     mode: write
     executable: true
     template: ./templates/cursor-hook-wrapper.sh.hbs
+
+renders:
+  - context: agent
+    output: "{cursor_root}/agent-team/{agent.id}.md"
+    template: ./templates/agent-prompt.md.hbs
+    exclude:
+      - architect
+  - context: system
+    output: "{cursor_root}/rules/agent-team.mdc"
+    inline_template: |
+      {{#each agents}}
+      - {{@key}}: {{this.role_name}}
+      {{/each}}
 ````
 
 ### Binding inheritance
@@ -1244,6 +1257,7 @@ Merge behavior:
 | `software` | Project wins |
 | `guardrail_impl` | Map merge by guardrail ID (new IDs added; same ID deep-merged) |
 | `outputs` | Map merge by output ID (project overrides base) |
+| `renders` | Array concatenation (base renders + project renders) |
 | `reporting` | Deep merge (project fields override base) |
 | passthrough fields | Project wins |
 
@@ -1274,6 +1288,62 @@ paths:
   cursor_root: .cursor
   git_hooks_root: scripts/git-hooks
 ````
+
+### Binding template context
+
+Both `outputs` and `renders` templates have access to the full binding generation context:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `system` | `{ id, name }` | System metadata |
+| `guardrails` | `Record<string, Guardrail>` | All guardrail definitions |
+| `policy` | `GuardrailPolicy` | Active guardrail policy |
+| `binding` | `SoftwareBinding` | Current binding |
+| `all_bindings` | `Record<string, SoftwareBinding>` | All loaded bindings |
+| `vars` | `Record<string, string>` | Variables from `config.vars` |
+| `paths` | `Record<string, string>` | Path variables from `config.paths` |
+| `reporting` | `{ commands, fail_open, timeout_ms } \| null` | Reporting config |
+| `resolved_checks` | `ResolvedCheck[]` | Resolved guardrail checks |
+| `tasks` | `Record<string, Task>` | All DSL tasks |
+| `artifacts` | `Record<string, Artifact>` | All DSL artifacts |
+| `agents` | `Record<string, Agent>` | All DSL agents |
+| `handoff_types` | `Record<string, HandoffType>` | All DSL handoff types |
+| `workflow` | `Record<string, Workflow>` | All DSL workflows |
+
+DSL entities include passthrough fields (`x-*` extensions), so custom metadata defined in the DSL is accessible in templates (e.g., `{{agents.implementer.x-team}}`).
+
+### Binding renders
+
+Binding `renders` provide entity-iteration rendering with full DSL context — the same capability as config-level `renders`, but defined within binding YAML files.
+
+Each render target specifies a `context` type and an `output` path pattern:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `context` | yes | Entity type: `agent`, `task`, `artifact`, `tool`, `workflow`, `system`, etc. |
+| `output` | yes | Output path with `{entity.id}` and `{paths_var}` expansion |
+| `template` | one of | Path to external `.hbs` template file |
+| `inline_template` | one of | Inline Handlebars template string |
+| `include` | no | Only render these entity IDs |
+| `exclude` | no | Skip these entity IDs |
+| `skip_empty` | no | Delete target if rendered output is empty |
+| `executable` | no | Set file permissions to 0755 |
+
+For non-`system` contexts, one file is generated per entity (filtered by `include`/`exclude`). The output path supports two types of variable expansion:
+
+- `{agent.id}`, `{task.id}`, etc. — replaced with the current entity ID
+- `{cursor_root}`, `{observability_root}`, etc. — replaced from `config.paths`
+
+**When to use binding renders vs config renders vs binding outputs:**
+
+| Use case | Recommended |
+|----------|-------------|
+| Generate per-entity files (agent prompts, workflow docs) | Binding `renders` or config `renders` |
+| Generate guardrail/policy runtime artifacts | Binding `outputs` |
+| Generate files using DSL data + guardrail data | Binding `renders` (has both) |
+| Simple config without bindings | Config `renders` |
+
+Config `renders` remains supported and is not deprecated. Binding `renders` offers the advantage of co-locating templates with their binding definition and having access to the full binding context (`vars`, `paths`, `resolved_checks`, etc.) in addition to DSL entities.
 
 ### Generate command
 

--- a/docs/spec/guardrail-di.md
+++ b/docs/spec/guardrail-di.md
@@ -845,7 +845,7 @@ agent-contracts generate guardrails -c agent-contracts.config.yaml --binding cur
    d. Validate merged result against `SoftwareBindingSchema`
 5. Run cross-reference checks (binding keys → DSL guardrails, policy → guardrails)
 6. For each binding with `outputs`:
-   a. Resolve the `GuardrailGenerationContext` (see section 9)
+   a. Resolve the `BindingGenerationContext` (see section 9)
    b. For each output entry, resolve the target path (section 5)
    c. Render using inline or external template
    d. Write output (mode: `write` replaces, `patch` merges)
@@ -885,9 +885,9 @@ This enables `context: guardrail` and `context: guardrail_policy` in render targ
 
 ## 9. Generation Context
 
-### 9.1 GuardrailGenerationContext
+### 9.1 BindingGenerationContext
 
-Passed to each binding's templates during `generate guardrails`:
+Passed to each binding's `outputs` and `renders` templates during `generate guardrails`:
 
 ```typescript
 interface ResolvedCheck {
@@ -897,8 +897,8 @@ interface ResolvedCheck {
   check: Check;   // CheckSchema instance with passthrough fields
 }
 
-interface GuardrailGenerationContext {
-  system: System;
+interface BindingGenerationContext {
+  system: { id: string; name: string };
   guardrails: Record<string, Guardrail>;
   policy: GuardrailPolicy;
   binding: SoftwareBinding;
@@ -911,6 +911,13 @@ interface GuardrailGenerationContext {
     timeout_ms: number;
   } | null;
   resolved_checks: ResolvedCheck[];
+
+  // DSL entity maps
+  tasks: Record<string, Task>;
+  artifacts: Record<string, Artifact>;
+  agents: Record<string, Agent>;
+  handoff_types: Record<string, HandoffType>;
+  workflow: Record<string, Workflow>;
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/config/binding-merger.ts
+++ b/src/config/binding-merger.ts
@@ -6,7 +6,8 @@ function isRecord(v: unknown): v is AnyRecord {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
-const BINDING_MERGE_SECTIONS = ["guardrail_impl", "outputs"];
+const BINDING_MAP_MERGE_SECTIONS = ["guardrail_impl", "outputs"];
+const BINDING_ARRAY_MERGE_SECTIONS = ["renders"];
 
 export function mergeBinding(
   base: AnyRecord,
@@ -15,7 +16,7 @@ export function mergeBinding(
   const hasExtends = typeof project["extends"] === "string";
   const result: AnyRecord = { ...base, ...project };
 
-  for (const section of BINDING_MERGE_SECTIONS) {
+  for (const section of BINDING_MAP_MERGE_SECTIONS) {
     const baseVal = base[section];
     const projVal = project[section];
 
@@ -30,6 +31,17 @@ export function mergeBinding(
       section,
       hasExtends,
     );
+  }
+
+  for (const section of BINDING_ARRAY_MERGE_SECTIONS) {
+    const baseVal = base[section];
+    const projVal = project[section];
+
+    if (projVal === undefined) continue;
+
+    const baseArr = Array.isArray(baseVal) ? baseVal : [];
+    const projArr = Array.isArray(projVal) ? projVal : [];
+    result[section] = [...baseArr, ...projArr];
   }
 
   // reporting: deep merge when both sides are objects, otherwise project wins

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,25 +1,13 @@
 import { z } from "zod";
 
-export const CONTEXT_TYPES = [
-  "agent",
-  "task",
-  "artifact",
-  "tool",
-  "validation",
-  "handoff_type",
-  "workflow",
-  "policy",
-  "guardrail",
-  "guardrail_policy",
-  "system",
-] as const;
+export {
+  CONTEXT_TYPES,
+  ContextTypeSchema,
+  ITERABLE_CONTEXT_TYPES,
+  type ContextType,
+} from "../schema/context-type.js";
 
-export const ContextTypeSchema = z.enum(CONTEXT_TYPES);
-export type ContextType = z.infer<typeof ContextTypeSchema>;
-
-export const ITERABLE_CONTEXT_TYPES = CONTEXT_TYPES.filter(
-  (t): t is Exclude<ContextType, "system"> => t !== "system",
-);
+import { ContextTypeSchema, type ContextType } from "../schema/context-type.js";
 
 export const RenderTargetSchema = z
   .object({
@@ -49,7 +37,7 @@ export type RenderTarget = z.infer<typeof RenderTargetSchema>;
 export const AgentContractsConfigSchema = z.object({
   dsl: z.string(),
   vars: z.record(z.string(), z.string()).optional(),
-  renders: z.array(RenderTargetSchema).min(1),
+  renders: z.array(RenderTargetSchema).default([]),
   bindings: z.array(z.string()).default([]),
   active_guardrail_policy: z.string().optional(),
   paths: z.record(z.string(), z.string()).optional(),

--- a/src/guardrail-generator/generator.ts
+++ b/src/guardrail-generator/generator.ts
@@ -6,13 +6,21 @@ import type { Dsl } from "../schema/index.js";
 import type { ResolvedConfig } from "../config/types.js";
 import type { LoadedBinding } from "../config/binding-loader.js";
 import type { BindingOutput } from "../schema/index.js";
+import type { ContextType } from "../schema/context-type.js";
 import type {
-  GuardrailGenerationContext,
+  BindingGenerationContext,
   GenerateResult,
   GenerateDiagnostic,
 } from "./types.js";
 import { resolveChecks } from "./resolve-checks.js";
 import { resolveBindingTargetPath } from "./resolve-paths.js";
+import {
+  buildEntityContext,
+  buildSystemContext,
+  getDslSection,
+  filterIds,
+  expandOutputPath,
+} from "../renderer/index.js";
 
 // Register the `json` template helper
 Handlebars.registerHelper("json", (value: unknown) => {
@@ -176,7 +184,7 @@ export async function generateGuardrails(
   }
 
   // Find reporting binding (one with `reporting` section)
-  let reporting: GuardrailGenerationContext["reporting"] = null;
+  let reporting: BindingGenerationContext["reporting"] = null;
   for (const lb of loadedBindings) {
     if (lb.binding.reporting) {
       reporting = {
@@ -199,14 +207,14 @@ export async function generateGuardrails(
       continue;
     }
 
-    if (!binding.outputs) continue;
+    if (!binding.outputs && !binding.renders) continue;
 
     // Resolve checks for this binding
     const checkResult = resolveChecks(dsl, binding, policy);
     diagnostics.push(...checkResult.diagnostics);
 
     // Build generation context
-    const ctx: GuardrailGenerationContext = {
+    const ctx: BindingGenerationContext = {
       system: { id: dsl.system.id, name: dsl.system.name },
       guardrails: dsl.guardrails,
       policy,
@@ -216,10 +224,15 @@ export async function generateGuardrails(
       paths,
       reporting,
       resolved_checks: checkResult.resolved,
+      tasks: dsl.tasks,
+      artifacts: dsl.artifacts,
+      agents: dsl.agents,
+      handoff_types: dsl.handoff_types,
+      workflow: dsl.workflow,
     };
 
     // Process each output
-    for (const [outputId, outputDef] of Object.entries(binding.outputs)) {
+    for (const [outputId, outputDef] of Object.entries(binding.outputs ?? {})) {
       // Resolve target path
       const pathResult = resolveBindingTargetPath(
         outputDef.target,
@@ -365,7 +378,109 @@ export async function generateGuardrails(
         }
       }
     }
+
+    // Process binding renders (entity-iteration rendering with full DSL context)
+    for (const renderTarget of binding.renders ?? []) {
+      let templateContent: string;
+      if (renderTarget.inline_template) {
+        templateContent = renderTarget.inline_template;
+      } else if (renderTarget.template) {
+        const templatePath = resolve(config.configDir, renderTarget.template);
+        try {
+          templateContent = await readFile(templatePath, "utf8");
+        } catch {
+          diagnostics.push({
+            path: `binding.${binding.software}.renders`,
+            message: `Template file not found: ${templatePath}`,
+            severity: "error",
+          });
+          continue;
+        }
+      } else {
+        diagnostics.push({
+          path: `binding.${binding.software}.renders`,
+          message: "Render target has neither template nor inline_template",
+          severity: "error",
+        });
+        continue;
+      }
+
+      const compiled = Handlebars.compile(templateContent, { noEscape: true });
+      const shouldSkipEmpty = renderTarget.skip_empty === true;
+      const context = renderTarget.context as ContextType;
+
+      if (context === "system") {
+        const sysCtx = buildSystemContext(dsl);
+        const mergedCtx = { ...sysCtx, vars, paths, binding, resolved_checks: checkResult.resolved };
+        const rendered = compiled(mergedCtx);
+
+        const resolvedOutput = resolveBindingRenderOutputPath(renderTarget.output, paths);
+        const outputPath = resolve(config.configDir, resolvedOutput);
+
+        if (shouldSkipEmpty && rendered.trim().length === 0) {
+          if (!dryRun) {
+            try { await unlink(outputPath); } catch { /* not found */ }
+          }
+          continue;
+        }
+
+        if (!dryRun) {
+          await mkdir(dirname(outputPath), { recursive: true });
+          await writeFile(outputPath, rendered, "utf8");
+          if (renderTarget.executable) {
+            await chmod(outputPath, 0o755);
+          }
+        }
+        outputFiles.push(outputPath);
+      } else {
+        const section = getDslSection(dsl, context);
+        const allIds = Object.keys(section);
+        const ids = filterIds(allIds, renderTarget.include, renderTarget.exclude);
+
+        for (const entityId of ids) {
+          const entityCtx = buildEntityContext(dsl, context, entityId);
+          const mergedCtx = { ...entityCtx, vars, paths, binding, resolved_checks: checkResult.resolved };
+          const rendered = compiled(mergedCtx);
+
+          const resolvedOutput = resolveBindingRenderOutputPath(
+            expandOutputPath(renderTarget.output, context, entityId),
+            paths,
+          );
+          const outputPath = resolve(config.configDir, resolvedOutput);
+
+          if (shouldSkipEmpty && rendered.trim().length === 0) {
+            if (!dryRun) {
+              try { await unlink(outputPath); } catch { /* not found */ }
+            }
+            continue;
+          }
+
+          if (!dryRun) {
+            await mkdir(dirname(outputPath), { recursive: true });
+            await writeFile(outputPath, rendered, "utf8");
+            if (renderTarget.executable) {
+              await chmod(outputPath, 0o755);
+            }
+          }
+          outputFiles.push(outputPath);
+        }
+      }
+    }
   }
 
   return { outputFiles, diagnostics };
+}
+
+/**
+ * Resolve path variables ({name}) from config.paths in binding render output paths.
+ * Uses the same {var} syntax as binding outputs target paths.
+ */
+function resolveBindingRenderOutputPath(
+  output: string,
+  paths: Record<string, string>,
+): string {
+  return output.replace(/\{(\w+)\}/g, (match, varName: string) => {
+    const value = paths[varName];
+    return value !== undefined ? value : match;
+  });
 }

--- a/src/guardrail-generator/index.ts
+++ b/src/guardrail-generator/index.ts
@@ -3,6 +3,7 @@ export { resolveChecks, type ResolveChecksResult } from "./resolve-checks.js";
 export { resolveBindingTargetPath, type PathResolveResult } from "./resolve-paths.js";
 export type {
   ResolvedCheck,
+  BindingGenerationContext,
   GuardrailGenerationContext,
   GenerateResult,
   GenerateDiagnostic,

--- a/src/guardrail-generator/types.ts
+++ b/src/guardrail-generator/types.ts
@@ -1,9 +1,14 @@
 import type {
+  Agent,
+  Artifact,
   Guardrail,
   GuardrailPolicy,
   GuardrailPolicyRule,
+  HandoffType,
   SoftwareBinding,
+  Task,
   Check,
+  Workflow,
 } from "../schema/index.js";
 
 export interface ResolvedCheck {
@@ -13,7 +18,7 @@ export interface ResolvedCheck {
   check: Check;
 }
 
-export interface GuardrailGenerationContext {
+export interface BindingGenerationContext {
   system: { id: string; name: string };
   guardrails: Record<string, Guardrail>;
   policy: GuardrailPolicy;
@@ -27,7 +32,16 @@ export interface GuardrailGenerationContext {
     timeout_ms: number;
   } | null;
   resolved_checks: ResolvedCheck[];
+
+  tasks: Record<string, Task>;
+  artifacts: Record<string, Artifact>;
+  agents: Record<string, Agent>;
+  handoff_types: Record<string, HandoffType>;
+  workflow: Record<string, Workflow>;
 }
+
+/** @deprecated Use BindingGenerationContext */
+export type GuardrailGenerationContext = BindingGenerationContext;
 
 export interface GenerateResult {
   outputFiles: string[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ export {
   resolveBindingTargetPath,
   type GenerateGuardrailsOptions,
   type ResolvedCheck,
+  type BindingGenerationContext,
   type GuardrailGenerationContext,
   type GenerateResult,
   type GenerateDiagnostic,

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,6 +1,10 @@
 export {
   renderFromConfig,
   checkDriftFromConfig,
+  buildEntityContext,
+  getDslSection,
+  filterIds,
+  expandOutputPath,
   type RenderOptions,
 } from "./renderer.js";
 export {

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -308,7 +308,7 @@ export interface RenderOptions {
   activeGuardrailPolicy?: string;
 }
 
-function getDslSection(dsl: Dsl, context: ContextType): Record<string, unknown> {
+export function getDslSection(dsl: Dsl, context: ContextType): Record<string, unknown> {
   const sectionMap: Record<string, Record<string, unknown>> = {
     agent: dsl.agents,
     task: dsl.tasks,
@@ -324,7 +324,7 @@ function getDslSection(dsl: Dsl, context: ContextType): Record<string, unknown> 
   return sectionMap[context] ?? {};
 }
 
-function filterIds(
+export function filterIds(
   allIds: string[],
   include?: string[],
   exclude?: string[],
@@ -334,11 +334,11 @@ function filterIds(
   return allIds;
 }
 
-function expandOutputPath(pattern: string, context: ContextType, entityId: string): string {
+export function expandOutputPath(pattern: string, context: ContextType, entityId: string): string {
   return pattern.replace(new RegExp(`\\{${context}\\.id\\}`, "g"), entityId);
 }
 
-function buildEntityContext(
+export function buildEntityContext(
   dsl: Dsl,
   context: ContextType,
   entityId: string,

--- a/src/schema/binding.ts
+++ b/src/schema/binding.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { ContextTypeSchema } from "./context-type.js";
 
 const CommandRegexMatcherSchema = z
   .object({
@@ -78,6 +79,40 @@ const GuardrailImplSchema = z.object({
   checks: z.array(CheckSchema),
 });
 
+export const BindingRenderTargetSchema = z
+  .object({
+    template: z.string().optional(),
+    inline_template: z.string().optional(),
+    context: ContextTypeSchema,
+    output: z.string(),
+    include: z.array(z.string()).optional(),
+    exclude: z.array(z.string()).optional(),
+    skip_empty: z.boolean().optional(),
+    executable: z.boolean().optional(),
+  })
+  .passthrough()
+  .refine(
+    (data) => {
+      const count = [data.template, data.inline_template].filter(Boolean).length;
+      return count === 1;
+    },
+    { message: "Exactly one of template or inline_template must be specified" },
+  )
+  .refine(
+    (data) => !(data.include && data.exclude),
+    { message: "include and exclude are mutually exclusive" },
+  )
+  .refine(
+    (data) => {
+      if (data.context === "system" && (data.include || data.exclude)) {
+        return false;
+      }
+      return true;
+    },
+    { message: "include/exclude cannot be used with context: system" },
+  );
+export type BindingRenderTarget = z.infer<typeof BindingRenderTargetSchema>;
+
 export const SoftwareBindingSchema = z
   .object({
     software: z.string(),
@@ -85,6 +120,7 @@ export const SoftwareBindingSchema = z
     extends: z.string().optional(),
     guardrail_impl: z.record(z.string(), GuardrailImplSchema).optional(),
     outputs: z.record(z.string(), BindingOutputSchema).optional(),
+    renders: z.array(BindingRenderTargetSchema).optional(),
     reporting: ReportingSchema.optional(),
   })
   .passthrough();

--- a/src/schema/context-type.ts
+++ b/src/schema/context-type.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const CONTEXT_TYPES = [
+  "agent",
+  "task",
+  "artifact",
+  "tool",
+  "validation",
+  "handoff_type",
+  "workflow",
+  "policy",
+  "guardrail",
+  "guardrail_policy",
+  "system",
+] as const;
+
+export const ContextTypeSchema = z.enum(CONTEXT_TYPES);
+export type ContextType = z.infer<typeof ContextTypeSchema>;
+
+export const ITERABLE_CONTEXT_TYPES = CONTEXT_TYPES.filter(
+  (t): t is Exclude<ContextType, "system"> => t !== "system",
+);

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -11,16 +11,24 @@ export {
 export { ArtifactSchema, type Artifact } from "./artifact.js";
 export {
   BindingOutputSchema,
+  BindingRenderTargetSchema,
   CheckSchema,
   MatcherSchema,
   ReportingSchema,
   SoftwareBindingSchema,
   type BindingOutput,
+  type BindingRenderTarget,
   type Check,
   type Matcher,
   type Reporting,
   type SoftwareBinding,
 } from "./binding.js";
+export {
+  CONTEXT_TYPES,
+  ContextTypeSchema,
+  ITERABLE_CONTEXT_TYPES,
+  type ContextType,
+} from "./context-type.js";
 export {
   ComponentsSchema,
   DslSchema,

--- a/test/config/binding-merger.test.ts
+++ b/test/config/binding-merger.test.ts
@@ -192,4 +192,60 @@ describe("mergeBinding", () => {
     expect(result["x-base-meta"]).toBe("from-base");
     expect(result["x-proj-meta"]).toBe("from-proj");
   });
+
+  it("concatenates renders arrays from base and project", () => {
+    const base = {
+      software: "cursor",
+      version: 1,
+      renders: [
+        { context: "system", output: "sys.md", inline_template: "base" },
+      ],
+    };
+    const project = {
+      extends: "./base.yaml",
+      software: "cursor",
+      version: 1,
+      renders: [
+        { context: "agent", output: "{agent.id}.md", inline_template: "proj" },
+      ],
+    };
+    const result = mergeBinding(base, project);
+    const renders = result["renders"] as unknown[];
+    expect(renders).toHaveLength(2);
+    expect(renders[0]).toEqual(expect.objectContaining({ context: "system" }));
+    expect(renders[1]).toEqual(expect.objectContaining({ context: "agent" }));
+  });
+
+  it("uses only project renders when base has none", () => {
+    const base = { software: "cursor", version: 1 };
+    const project = {
+      extends: "./base.yaml",
+      software: "cursor",
+      version: 1,
+      renders: [
+        { context: "system", output: "out.md", inline_template: "only-proj" },
+      ],
+    };
+    const result = mergeBinding(base, project);
+    const renders = result["renders"] as unknown[];
+    expect(renders).toHaveLength(1);
+  });
+
+  it("keeps base renders when project has none", () => {
+    const base = {
+      software: "cursor",
+      version: 1,
+      renders: [
+        { context: "system", output: "out.md", inline_template: "only-base" },
+      ],
+    };
+    const project = {
+      extends: "./base.yaml",
+      software: "cursor",
+      version: 1,
+    };
+    const result = mergeBinding(base, project);
+    const renders = result["renders"] as unknown[];
+    expect(renders).toHaveLength(1);
+  });
 });

--- a/test/guardrail-generator/generator.test.ts
+++ b/test/guardrail-generator/generator.test.ts
@@ -837,3 +837,422 @@ describe("generateGuardrails patch merge (issue #13)", () => {
     expect(body).toEqual({ a: 1, b: 2 });
   });
 });
+
+function dslWithEntities(): Dsl {
+  return minimalDsl({
+    agents: {
+      implementer: {
+        role_name: "Implementer",
+        purpose: "Implement features",
+        "x-team": "alpha",
+      },
+      reviewer: {
+        role_name: "Reviewer",
+        purpose: "Review code",
+      },
+    },
+    tasks: {
+      "implement-feature": {
+        description: "Implement a feature",
+        target_agent: "implementer",
+        allowed_from_agents: ["reviewer"],
+        workflow: "dev",
+        input_artifacts: [],
+        invocation_handoff: "task-handoff",
+        result_handoff: "task-handoff",
+      },
+    },
+    artifacts: {
+      "source-code": {
+        type: "file",
+        description: "Source code files",
+        owner: "implementer",
+        producers: ["implementer"],
+        consumers: ["reviewer"],
+        editors: [],
+        states: ["draft", "final"],
+      },
+    },
+    handoff_types: {
+      "task-handoff": {
+        version: 1,
+        description: "Standard task handoff",
+        schema: { type: "object", properties: {} },
+      },
+    },
+    workflow: {
+      dev: {
+        description: "Development workflow",
+        steps: [],
+      },
+    },
+  });
+}
+
+describe("DSL entities in binding output context", () => {
+  it("exposes tasks in inline_template via {{#each tasks}}", async () => {
+    const configDir = await newConfigDir();
+    const dsl = dslWithEntities();
+    const config = baseResolvedConfig(configDir);
+    const lb = bindingWithOutputs(configDir, "app", {
+      out: {
+        target: "{hooks}/tasks.txt",
+        inline_template: "{{#each tasks}}{{@key}}: {{this.description}}\n{{/each}}",
+      },
+    });
+
+    await generateGuardrails({ dsl, config, loadedBindings: [lb] });
+
+    const body = await readFile(join(configDir, "hooks", "tasks.txt"), "utf8");
+    expect(body).toContain("implement-feature: Implement a feature");
+  });
+
+  it("exposes agents in inline_template via {{#each agents}}", async () => {
+    const configDir = await newConfigDir();
+    const dsl = dslWithEntities();
+    const config = baseResolvedConfig(configDir);
+    const lb = bindingWithOutputs(configDir, "app", {
+      out: {
+        target: "{hooks}/agents.txt",
+        inline_template: "{{#each agents}}{{@key}}: {{this.role_name}}\n{{/each}}",
+      },
+    });
+
+    await generateGuardrails({ dsl, config, loadedBindings: [lb] });
+
+    const body = await readFile(join(configDir, "hooks", "agents.txt"), "utf8");
+    expect(body).toContain("implementer: Implementer");
+    expect(body).toContain("reviewer: Reviewer");
+  });
+
+  it("exposes artifacts, handoff_types, and workflow", async () => {
+    const configDir = await newConfigDir();
+    const dsl = dslWithEntities();
+    const config = baseResolvedConfig(configDir);
+    const lb = bindingWithOutputs(configDir, "app", {
+      out: {
+        target: "{hooks}/all.txt",
+        inline_template: [
+          "artifacts:{{#each artifacts}} {{@key}}{{/each}}",
+          "handoffs:{{#each handoff_types}} {{@key}}{{/each}}",
+          "workflows:{{#each workflow}} {{@key}}{{/each}}",
+        ].join("\n"),
+      },
+    });
+
+    await generateGuardrails({ dsl, config, loadedBindings: [lb] });
+
+    const body = await readFile(join(configDir, "hooks", "all.txt"), "utf8");
+    expect(body).toContain("artifacts: source-code");
+    expect(body).toContain("handoffs: task-handoff");
+    expect(body).toContain("workflows: dev");
+  });
+
+  it("exposes passthrough (x-*) fields on agents", async () => {
+    const configDir = await newConfigDir();
+    const dsl = dslWithEntities();
+    const config = baseResolvedConfig(configDir);
+    const lb = bindingWithOutputs(configDir, "app", {
+      out: {
+        target: "{hooks}/ext.txt",
+        inline_template: "team={{agents.implementer.x-team}}",
+      },
+    });
+
+    await generateGuardrails({ dsl, config, loadedBindings: [lb] });
+
+    const body = await readFile(join(configDir, "hooks", "ext.txt"), "utf8");
+    expect(body).toBe("team=alpha");
+  });
+});
+
+function bindingWithRenders(
+  configDir: string,
+  software: string,
+  renders: NonNullable<SoftwareBinding["renders"]>,
+  extras: Partial<SoftwareBinding> = {},
+): LoadedBinding {
+  return loadedBinding(configDir, software, {
+    software,
+    version: 1,
+    guardrail_impl: {
+      gr1: { checks: [{ message: "check-a" }] },
+    },
+    renders,
+    ...extras,
+  });
+}
+
+describe("binding renders", () => {
+  it("renders system context with inline_template", async () => {
+    const configDir = await newConfigDir();
+    const dsl = dslWithEntities();
+    const config = baseResolvedConfig(configDir, {
+      paths: { out: join(configDir, "gen") },
+    });
+    const lb = bindingWithRenders(configDir, "app", [
+      {
+        context: "system" as const,
+        output: "{out}/sys.txt",
+        inline_template: "name={{system.name}}",
+      },
+    ]);
+
+    const result = await generateGuardrails({ dsl, config, loadedBindings: [lb] });
+
+    expect(result.diagnostics.filter((d) => d.severity === "error")).toEqual([]);
+    expect(result.outputFiles).toEqual([join(configDir, "gen", "sys.txt")]);
+    const body = await readFile(join(configDir, "gen", "sys.txt"), "utf8");
+    expect(body).toBe("name=System");
+  });
+
+  it("renders agent context with entity iteration", async () => {
+    const configDir = await newConfigDir();
+    const dsl = dslWithEntities();
+    const config = baseResolvedConfig(configDir, {
+      paths: { out: join(configDir, "gen") },
+    });
+    const lb = bindingWithRenders(configDir, "app", [
+      {
+        context: "agent" as const,
+        output: "{out}/{agent.id}.md",
+        inline_template: "# {{agent.role_name}}\n{{agent.purpose}}",
+      },
+    ]);
+
+    const result = await generateGuardrails({ dsl, config, loadedBindings: [lb] });
+
+    expect(result.diagnostics.filter((d) => d.severity === "error")).toEqual([]);
+    expect(result.outputFiles).toHaveLength(2);
+
+    const impl = await readFile(join(configDir, "gen", "implementer.md"), "utf8");
+    expect(impl).toBe("# Implementer\nImplement features");
+    const rev = await readFile(join(configDir, "gen", "reviewer.md"), "utf8");
+    expect(rev).toBe("# Reviewer\nReview code");
+  });
+
+  it("supports include filter on entity renders", async () => {
+    const configDir = await newConfigDir();
+    const dsl = dslWithEntities();
+    const config = baseResolvedConfig(configDir, {
+      paths: { out: join(configDir, "gen") },
+    });
+    const lb = bindingWithRenders(configDir, "app", [
+      {
+        context: "agent" as const,
+        output: "{out}/{agent.id}.md",
+        inline_template: "{{agent.role_name}}",
+        include: ["implementer"],
+      },
+    ]);
+
+    const result = await generateGuardrails({ dsl, config, loadedBindings: [lb] });
+
+    expect(result.outputFiles).toHaveLength(1);
+    expect(result.outputFiles[0]).toContain("implementer.md");
+  });
+
+  it("supports exclude filter on entity renders", async () => {
+    const configDir = await newConfigDir();
+    const dsl = dslWithEntities();
+    const config = baseResolvedConfig(configDir, {
+      paths: { out: join(configDir, "gen") },
+    });
+    const lb = bindingWithRenders(configDir, "app", [
+      {
+        context: "agent" as const,
+        output: "{out}/{agent.id}.md",
+        inline_template: "{{agent.role_name}}",
+        exclude: ["reviewer"],
+      },
+    ]);
+
+    const result = await generateGuardrails({ dsl, config, loadedBindings: [lb] });
+
+    expect(result.outputFiles).toHaveLength(1);
+    expect(result.outputFiles[0]).toContain("implementer.md");
+  });
+
+  it("renders with external template file", async () => {
+    const configDir = await newConfigDir();
+    const dsl = dslWithEntities();
+    const tplDir = join(configDir, "templates");
+    await mkdir(tplDir, { recursive: true });
+    await writeFile(join(tplDir, "agent.hbs"), "Role: {{agent.role_name}}");
+
+    const config = baseResolvedConfig(configDir, {
+      paths: { out: join(configDir, "gen") },
+    });
+    const lb = bindingWithRenders(configDir, "app", [
+      {
+        context: "agent" as const,
+        output: "{out}/{agent.id}.md",
+        template: "templates/agent.hbs",
+      },
+    ]);
+
+    const result = await generateGuardrails({ dsl, config, loadedBindings: [lb] });
+
+    expect(result.diagnostics.filter((d) => d.severity === "error")).toEqual([]);
+    const body = await readFile(join(configDir, "gen", "implementer.md"), "utf8");
+    expect(body).toBe("Role: Implementer");
+  });
+
+  it("skips empty renders when skip_empty is true", async () => {
+    const configDir = await newConfigDir();
+    const dsl = dslWithEntities();
+    const config = baseResolvedConfig(configDir, {
+      paths: { out: join(configDir, "gen") },
+    });
+    const lb = bindingWithRenders(configDir, "app", [
+      {
+        context: "system" as const,
+        output: "{out}/maybe.txt",
+        inline_template: "",
+        skip_empty: true,
+      },
+    ]);
+
+    const result = await generateGuardrails({ dsl, config, loadedBindings: [lb] });
+
+    expect(result.outputFiles).toEqual([]);
+  });
+
+  it("makes file executable when executable is true", async () => {
+    const configDir = await newConfigDir();
+    const dsl = dslWithEntities();
+    const config = baseResolvedConfig(configDir, {
+      paths: { out: join(configDir, "gen") },
+    });
+    const lb = bindingWithRenders(configDir, "app", [
+      {
+        context: "system" as const,
+        output: "{out}/run.sh",
+        inline_template: "#!/bin/bash\necho hi",
+        executable: true,
+      },
+    ]);
+
+    await generateGuardrails({ dsl, config, loadedBindings: [lb] });
+
+    const st = await stat(join(configDir, "gen", "run.sh"));
+    expect(st.mode & 0o755).toBe(0o755);
+  });
+
+  it("exposes vars and paths in binding render context", async () => {
+    const configDir = await newConfigDir();
+    const dsl = dslWithEntities();
+    const config = baseResolvedConfig(configDir, {
+      vars: { env: "production" },
+      paths: { out: join(configDir, "gen") },
+    });
+    const lb = bindingWithRenders(configDir, "app", [
+      {
+        context: "system" as const,
+        output: "{out}/info.txt",
+        inline_template: "env={{vars.env}}",
+      },
+    ]);
+
+    await generateGuardrails({ dsl, config, loadedBindings: [lb] });
+
+    const body = await readFile(join(configDir, "gen", "info.txt"), "utf8");
+    expect(body).toBe("env=production");
+  });
+
+  it("returns error when template file not found", async () => {
+    const configDir = await newConfigDir();
+    const dsl = dslWithEntities();
+    const config = baseResolvedConfig(configDir, {
+      paths: { out: join(configDir, "gen") },
+    });
+    const lb = bindingWithRenders(configDir, "app", [
+      {
+        context: "system" as const,
+        output: "{out}/x.txt",
+        template: "nonexistent.hbs",
+      },
+    ]);
+
+    const result = await generateGuardrails({ dsl, config, loadedBindings: [lb] });
+
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        path: "binding.app.renders",
+        severity: "error",
+        message: expect.stringContaining("Template file not found"),
+      }),
+    );
+  });
+
+  it("processes binding with only renders (no outputs)", async () => {
+    const configDir = await newConfigDir();
+    const dsl = dslWithEntities();
+    const config = baseResolvedConfig(configDir, {
+      paths: { out: join(configDir, "gen") },
+    });
+    const lb = loadedBinding(configDir, "render-only", {
+      software: "render-only",
+      version: 1,
+      guardrail_impl: {
+        gr1: { checks: [{ message: "check" }] },
+      },
+      renders: [
+        {
+          context: "system" as const,
+          output: "{out}/hello.txt",
+          inline_template: "hello",
+        },
+      ],
+    });
+
+    const result = await generateGuardrails({ dsl, config, loadedBindings: [lb] });
+
+    expect(result.diagnostics.filter((d) => d.severity === "error")).toEqual([]);
+    expect(result.outputFiles).toEqual([join(configDir, "gen", "hello.txt")]);
+    const body = await readFile(join(configDir, "gen", "hello.txt"), "utf8");
+    expect(body).toBe("hello");
+  });
+
+  it("renders task context with entity iteration", async () => {
+    const configDir = await newConfigDir();
+    const dsl = dslWithEntities();
+    const config = baseResolvedConfig(configDir, {
+      paths: { out: join(configDir, "gen") },
+    });
+    const lb = bindingWithRenders(configDir, "app", [
+      {
+        context: "task" as const,
+        output: "{out}/{task.id}.txt",
+        inline_template: "{{task.description}} -> {{task.target_agent}}",
+      },
+    ]);
+
+    const result = await generateGuardrails({ dsl, config, loadedBindings: [lb] });
+
+    expect(result.outputFiles).toHaveLength(1);
+    const body = await readFile(join(configDir, "gen", "implement-feature.txt"), "utf8");
+    expect(body).toBe("Implement a feature -> implementer");
+  });
+
+  it("renders workflow context with entity iteration", async () => {
+    const configDir = await newConfigDir();
+    const dsl = dslWithEntities();
+    const config = baseResolvedConfig(configDir, {
+      paths: { out: join(configDir, "gen") },
+    });
+    const lb = bindingWithRenders(configDir, "app", [
+      {
+        context: "workflow" as const,
+        output: "{out}/{workflow.id}.txt",
+        inline_template: "{{workflow.description}}",
+      },
+    ]);
+
+    const result = await generateGuardrails({ dsl, config, loadedBindings: [lb] });
+
+    expect(result.outputFiles).toHaveLength(1);
+    const body = await readFile(join(configDir, "gen", "dev.txt"), "utf8");
+    expect(body).toBe("Development workflow");
+  });
+});

--- a/test/schema/guardrail.test.ts
+++ b/test/schema/guardrail.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   BindingOutputSchema,
+  BindingRenderTargetSchema,
   CheckSchema,
   GuardrailPolicyRuleEscalationSchema,
   GuardrailPolicyRuleSchema,
@@ -547,5 +548,116 @@ describe("SoftwareBindingSchema", () => {
       "x-binding-meta": "extra",
     });
     expect((b as Record<string, unknown>)["x-binding-meta"]).toBe("extra");
+  });
+
+  it("accepts renders array in binding", () => {
+    const b = SoftwareBindingSchema.parse({
+      software: "cursor",
+      version: 1,
+      renders: [
+        {
+          context: "agent",
+          output: "{cursor_root}/{agent.id}.md",
+          inline_template: "# {{agent.role_name}}",
+        },
+        {
+          context: "system",
+          output: "sys.md",
+          template: "./templates/sys.hbs",
+        },
+      ],
+    });
+    expect(b.renders).toHaveLength(2);
+    expect(b.renders![0].context).toBe("agent");
+    expect(b.renders![1].context).toBe("system");
+  });
+
+  it("accepts binding with no renders", () => {
+    const b = SoftwareBindingSchema.parse({
+      software: "s",
+      version: 1,
+    });
+    expect(b.renders).toBeUndefined();
+  });
+});
+
+describe("BindingRenderTargetSchema", () => {
+  it("parses valid render target with inline_template", () => {
+    const r = BindingRenderTargetSchema.parse({
+      context: "agent",
+      output: "{out}/{agent.id}.md",
+      inline_template: "# {{agent.role_name}}",
+    });
+    expect(r.context).toBe("agent");
+    expect(r.inline_template).toContain("role_name");
+  });
+
+  it("parses valid render target with template file", () => {
+    const r = BindingRenderTargetSchema.parse({
+      context: "system",
+      output: "out.md",
+      template: "./templates/sys.hbs",
+    });
+    expect(r.template).toBe("./templates/sys.hbs");
+  });
+
+  it("rejects when both template and inline_template are set", () => {
+    const r = BindingRenderTargetSchema.safeParse({
+      context: "system",
+      output: "out.md",
+      template: "t.hbs",
+      inline_template: "x",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects when neither template nor inline_template is set", () => {
+    const r = BindingRenderTargetSchema.safeParse({
+      context: "system",
+      output: "out.md",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects when both include and exclude are set", () => {
+    const r = BindingRenderTargetSchema.safeParse({
+      context: "agent",
+      output: "{agent.id}.md",
+      inline_template: "x",
+      include: ["a"],
+      exclude: ["b"],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects include/exclude with system context", () => {
+    const r = BindingRenderTargetSchema.safeParse({
+      context: "system",
+      output: "out.md",
+      inline_template: "x",
+      include: ["a"],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts all valid context types", () => {
+    for (const ctx of ["agent", "task", "artifact", "tool", "workflow", "system"]) {
+      const r = BindingRenderTargetSchema.safeParse({
+        context: ctx,
+        output: "out.md",
+        inline_template: "x",
+      });
+      expect(r.success).toBe(true);
+    }
+  });
+
+  it("allows passthrough fields", () => {
+    const r = BindingRenderTargetSchema.parse({
+      context: "system",
+      output: "out.md",
+      inline_template: "x",
+      "x-custom": "meta",
+    });
+    expect((r as Record<string, unknown>)["x-custom"]).toBe("meta");
   });
 });


### PR DESCRIPTION
## Summary

- **Rename** `GuardrailGenerationContext` → `BindingGenerationContext` (deprecated alias preserved for backward compatibility)
- **Add DSL entity maps** (`tasks`, `artifacts`, `agents`, `handoff_types`, `workflow`) to the binding generation template context, enabling `{{#each tasks}}`, `{{#each agents}}`, etc. in binding `outputs` templates
- **Add `renders:` section** to `SoftwareBindingSchema` — entity-iteration rendering (same as config-level `renders`) now available directly in binding YAML files, with support for `context`, `include`/`exclude`, `skip_empty`, `executable`, and dual path variable expansion (`{entity.id}` + `{paths_var}`)
- **Extract** `ContextTypeSchema` to shared module (`src/schema/context-type.ts`) to avoid circular dependencies
- **Export** `buildEntityContext`, `getDslSection`, `filterIds`, `expandOutputPath` from renderer for reuse
- **Support** array concatenation merge for `renders` in binding `extends`
- **Make** config-level `renders` optional (`default([])`) so projects can use binding renders exclusively
- **Bump** version to 0.14.0

## Test plan

- [x] 29 new tests added (631 total, all passing)
- [x] DSL entity access in binding output templates (`{{#each tasks}}`, `{{#each agents}}`, passthrough `x-*` fields)
- [x] Binding renders: system context, entity iteration, include/exclude filters, external templates, skip_empty, executable, vars/paths access, error handling, renders-only binding
- [x] BindingRenderTargetSchema validation (mutual exclusion, context constraints, passthrough)
- [x] Binding merger renders array concatenation
- [x] All 602 pre-existing tests continue to pass (no regressions)
- [x] TypeScript compilation clean

Closes #28

Made with [Cursor](https://cursor.com)