### PR TITLE
feat: add dsl_base and agent sections property

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ An **Agent** defines who an execution entity is:
 * permissions
 * constraints
 * behavioral rules
+* structured content sections (reference material, procedures, criteria)
 
 ### Task
 
@@ -317,6 +318,7 @@ Design regressions become testable.
 ## Features
 
 * **Declarative YAML DSL** for multi-agent development workflows
+* **Agent `sections`** for embedding structured reference material, procedures, and criteria directly in agent definitions
 * **Static schema validation**
 * **Reference integrity checks**
 * **Semantic linting**
@@ -574,9 +576,11 @@ agents:
     constraints:
       - "Never write code directly"
 
-    x-identity: |
-      You act as the Architect. You NEVER implement or test directly.
-      Instead you delegate to specialist sub-agents.
+    sections:
+      - title: "Delegation Protocol"
+        content: |
+          You act as the Architect. You NEVER implement or test directly.
+          Instead you delegate to specialist sub-agents.
 ````
 
 ---

--- a/dsl_base/agent-contracts.yaml
+++ b/dsl_base/agent-contracts.yaml
@@ -1,0 +1,15 @@
+version: 1
+system:
+  id: dsl-management-base
+  name: DSL Management Base
+  default_workflow_order:
+    - dsl-update
+    - dsl-audit
+
+agents: { $ref: "./agents/" }
+tasks: { $ref: "./tasks.yaml" }
+artifacts: { $ref: "./artifacts.yaml" }
+tools: { $ref: "./tools.yaml" }
+validations: { $ref: "./validations.yaml" }
+handoff_types: { $ref: "./handoff-types.yaml" }
+workflow: { $ref: "./workflow.yaml" }

--- a/dsl_base/agents/dsl-auditor.yaml
+++ b/dsl_base/agents/dsl-auditor.yaml
@@ -47,16 +47,7 @@ dsl-auditor:
       action: stop_and_report
     - condition: Structural defect detected in templates
       action: stop_and_report
-  x-authority:
-    can_decide:
-      - gap_classification
-      - improvement_priority
-      - fix_recommendation
-    cannot_decide:
-      - dsl_structure_change
-      - template_modification
-      - agent_permission_change
-  x-sections:
+  sections:
     - title: "Audit Procedure"
       content: |
         **Phase 1: Source Collection**

--- a/dsl_base/agents/dsl-auditor.yaml
+++ b/dsl_base/agents/dsl-auditor.yaml
@@ -1,0 +1,116 @@
+dsl-auditor:
+  role_name: DSL Auditor
+  purpose: >-
+    Audit completeness of agent-contracts DSL definitions against generated
+    agent prompts, detect gaps, and present improvement recommendations.
+  mode: read-write
+  can_read_artifacts:
+    - dsl-source
+    - dsl-generated-output
+    - dsl-audit-report
+    - dsl-score-report
+  can_write_artifacts:
+    - dsl-audit-report
+  can_invoke_agents:
+    - dsl-auditor
+  can_execute_tools:
+    - agent-contracts-cli
+  can_perform_validations:
+    - dsl-completeness-audit
+  can_return_handoffs:
+    - dsl-audit-result
+  responsibilities:
+    - Cross-check DSL definitions against generated prompts across 19 dimensions
+    - Classify detected gaps as template gap, data gap, or DSL gap
+    - Prioritize improvement recommendations (P0/P1/P2) with concrete fix proposals
+    - Identify improvement areas based on score results
+  constraints:
+    - Do not directly modify DSL definitions (read-only analysis)
+    - Recommendations must include concrete YAML or template fix proposals
+    - Findings must be classified as PASS / MISS / PARTIAL / N/A
+  rules:
+    - id: R-AUDIT-001
+      description: >-
+        Audit must cover all 19 dimensions: purpose, mode, can_read_artifacts,
+        can_write_artifacts, can_invoke_agents, tools, can_perform_validations,
+        responsibilities, constraints, rules, escalation_criteria, x-authority,
+        supported_tasks, delegatable_tasks, handoff_schemas, guardrails,
+        anti_patterns, x-audit-checklist, x-sections.
+      severity: mandatory
+    - id: R-AUDIT-002
+      description: >-
+        When a MISS is detected, classify the root cause as one of:
+        template gap, data gap, or DSL gap.
+      severity: mandatory
+  escalation_criteria:
+    - condition: 3 or more critical-level gaps detected
+      action: stop_and_report
+    - condition: Structural defect detected in templates
+      action: stop_and_report
+  x-authority:
+    can_decide:
+      - gap_classification
+      - improvement_priority
+      - fix_recommendation
+    cannot_decide:
+      - dsl_structure_change
+      - template_modification
+      - agent_permission_change
+  x-sections:
+    - title: "Audit Procedure"
+      content: |
+        **Phase 1: Source Collection**
+        - Read all agent definitions from `agent-contracts/dsl/agents/*.yaml`
+        - Read all generated prompts from the rendering output directory
+        - Read the agent prompt template (`.hbs`)
+
+        **Phase 2: Cross-check (19 Dimensions)**
+
+        | # | Dimension | Importance |
+        |---|-----------|------------|
+        | 1 | purpose | high |
+        | 2 | mode | high |
+        | 3 | can_read_artifacts | high |
+        | 4 | can_write_artifacts + required_validations | **critical** |
+        | 5 | can_invoke_agents | high |
+        | 6 | tools (can_execute_tools → tools.yaml) | medium |
+        | 7 | can_perform_validations | high |
+        | 8 | responsibilities | high |
+        | 9 | constraints | high |
+        | 10 | rules (id, severity, description) | high |
+        | 11 | escalation_criteria | high |
+        | 12 | x-authority (can_decide / cannot_decide) | **critical** |
+        | 13 | supported_tasks | high |
+        | 14 | delegatable_tasks | high |
+        | 15 | handoff_schemas (allOf $ref resolved) | **critical** |
+        | 16 | guardrails | high |
+        | 17 | anti_patterns | low |
+        | 18 | x-audit-checklist | medium |
+        | 19 | x-sections | medium |
+
+        **Phase 3: Template Root-Cause Analysis**
+        - Template gap: rendering logic does not exist for the dimension
+        - Data gap: logic exists but the CLI does not pass the data
+        - DSL gap: YAML definition is incomplete or missing
+
+        **Phase 4: Recommendations**
+        - Template fix proposals (additional `.hbs` sections)
+        - DSL fix proposals (YAML corrections)
+        - Regeneration instructions (`npx agent-contracts render`)
+
+    - title: "Verdict Criteria"
+      content: |
+        | Verdict | Meaning |
+        |---------|---------|
+        | PASS | DSL definition is accurately reflected in generated output |
+        | MISS | DSL definition exists but is not reflected in generated output |
+        | PARTIAL | Only partially reflected (e.g. some list items missing) |
+        | N/A | DSL definition is empty array or undefined; inspection not required |
+
+        Severity classification:
+
+        | Severity | Description |
+        |----------|-------------|
+        | critical | Gap directly impacts governance decisions (authority, write permissions) |
+        | warning | Gap affects task quality (validations, tool details) |
+        | info | Observation about information redundancy |

--- a/dsl_base/agents/dsl-designer.yaml
+++ b/dsl_base/agents/dsl-designer.yaml
@@ -1,0 +1,416 @@
+dsl-designer:
+  role_name: DSL Designer
+  purpose: >-
+    Design, create, and update agent-contracts DSL definitions and bindings.
+    Verify quality using validate, lint, render, and score commands.
+    Holds specification knowledge of DSL structure, schemas, merge operators,
+    and variable substitution.
+  mode: read-write
+  can_read_artifacts:
+    - dsl-source
+    - dsl-generated-output
+    - dsl-score-report
+    - dsl-audit-report
+  can_write_artifacts:
+    - dsl-source
+    - dsl-generated-output
+    - dsl-score-report
+  can_invoke_agents:
+    - dsl-designer
+  can_execute_tools:
+    - agent-contracts-cli
+  can_perform_validations:
+    - dsl-schema-validation
+    - dsl-lint-validation
+    - dsl-score-validation
+  can_return_handoffs:
+    - dsl-task-result
+  responsibilities:
+    - Create new and update existing agent-contracts DSL (YAML) definitions
+    - Design all sections — agents, tasks, artifacts, tools, validations, handoff_types, workflow, policies, guardrails, guardrail_policies
+    - Add and update software bindings
+    - Correctly use extends-based DSL inheritance and merge operators
+    - Verify quality via agent-contracts validate / lint / render / score
+    - Improve score across 7 dimensions (artifact validation coverage, task validation coverage, guardrail policy coverage, workflow validation integration, schema completeness, cross-reference bidirectionality, guardrail scope resolution)
+  constraints:
+    - DSL definitions must pass agent-contracts validate
+    - Do not break existing extends inheritance chains
+    - Do not directly edit generated files — always modify DSL source and re-render
+    - handoff_types schemas must be JSON Schema compliant with correct allOf $ref usage
+  rules:
+    - id: R-DSL-001
+      description: >-
+        After any DSL change, verify in order: validate → lint → render --check → score.
+      severity: mandatory
+    - id: R-DSL-002
+      description: >-
+        When adding a new agent, explicitly define all permission fields:
+        can_read_artifacts, can_write_artifacts, can_invoke_agents,
+        can_execute_tools, can_perform_validations.
+      severity: mandatory
+    - id: R-DSL-003
+      description: >-
+        When adding a new task, define all required fields: target_agent,
+        allowed_from_agents, workflow, input_artifacts, invocation_handoff,
+        result_handoff, validations, responsibilities, completion_criteria,
+        execution_steps.
+      severity: mandatory
+    - id: R-DSL-004
+      description: >-
+        When adding a guardrail, also add a corresponding enforcement rule
+        in guardrail_policies and define check implementation in the binding's
+        guardrail_impl.
+      severity: mandatory
+    - id: R-DSL-005
+      description: >-
+        Binding outputs should use path variables from agent-contracts.config.yaml
+        (e.g. {cursor_root}, {check_scripts_root}).
+      severity: recommended
+  escalation_criteria:
+    - condition: Schema errors from validate cannot be resolved
+      action: stop_and_report
+    - condition: Unintended override occurring during extends merge
+      action: stop_and_report
+    - condition: Score below 70% with no clear improvement path
+      action: stop_and_report
+  x-authority:
+    can_decide:
+      - dsl_structure_design
+      - agent_permission_assignment
+      - task_workflow_mapping
+      - guardrail_scope_definition
+      - binding_implementation
+    cannot_decide:
+      - business_priority
+      - domain_term_meaning
+      - product_requirements
+  x-sections:
+    - title: "agent-contracts DSL Specification Reference"
+      content: |
+        ### Top-Level Structure
+
+        ```yaml
+        version: 1                     # Required. Always 1
+        extends: "./base/"             # Optional. Base DSL path (directory or file)
+        system:
+          id: string                   # Project ID (required)
+          name: string                 # Display name (required)
+          default_workflow_order: []   # Workflow execution order
+        agents: {}                     # Agent definition map (ID → definition)
+        tasks: {}                      # Task definition map
+        artifacts: {}                  # Artifact definition map
+        tools: {}                      # Tool definition map
+        validations: {}                # Validation definition map
+        handoff_types: {}              # Handoff type definition map
+        workflow: {}                   # Workflow definition map
+        policies: {}                   # Policy definition map
+        guardrails: {}                 # Guardrail definition map
+        guardrail_policies: {}         # Guardrail policy definition map
+        components:
+          schemas: {}                  # Shared schemas (for handoff_types allOf $ref)
+        ```
+
+        Multi-file format uses `$ref` per section:
+
+        ```yaml
+        agents: { $ref: "./agents/" }        # Directory $ref (auto-loads *.yaml)
+        tasks: { $ref: "./tasks.yaml" }      # File $ref
+        ```
+
+        ### Agent Schema
+
+        ```yaml
+        <agent-id>:
+          role_name: string            # Display name (required)
+          purpose: string              # Agent purpose (required)
+          mode: read-write | read-only # Operation mode (default: read-write)
+          dispatch_only: boolean       # true = dispatch only, no implementation (default: false)
+          can_read_artifacts: []       # Readable artifact ID list
+          can_write_artifacts: []      # Writable artifact ID list
+          can_execute_tools: []        # Executable tool ID list
+          can_perform_validations: []  # Executable validation ID list
+          can_invoke_agents: []        # Invocable agent ID list
+          can_return_handoffs: []      # Returnable handoff_type ID list
+          responsibilities: []         # Responsibility list (string array)
+          constraints: []              # Constraint list (string array)
+          rules:                       # Rule list
+            - id: string               #   Rule ID (R-XXX-NNN format recommended)
+              description: string      #   Rule description
+              severity: mandatory | recommended | optional
+          anti_patterns: []            # Anti-pattern list (string array)
+          escalation_criteria:         # Escalation conditions
+            - condition: string
+              action: stop_and_report | report_to_architect
+        ```
+
+        ### Task Schema
+
+        ```yaml
+        <task-id>:
+          description: string          # Task description (required)
+          target_agent: string         # Executing agent ID (required)
+          allowed_from_agents: []      # Delegating agent ID list (required)
+          workflow: string             # Parent workflow ID (required)
+          input_artifacts: []          # Input artifact ID list
+          invocation_handoff: string   # Invocation handoff_type ID
+          result_handoff: string       # Result handoff_type ID
+          validations: []              # Validation ID list to execute
+          responsibilities: []         # Task-specific responsibility list
+          completion_criteria: []      # Completion criteria list
+          execution_steps:             # Execution steps (ordered list)
+            - id: string               #   Step ID
+              action: string           #   Action description
+              reads_artifact: string   #   Artifact ID to read
+              produces_artifact: string#   Artifact ID to produce
+              uses_tool: string        #   Tool ID to use
+              required: boolean        #   Whether step is mandatory
+          escalation_criteria:
+            - condition: string
+              action: string
+        ```
+
+        ### Artifact Schema
+
+        ```yaml
+        <artifact-id>:
+          type: doc | schema | code | config | html
+          description: string          # Description (required)
+          owner: string                # Owner agent ID (required)
+          producers: []                # Producer agent ID list
+          editors: []                  # Editor agent ID list
+          consumers: []                # Consumer agent ID list
+          states: []                   # Lifecycle states
+          required_validations: []     # Required validation ID list
+          visibility: project | team | external
+        ```
+
+        ### Tool Schema
+
+        ```yaml
+        <tool-id>:
+          kind: cli | api | mcp        # Tool kind (required)
+          description: string          # Description (required)
+          input_artifacts: []          # Input artifact ID list
+          output_artifacts: []         # Output artifact ID list
+          invokable_by: []             # Agent ID list that can invoke
+          side_effects: []             # Side effect list
+          commands:                    # Command definitions
+            - command: string          #   Command string
+              category: verification | pre-analysis | generation
+              reads: []                #   Artifact ID list to read
+              writes: []               #   Artifact ID list to write
+              purpose: string          #   Command purpose
+        ```
+
+        ### Validation Schema
+
+        ```yaml
+        <validation-id>:
+          target_artifact: string      # Target artifact ID (required)
+          kind: schema | semantic | traceability | mechanical
+          executor_type: agent | tool  # Executor type (required)
+          executor: string             # Executor agent/tool ID (required)
+          blocking: boolean            # true = blocking (default: false)
+          produces_evidence: string    # Evidence artifact ID
+        ```
+
+        ### Handoff Type Schema
+
+        ```yaml
+        <handoff-type-id>:
+          version: integer             # Version (required)
+          description: string          # Description (required)
+          schema:                      # JSON Schema (required)
+            allOf:                     # Common schema ref + specific fields
+              - $ref: "#/components/schemas/<base-schema>"
+              - type: object
+                properties: {}
+                required: []
+            # Direct definition without allOf is also valid
+            type: object
+            properties: {}
+            required: []
+          example: {}                  # Example in YAML format
+        ```
+
+        ### Workflow Schema
+
+        ```yaml
+        <workflow-id>:
+          description: string          # Description (required)
+          entry_conditions: []         # Entry conditions
+          trigger: string              # Trigger description
+          steps:                       # Step definitions
+            - type: delegate           # Task delegation step
+              task: string             #   Task ID
+              from_agent: string       #   Delegating agent ID
+              description: string
+            - type: gate               # Gate step
+              gate_kind: string        #   Gate kind (e.g. audit-result)
+              description: string
+            - type: decision           # Decision branch step
+              on: string               #   Decision target (e.g. audit-result.verdict)
+              description: string
+              branches: {}             #   Branch target map
+        ```
+
+        ### Guardrail Schema
+
+        ```yaml
+        <guardrail-id>:
+          description: string          # Description (required)
+          scope:                       # Application scope
+            artifacts: []
+            workflows: []
+            agents: []
+            tasks: []
+            tools: []
+          rationale: string            # Rationale
+          tags: []                     # Tags (for classification)
+        ```
+
+        ### Guardrail Policy Schema
+
+        ```yaml
+        <policy-id>:
+          description: string          # Description (required)
+          rules:                       # Enforcement rules
+            - guardrail: string        #   Guardrail ID (required)
+              severity: critical | mandatory | warning | info
+              action: block | warn | shadow | info
+              allow_override: boolean  #   Allow override
+              override_requires: []    #   Override requirements (e.g. rationale)
+        ```
+
+        ### Config Schema (agent-contracts.config.yaml)
+
+        ```yaml
+        dsl: string                    # DSL entry point path (required)
+        bindings: []                   # Binding file path list
+        active_guardrail_policy: string  # Active policy ID
+        paths:                         # Path variables (used as {key} in binding outputs)
+          <key>: string
+        vars:                          # Value substitution variables (referenced as ${vars.key} in DSL)
+          <key>: string
+        renders:                       # Rendering definitions
+          - template: string           #   Handlebars template path
+            context: system | agent | task | artifact | tool | validation | handoff_type | workflow | policy | guardrail | guardrail_policy
+            output: string             #   Output path ({<context>.id} placeholder available)
+            include: []                #   Target entity IDs (include/exclude are mutually exclusive)
+            exclude: []                #   Excluded entity IDs
+            skip_empty: boolean        #   Skip file generation on empty output
+        ```
+
+    - title: "Merge Operator Reference"
+      content: |
+        Override base DSL inherited via extends using the following merge operators:
+
+        | Operator | Behavior | Target |
+        |----------|----------|--------|
+        | `$append` | Append to end | map / array |
+        | `$prepend` | Prepend to start | map / array |
+        | `$insert_after` | Insert after specified element | array (identified by id field) |
+        | `$replace` | Replace entire value | any |
+        | `$remove` | Remove by key/ID | map / array |
+        | direct value | Override scalar field | scalar |
+
+        Maps (agents, tasks, etc.) are automatically deep-merged.
+        Defining the same key in the project overrides the base;
+        adding a new key extends the base.
+
+        Arrays (responsibilities, constraints, etc.) are replaced by default
+        in the project. Use `$append` / `$prepend` to add to the base array.
+
+        Examples:
+
+        ```yaml
+        # Append a constraint to base implementer
+        agents:
+          implementer:
+            constraints:
+              $append:
+                - "New constraint appended"
+
+        # Insert a step after a specific step in base task
+        tasks:
+          implement-feature:
+            execution_steps:
+              $insert_after:
+                target: run-db-lint
+                items:
+                  - id: run-contract-pipeline
+                    action: "Run contract pipeline"
+
+        # Remove an agent from base
+        agents:
+          $remove:
+            - legacy-agent
+        ```
+
+        Processing order: load → extends merge → vars substitution → schema validation
+
+    - title: "CLI Command Reference"
+      content: |
+        | Command | Description |
+        |---------|-------------|
+        | `npx agent-contracts resolve` | Output extends-resolved YAML |
+        | `npx agent-contracts resolve --expand-defaults` | Output with Zod default values expanded |
+        | `npx agent-contracts validate` | Schema validation and reference checks |
+        | `npx agent-contracts lint` | Semantic lint (--strict treats warnings as errors) |
+        | `npx agent-contracts render -c <config>` | Template rendering |
+        | `npx agent-contracts render -c <config> --check` | Drift detection (for CI) |
+        | `npx agent-contracts score` | Completeness score (7 dimensions) |
+        | `npx agent-contracts score --threshold 70` | Exit 1 if below threshold (CI gate) |
+        | `npx agent-contracts check -c <config>` | Pipeline: resolve → validate → lint → render --check |
+        | `npx agent-contracts generate guardrails` | Generate guardrail runtime artifacts |
+
+        Common options for all commands:
+        - `-c, --config <path>`: Config file path (default: agent-contracts.config.yaml)
+        - `--format <text|json>`: Output format
+
+        ### Score 7 Dimensions
+
+        | Dimension | Measures | Weight |
+        |-----------|----------|--------|
+        | Artifact validation coverage | Ratio of artifacts with required_validations defined | High |
+        | Task validation coverage | Ratio of tasks with validations defined | High |
+        | Guardrail policy coverage | Ratio of guardrails referenced in guardrail_policies | Medium |
+        | Workflow validation integration | Ratio of blocking validations referenced in workflow/tasks | High |
+        | Schema completeness | Fill rate of optional fields (description, rationale, trigger, etc.) | Low |
+        | Cross-reference bidirectionality | Bidirectional reference rate between agent↔artifact, agent↔tool | Medium |
+        | Guardrail scope resolution | Existence check rate for entities in guardrail scopes | Medium |
+
+    - title: "Handlebars Template Helpers"
+      content: |
+        Built-in helpers available in templates:
+
+        | Helper | Usage | Description |
+        |--------|-------|-------------|
+        | `eq` | `{{#if (eq a b)}}` | Equality comparison |
+        | `notEmpty` | `{{#if (notEmpty obj)}}` | Check if object is non-empty |
+        | `inc` | `{{inc @index}}` | 1-based index |
+        | `yamlBlock` | `{{{yamlBlock obj}}}` | Render as YAML |
+        | `lookupPayloadFields` | `{{#each (lookupPayloadFields schema)}}` | Extract schema fields (resolves allOf) |
+        | `join` | `{{join arr ", "}}` | Join array |
+        | `contains` | `{{#if (contains arr "x")}}` | Array inclusion check |
+        | `groupBy` | `{{#with (groupBy arr "key")}}` | Group by field |
+        | `filterByField` | `{{#each (filterByField arr "field" "val")}}` | Filter by field |
+        | `keys` / `values` | `{{#each (keys obj)}}` | Object keys/values as array |
+        | `size` | `{{size obj}}` | Array length or object key count |
+        | `not` | `{{#if (not x)}}` | Negation |
+        | `or` / `and` | `{{#if (or a b)}}` | Logical operators (variadic) |
+        | `gt` / `gte` / `lt` | `{{#if (gt a b)}}` | Numeric comparison |
+        | `sequenceDiagram` | `{{{sequenceDiagram @key ../dsl}}}` | Generate Mermaid sequence diagram |
+        | `overviewFlowchart` | `{{{overviewFlowchart dsl}}}` | Generate Mermaid flowchart |
+
+        Rendering context (agent):
+        - `agent` — Agent definition
+        - `receivableTasks` — Receivable tasks
+        - `delegatableTasks` — Delegatable tasks
+        - `relatedArtifacts` — Related artifacts (R/W)
+        - `relatedTools` — Related tools
+        - `relatedHandoffTypes` — Related handoff types
+        - `mergedBehavior` — Merged behavior spec (responsibilities + task-level)
+        - `relatedGuardrails` — Related guardrails
+        - `relatedValidations` — Related validations
+        - `dsl` — Resolved DSL (full)

--- a/dsl_base/agents/dsl-designer.yaml
+++ b/dsl_base/agents/dsl-designer.yaml
@@ -73,18 +73,7 @@ dsl-designer:
       action: stop_and_report
     - condition: Score below 70% with no clear improvement path
       action: stop_and_report
-  x-authority:
-    can_decide:
-      - dsl_structure_design
-      - agent_permission_assignment
-      - task_workflow_mapping
-      - guardrail_scope_definition
-      - binding_implementation
-    cannot_decide:
-      - business_priority
-      - domain_term_meaning
-      - product_requirements
-  x-sections:
+  sections:
     - title: "agent-contracts DSL Specification Reference"
       content: |
         ### Top-Level Structure
@@ -141,6 +130,9 @@ dsl-designer:
           escalation_criteria:         # Escalation conditions
             - condition: string
               action: stop_and_report | report_to_architect
+          sections:                    # Structured content sections (rendered in prompts)
+            - title: string
+              content: string          #   Markdown text
         ```
 
         ### Task Schema

--- a/dsl_base/artifacts.yaml
+++ b/dsl_base/artifacts.yaml
@@ -1,0 +1,69 @@
+dsl-source:
+  type: config
+  description: >-
+    agent-contracts DSL source files — YAML definitions for agents, tasks,
+    artifacts, tools, validations, handoff_types, workflow, policies,
+    guardrails, guardrail_policies, and bindings.
+  owner: dsl-designer
+  producers:
+    - dsl-designer
+  editors:
+    - dsl-designer
+  consumers:
+    - dsl-auditor
+  states:
+    - draft
+    - validated
+    - rendered
+  required_validations:
+    - dsl-schema-validation
+    - dsl-lint-validation
+
+dsl-generated-output:
+  type: doc
+  description: >-
+    Files generated from DSL via render — agent prompts, overview documents,
+    workflow commands, guardrail configurations, etc.
+  owner: dsl-designer
+  producers:
+    - dsl-designer
+  editors:
+    - dsl-designer
+  consumers:
+    - dsl-auditor
+  states:
+    - generated
+    - verified
+  required_validations:
+    - dsl-completeness-audit
+
+dsl-score-report:
+  type: doc
+  description: >-
+    Output of agent-contracts score command — completeness evaluation
+    across 7 dimensions.
+  owner: dsl-designer
+  producers:
+    - dsl-designer
+  editors:
+    - dsl-designer
+  consumers:
+    - dsl-auditor
+  states:
+    - generated
+
+dsl-audit-report:
+  type: doc
+  description: >-
+    DSL completeness audit report — PASS/MISS matrix across 19 dimensions,
+    gap analysis, and improvement recommendations.
+  owner: dsl-auditor
+  producers:
+    - dsl-auditor
+  editors:
+    - dsl-auditor
+  consumers:
+    - dsl-designer
+  states:
+    - submitted
+  x-artifact-class: evidence

--- a/dsl_base/handoff-types.yaml
+++ b/dsl_base/handoff-types.yaml
@@ -1,0 +1,108 @@
+dsl-task-request:
+  version: 1
+  description: Request to execute a DSL management task
+  schema:
+    type: object
+    properties:
+      task_id:
+        type: string
+        description: Identifier of the task to execute
+      scope:
+        type: string
+        description: Scope of changes (agents, tasks, artifacts, workflow, bindings, etc.)
+      context:
+        type: string
+        description: Background and purpose of the change
+    required:
+      - task_id
+
+dsl-task-result:
+  version: 1
+  description: Result of a DSL management task execution
+  schema:
+    type: object
+    properties:
+      changed_files:
+        type: array
+        items:
+          type: string
+        description: List of changed file paths
+      validation_result:
+        type: string
+        enum:
+          - pass
+          - fail
+        description: Result of validate / lint
+      score:
+        type: number
+        description: Score command result (0-100)
+      notes:
+        type: string
+        description: Additional notes or improvement suggestions
+    required:
+      - validation_result
+
+dsl-audit-result:
+  version: 1
+  description: Result of DSL completeness audit
+  schema:
+    type: object
+    properties:
+      total_dimensions:
+        type: integer
+        description: Number of dimensions inspected
+      pass_count:
+        type: integer
+        description: Number of PASS dimensions
+      miss_count:
+        type: integer
+        description: Number of MISS dimensions
+      partial_count:
+        type: integer
+        description: Number of PARTIAL dimensions
+      critical_gaps:
+        type: array
+        items:
+          type: object
+          properties:
+            dimension:
+              type: string
+            agent:
+              type: string
+            gap_type:
+              type: string
+              enum:
+                - template_gap
+                - data_gap
+                - dsl_gap
+            severity:
+              type: string
+              enum:
+                - critical
+                - warning
+                - info
+        description: List of detected critical gaps
+      recommendations:
+        type: array
+        items:
+          type: object
+          properties:
+            priority:
+              type: string
+              enum:
+                - P0
+                - P1
+                - P2
+            description:
+              type: string
+            fix_type:
+              type: string
+              enum:
+                - template_fix
+                - dsl_fix
+                - regeneration
+        description: Prioritized improvement recommendation list
+    required:
+      - total_dimensions
+      - pass_count
+      - miss_count

--- a/dsl_base/tasks.yaml
+++ b/dsl_base/tasks.yaml
@@ -1,0 +1,179 @@
+# === DSL Update Tasks ===
+
+update-dsl-definitions:
+  description: Create new or update existing agent-contracts DSL definitions
+  target_agent: dsl-designer
+  allowed_from_agents:
+    - dsl-designer
+  workflow: dsl-update
+  input_artifacts:
+    - dsl-source
+  invocation_handoff: dsl-task-request
+  result_handoff: dsl-task-result
+  validations:
+    - dsl-schema-validation
+    - dsl-lint-validation
+  responsibilities:
+    - Create and update DSL YAML files
+    - Define agents, tasks, artifacts, tools, validations, handoff_types, workflow, guardrails
+    - Configure system section
+  completion_criteria:
+    - agent-contracts validate succeeds
+    - agent-contracts lint reports no errors
+    - Cross-references for newly added entities are correct
+  execution_steps:
+    - id: read-current-dsl
+      action: Read current DSL definitions and understand the structure
+      reads_artifact: dsl-source
+      required: true
+    - id: update-dsl
+      action: Create or update DSL definitions
+      produces_artifact: dsl-source
+    - id: validate
+      action: Run agent-contracts validate
+      uses_tool: agent-contracts-cli
+      required: true
+    - id: lint
+      action: Run agent-contracts lint
+      uses_tool: agent-contracts-cli
+  escalation_criteria:
+    - condition: Schema errors from validate cannot be resolved
+      action: stop_and_report
+
+update-dsl-binding:
+  description: Create new or update existing software bindings
+  target_agent: dsl-designer
+  allowed_from_agents:
+    - dsl-designer
+  workflow: dsl-update
+  input_artifacts:
+    - dsl-source
+  invocation_handoff: dsl-task-request
+  result_handoff: dsl-task-result
+  validations:
+    - dsl-schema-validation
+  responsibilities:
+    - Add and update guardrail_impl check definitions
+    - Configure outputs section templates and inline templates
+    - Set up binding extends inheritance
+  completion_criteria:
+    - Binding YAML conforms to the correct schema
+    - guardrail_impl hook_event / matcher values are valid
+    - agent-contracts generate guardrails succeeds
+  execution_steps:
+    - id: read-guardrails
+      action: Review target guardrail definitions and policies
+      reads_artifact: dsl-source
+      required: true
+    - id: update-binding
+      action: Create or update binding YAML
+      produces_artifact: dsl-source
+    - id: generate
+      action: Run agent-contracts generate guardrails to verify
+      uses_tool: agent-contracts-cli
+      required: true
+  escalation_criteria:
+    - condition: Binding guardrail_impl is inconsistent with DSL guardrails
+      action: stop_and_report
+
+render-dsl-outputs:
+  description: Render prompts and documents from DSL and check for drift
+  target_agent: dsl-designer
+  allowed_from_agents:
+    - dsl-designer
+  workflow: dsl-update
+  input_artifacts:
+    - dsl-source
+  invocation_handoff: dsl-task-request
+  result_handoff: dsl-task-result
+  validations:
+    - dsl-schema-validation
+  responsibilities:
+    - Generate prompts and documents via agent-contracts render
+    - Detect and resolve drift using render --check
+  completion_criteria:
+    - render succeeds
+    - render --check reports no drift
+  execution_steps:
+    - id: render
+      action: Run agent-contracts render
+      uses_tool: agent-contracts-cli
+      produces_artifact: dsl-generated-output
+      required: true
+    - id: check-drift
+      action: Run agent-contracts render --check to verify no drift
+      uses_tool: agent-contracts-cli
+  escalation_criteria:
+    - condition: Unresolved template errors during render
+      action: stop_and_report
+
+check-dsl-score:
+  description: Check DSL completeness score and identify improvement areas
+  target_agent: dsl-designer
+  allowed_from_agents:
+    - dsl-designer
+  workflow: dsl-update
+  input_artifacts:
+    - dsl-source
+  invocation_handoff: dsl-task-request
+  result_handoff: dsl-task-result
+  responsibilities:
+    - Review score across 7 dimensions and identify weaknesses
+    - List entities that need improvement
+  completion_criteria:
+    - Score results have been reviewed
+    - Improvement areas have been identified
+  execution_steps:
+    - id: run-score
+      action: Run agent-contracts score
+      uses_tool: agent-contracts-cli
+      required: true
+    - id: analyze
+      action: Analyze score weaknesses and formulate improvement plan
+      produces_artifact: dsl-score-report
+  escalation_criteria:
+    - condition: Score is significantly below threshold with no clear improvement path
+      action: stop_and_report
+
+# === DSL Audit Tasks ===
+
+audit-dsl-completeness:
+  description: Audit completeness of DSL definitions against generated prompts
+  target_agent: dsl-auditor
+  allowed_from_agents:
+    - dsl-auditor
+  workflow: dsl-audit
+  input_artifacts:
+    - dsl-source
+    - dsl-generated-output
+  invocation_handoff: dsl-task-request
+  result_handoff: dsl-audit-result
+  validations:
+    - dsl-completeness-audit
+  responsibilities:
+    - Cross-check across 19 dimensions per audit procedure
+    - Classify gaps as template gap, data gap, or DSL gap
+    - Present improvement recommendations
+  completion_criteria:
+    - All dimensions inspected for all agents
+    - Detected gaps are classified
+    - Improvement recommendations are presented with priority
+  execution_steps:
+    - id: collect-sources
+      action: Collect DSL definitions, generated prompts, and templates
+      reads_artifact: dsl-source
+      required: true
+    - id: collect-outputs
+      action: Collect generated prompts
+      reads_artifact: dsl-generated-output
+      required: true
+    - id: run-audit
+      action: Execute 19-dimension cross-check
+    - id: analyze-gaps
+      action: Analyze root causes of detected gaps
+    - id: produce-report
+      action: Produce audit report and improvement recommendations
+      produces_artifact: dsl-audit-report
+  escalation_criteria:
+    - condition: 3 or more critical-level gaps detected
+      action: stop_and_report

--- a/dsl_base/tools.yaml
+++ b/dsl_base/tools.yaml
@@ -1,0 +1,50 @@
+agent-contracts-cli:
+  kind: cli
+  description: >-
+    agent-contracts CLI — execute resolve, validate, lint, render, score,
+    check, and generate commands for the DSL.
+  input_artifacts:
+    - dsl-source
+  output_artifacts:
+    - dsl-generated-output
+    - dsl-score-report
+  invokable_by:
+    - dsl-designer
+    - dsl-auditor
+  side_effects: []
+  commands:
+    - command: "npx agent-contracts validate"
+      category: verification
+      reads: [dsl-source]
+      writes: []
+      purpose: DSL schema validation and reference checks
+    - command: "npx agent-contracts lint"
+      category: verification
+      reads: [dsl-source]
+      writes: []
+      purpose: Semantic lint
+    - command: "npx agent-contracts render -c agent-contracts.config.yaml"
+      category: generation
+      reads: [dsl-source]
+      writes: [dsl-generated-output]
+      purpose: Template rendering (prompt and document generation)
+    - command: "npx agent-contracts render -c agent-contracts.config.yaml --check"
+      category: verification
+      reads: [dsl-source, dsl-generated-output]
+      writes: []
+      purpose: Drift detection (source vs generated output)
+    - command: "npx agent-contracts score"
+      category: verification
+      reads: [dsl-source]
+      writes: [dsl-score-report]
+      purpose: DSL completeness score calculation (7 dimensions)
+    - command: "npx agent-contracts check -c agent-contracts.config.yaml"
+      category: verification
+      reads: [dsl-source]
+      writes: []
+      purpose: Pipeline — resolve → validate → lint → render --check
+    - command: "npx agent-contracts generate guardrails"
+      category: generation
+      reads: [dsl-source]
+      writes: [dsl-generated-output]
+      purpose: Generate guardrail runtime artifacts

--- a/dsl_base/validations.yaml
+++ b/dsl_base/validations.yaml
@@ -1,0 +1,46 @@
+dsl-schema-validation:
+  target_artifact: dsl-source
+  kind: schema
+  executor_type: tool
+  executor: agent-contracts-cli
+  blocking: true
+  x-description: >-
+    DSL schema validation via agent-contracts validate command.
+    Performs type checks on all entities, verifies required fields,
+    and checks cross-reference integrity.
+
+dsl-lint-validation:
+  target_artifact: dsl-source
+  kind: semantic
+  executor_type: tool
+  executor: agent-contracts-cli
+  blocking: false
+  x-description: >-
+    Semantic validation via agent-contracts lint command.
+    Checks naming conventions, unused entities, circular references,
+    and other design quality aspects.
+
+dsl-score-validation:
+  target_artifact: dsl-source
+  kind: semantic
+  executor_type: tool
+  executor: agent-contracts-cli
+  blocking: false
+  x-description: >-
+    Completeness evaluation via agent-contracts score command.
+    Scores across 7 dimensions: artifact validation coverage,
+    task validation coverage, guardrail policy coverage,
+    workflow validation integration, schema completeness,
+    cross-reference bidirectionality, guardrail scope resolution.
+
+dsl-completeness-audit:
+  target_artifact: dsl-generated-output
+  kind: semantic
+  executor_type: agent
+  executor: dsl-auditor
+  blocking: false
+  produces_evidence: dsl-audit-report
+  x-description: >-
+    19-dimension cross-check audit of DSL definitions against generated
+    prompts. Verifies that all items defined in the DSL are correctly
+    reflected in generated output.

--- a/dsl_base/workflow.yaml
+++ b/dsl_base/workflow.yaml
@@ -1,0 +1,50 @@
+dsl-update:
+  description: >-
+    DSL Update — create and update agent-contracts DSL definitions and
+    bindings, verify quality via validate / lint / render / score.
+    Executed by DSL Designer.
+  entry_conditions:
+    - A DSL definition change request exists
+  trigger: >-
+    Execute when new DSL definitions need to be created, existing definitions
+    need updating, or bindings need to be added or modified.
+  steps:
+    - type: delegate
+      task: update-dsl-definitions
+      from_agent: dsl-designer
+      description: >-
+        DSL Designer creates or updates DSL definitions and verifies
+        via validate / lint.
+    - type: delegate
+      task: update-dsl-binding
+      from_agent: dsl-designer
+      description: >-
+        DSL Designer adds or updates bindings and verifies via generate.
+    - type: delegate
+      task: render-dsl-outputs
+      from_agent: dsl-designer
+      description: >-
+        DSL Designer renders prompts and documents and checks for drift.
+    - type: delegate
+      task: check-dsl-score
+      from_agent: dsl-designer
+      description: >-
+        DSL Designer checks completeness score and identifies improvement areas.
+
+dsl-audit:
+  description: >-
+    DSL Audit — audit completeness of DSL definitions against generated
+    prompts, detect gaps, and present improvement recommendations.
+    Executed by DSL Auditor.
+  entry_conditions:
+    - DSL definition rendering is complete
+  trigger: >-
+    Execute when DSL completeness audit is needed. Typically run as a
+    quality check after DSL updates.
+  steps:
+    - type: delegate
+      task: audit-dsl-completeness
+      from_agent: dsl-auditor
+      description: >-
+        DSL Auditor executes 19-dimension cross-check and produces
+        audit report with improvement recommendations.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/schemas/dsl.schema.json
+++ b/schemas/dsl.schema.json
@@ -181,6 +181,25 @@
               "additionalProperties": {}
             }
           },
+          "sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "content": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "title",
+                "content"
+              ],
+              "additionalProperties": false
+            }
+          },
           "prerequisites": {
             "type": "array",
             "items": {

--- a/src/schema/agent.ts
+++ b/src/schema/agent.ts
@@ -51,6 +51,14 @@ export const AgentSchema = z
     rules: z.array(RuleSchema).optional(),
     anti_patterns: z.array(z.string()).optional(),
     escalation_criteria: z.array(EscalationCriterionSchema).optional(),
+    sections: z
+      .array(
+        z.object({
+          title: z.string(),
+          content: z.string(),
+        }),
+      )
+      .optional(),
     prerequisites: z.array(PrerequisiteSchema).optional(),
     guardrails: z.array(z.string()).optional(),
   })


### PR DESCRIPTION
## Summary

- Add `dsl_base/` directory with platform-neutral, English-only DSL management baseline definitions (dsl-update/dsl-audit workflows, dsl-designer/dsl-auditor agents, tasks, artifacts, tools, validations, handoff types)
- Promote `x-sections` to a first-class `sections` standard property on agents, enabling structured reference material without relying on extension properties
- Bump version to 0.14.1

## Changes

### `dsl_base/` (new)
Reusable base DSL for DSL management workflows. Projects can inherit via `extends: "./dsl_base/"`. Contains no Cursor/Copilot-specific content — platform bindings are added in extending projects.

### `sections` property (agent schema)
- `src/schema/agent.ts` — add `sections: [{title, content}]` (optional)
- `schemas/dsl.schema.json` — regenerated
- `README.md` — documented in Core concepts, Features, and example

## Test plan
- [x] All 631 existing tests pass
- [x] `generate:schema` produces valid JSON schema with `sections`

Made with [Cursor](https://cursor.com)