### PR TITLE
feat: Multi-team Public Interface (team_interface / imports)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ A working example is available in [`sample/`](./sample), including:
 * [`sample/templates`](./sample/templates)
 * [`sample/output`](./sample/output)
 
+A multi-team example is available in [`sample/multi-team/`](./sample/multi-team), demonstrating cross-team interface declaration and consumption.
+
 ---
 
 ## Core concepts
@@ -222,7 +224,7 @@ A **Workflow** defines a phase-level execution sequence:
 * `entry_conditions`
 * `trigger`
 * `external_participants` — actors/participants outside the agent system (e.g., User, external advisory)
-* ordered steps (delegate, gate, validation, decision)
+* ordered steps (`delegate`, `gate`, `team_task`, `decision`; legacy: `handoff`, `validation`)
 
 Workflow steps support additional properties:
 
@@ -332,7 +334,9 @@ Design regressions become testable.
 * **Guardrail policies** with configurable enforcement (block/warn/shadow/info)
 * **Software bindings** (DI) for tool-specific guardrail implementation (Cursor, Git, GitHub)
 * **Guardrail generation** from DSL + policy + bindings via `generate guardrails`
+* **Interface generation** from DSL via `generate interface` for cross-team contracts
 * **Flexible file splitting** via `$ref` (replacement), `$refs` (import + deep-merge), and JSON Pointer `$ref` (in-document)
+* **Multi-team collaboration** via `team_interface` (public boundary), `imports` (team consumption), and `team_task` (cross-team delegation)
 * **YAML safety linting** for reserved word collision detection across YAML 1.1/1.2
 * **`extensions` declarations** with scope, schema validation, and strict enforcement for custom `x-*` fields
 * **`resolve --expand-defaults`** to materialize all Zod schema defaults in output
@@ -368,6 +372,13 @@ artifacts: {}
 tools: {}
 validations: {}
 handoff_types: {}
+team_interface:             # optional — multi-team public boundary
+  version: 1
+  accepts:
+    workflows: {}
+  exposes:
+    artifacts: []
+imports: {}                 # optional — consumed team interfaces
 workflow: {}
 policies: {}
 guardrails: {}
@@ -830,6 +841,104 @@ Supported merge operators:
 
 ---
 
+## Multi-team collaboration
+
+`agent-contracts` supports multi-team workflows where teams declare public interfaces and consume each other's capabilities.
+
+### Team Interface
+
+A `team_interface` declares what a team exposes to the outside:
+
+````yaml
+team_interface:
+  version: 1
+  description: "Backend team public interface"
+  accepts:
+    workflows:
+      implement:
+        internal_workflow: feature-implement
+        input_handoff: feature-request
+        output_handoff: implementation-result
+        description: "Request a feature implementation"
+  exposes:
+    artifacts:
+      - api-contract
+      - build-report
+  constraints:
+    - "feature-request must include acceptance_criteria"
+````
+
+Key design decisions:
+
+* **Workflow-level accepts** — external callers invoke a workflow, not individual tasks
+* **Explicit mapping** — `internal_workflow` separates the stable public name from the internal workflow ID
+* **Listing-based exposure** — an entity is external only if listed in `team_interface`
+
+### Imports
+
+A team consumes another team's generated interface via `imports`:
+
+````yaml
+imports:
+  backend:
+    interface: ./teams/backend/team-interface.yaml
+    version: ">=1"
+````
+
+Imported entities are referenced as `{team_id}.{public_name}` in cross-team workflow steps.
+
+### `team_task` workflow step
+
+Cross-team delegation uses the `team_task` step type:
+
+````yaml
+workflow:
+  execute-tests:
+    steps:
+      - type: team_task
+        to_team: backend
+        workflow: implement
+        handoff: feature-request
+        expects: implementation-result
+        description: "Delegate implementation to backend team"
+````
+
+| Field | Description |
+|-------|-------------|
+| `to_team` | Team ID from `imports` |
+| `workflow` | Public workflow name from the imported interface |
+| `handoff` | Handoff type for the request |
+| `expects` | Handoff type for the response |
+
+### Generating a team interface
+
+The `generate interface` command produces a self-contained `team-interface.yaml`:
+
+````bash
+agent-contracts generate interface -c agent-contracts.config.yaml
+agent-contracts generate interface -c agent-contracts.config.yaml -o custom-output.yaml
+agent-contracts generate interface -c agent-contracts.config.yaml --dry-run
+````
+
+The output includes:
+
+* Workflow entries with handoff key references
+* A `handoff_types` section containing only schemas referenced by external workflows
+* An `exposes.artifacts` section with type, description, and states
+* Metadata (`team_id`, `team_name`, `version`, `generated_at`)
+
+### Interface drift detection
+
+The `check` command detects drift between the declared `team_interface` and the generated `team-interface.yaml`:
+
+````bash
+agent-contracts check -c agent-contracts.config.yaml
+````
+
+If a `team-interface.yaml` exists and differs from what would be regenerated, the check reports drift.
+
+---
+
 ## Variable substitution
 
 When using `extends` to share a base DSL across projects, base definitions often contain values that differ per project (project name, language, repository URL, etc.).
@@ -911,6 +1020,7 @@ npx agent-contracts
 | `agent-contracts render`          | Render outputs from config                             |
 | `agent-contracts score [path]`    | Calculate DSL completeness score                       |
 | `agent-contracts generate guardrails` | Generate guardrail artifacts from bindings       |
+| `agent-contracts generate interface` | Generate team interface YAML from DSL |
 | `agent-contracts check`           | Run resolve → validate → lint → render --check         |
 
 The `[path]` argument defaults to `agent-contracts.yaml` in the current directory.
@@ -957,6 +1067,9 @@ agent-contracts score --format json
 agent-contracts render -c agent-contracts.config.yaml
 agent-contracts render -c agent-contracts.config.yaml --check
 agent-contracts check -c agent-contracts.config.yaml --strict
+agent-contracts generate interface -c agent-contracts.config.yaml
+agent-contracts generate interface -c agent-contracts.config.yaml --dry-run
+agent-contracts generate interface -c agent-contracts.config.yaml --format json
 ````
 
 ---
@@ -1414,6 +1527,8 @@ Checks:
 * owner / producer / editor / consumer validity
 * handoff schema consistency (`required` vs. `properties` alignment)
 * permission alignment between agents and artifacts
+* `team_interface` internal consistency (workflows, handoffs, and exposed artifacts exist in the DSL)
+* cross-team reference validity (`team_task` targets exist in `imports`)
 
 ### Semantic lint
 

--- a/sample/multi-team/README.md
+++ b/sample/multi-team/README.md
@@ -1,0 +1,24 @@
+# Multi-Team Example
+
+This example demonstrates the multi-team collaboration features of agent-contracts.
+
+## Files
+
+- `backend-team.yaml` — Backend team DSL with a `team_interface` section
+- `qa-consumer.yaml` — QA team DSL that imports the backend team's interface
+
+## Usage
+
+Generate the backend team's public interface:
+
+```bash
+agent-contracts generate interface -c backend-config.yaml
+```
+
+The QA team references the generated interface in its `imports` section.
+
+## How it works
+
+1. The **backend team** declares a `team_interface` with accepted workflows and exposed artifacts
+2. `generate interface` produces a `team-interface.yaml` containing only the public surface
+3. The **QA team** imports the backend interface and uses `team_task` steps to delegate work

--- a/sample/multi-team/backend-team.yaml
+++ b/sample/multi-team/backend-team.yaml
@@ -1,0 +1,146 @@
+version: 1
+system:
+  id: backend-team
+  name: Backend Team
+  default_workflow_order:
+    - implement
+    - review
+
+team_interface:
+  version: 1
+  description: "Backend team public interface"
+  accepts:
+    workflows:
+      implement:
+        internal_workflow: feature-implement
+        input_handoff: feature-request
+        output_handoff: implementation-result
+        description: "Request a feature implementation"
+  exposes:
+    artifacts:
+      - api-contract
+      - build-report
+  constraints:
+    - "feature-request must include acceptance_criteria"
+
+agents:
+  backend-architect:
+    role_name: Backend Architect
+    purpose: Designs and reviews backend implementations
+    can_read_artifacts:
+      - api-contract
+      - build-report
+      - codebase
+    can_write_artifacts:
+      - api-contract
+      - codebase
+    can_return_handoffs:
+      - feature-request
+      - implementation-result
+
+tasks:
+  plan-feature:
+    description: Plan and implement a feature
+    target_agent: backend-architect
+    allowed_from_agents:
+      - backend-architect
+    workflow: implement
+    input_artifacts:
+      - api-contract
+    invocation_handoff: feature-request
+    result_handoff: implementation-result
+
+artifacts:
+  api-contract:
+    type: specification
+    description: "OpenAPI specification for the backend API"
+    owner: backend-architect
+    producers:
+      - backend-architect
+    editors:
+      - backend-architect
+    consumers:
+      - backend-architect
+    states:
+      - draft
+      - reviewed
+      - published
+  build-report:
+    type: report
+    description: "Build and test results"
+    owner: backend-architect
+    producers:
+      - backend-architect
+    editors:
+      - backend-architect
+    consumers:
+      - backend-architect
+    states:
+      - generated
+  codebase:
+    type: code
+    owner: backend-architect
+    producers:
+      - backend-architect
+    editors:
+      - backend-architect
+    consumers:
+      - backend-architect
+    states:
+      - draft
+      - reviewed
+
+tools: {}
+validations: {}
+
+handoff_types:
+  feature-request:
+    version: 1
+    description: "Request to implement a feature"
+    schema:
+      type: object
+      required:
+        - feature_name
+        - acceptance_criteria
+      properties:
+        feature_name:
+          type: string
+        acceptance_criteria:
+          type: array
+          items:
+            type: string
+  implementation-result:
+    version: 1
+    description: "Result of a feature implementation"
+    schema:
+      type: object
+      required:
+        - status
+        - changed_files
+      properties:
+        status:
+          type: string
+          enum:
+            - success
+            - partial
+            - failed
+        changed_files:
+          type: array
+          items:
+            type: string
+
+workflow:
+  feature-implement:
+    description: "End-to-end feature implementation"
+    steps:
+      - type: delegate
+        task: plan-feature
+        from_agent: backend-architect
+  review:
+    description: "Code review workflow"
+    steps:
+      - type: gate
+        gate_kind: feature-request
+
+policies: {}
+guardrails: {}

--- a/sample/multi-team/qa-consumer.yaml
+++ b/sample/multi-team/qa-consumer.yaml
@@ -1,0 +1,139 @@
+version: 1
+system:
+  id: qa-team
+  name: QA Team
+  default_workflow_order:
+    - test-plan
+    - execute-tests
+
+imports:
+  backend:
+    interface: ./backend-team-interface.yaml
+    version: ">=1"
+
+agents:
+  qa-lead:
+    role_name: QA Lead
+    purpose: Plans and coordinates testing activities
+    can_read_artifacts:
+      - test-plan-doc
+      - test-results
+    can_write_artifacts:
+      - test-plan-doc
+      - test-results
+    can_return_handoffs:
+      - test-delegation
+      - test-result
+
+tasks:
+  create-test-plan:
+    description: Create a test plan for a feature
+    target_agent: qa-lead
+    allowed_from_agents:
+      - qa-lead
+    workflow: test-plan
+    input_artifacts:
+      - test-plan-doc
+    invocation_handoff: test-delegation
+    result_handoff: test-result
+
+artifacts:
+  test-plan-doc:
+    type: document
+    description: "Test plan document"
+    owner: qa-lead
+    producers:
+      - qa-lead
+    editors:
+      - qa-lead
+    consumers:
+      - qa-lead
+    states:
+      - draft
+      - approved
+  test-results:
+    type: report
+    description: "Test execution results"
+    owner: qa-lead
+    producers:
+      - qa-lead
+    editors:
+      - qa-lead
+    consumers:
+      - qa-lead
+    states:
+      - pending
+      - complete
+
+tools: {}
+validations: {}
+
+handoff_types:
+  test-delegation:
+    version: 1
+    schema:
+      type: object
+      properties:
+        test_scope:
+          type: string
+  test-result:
+    version: 1
+    schema:
+      type: object
+      properties:
+        passed:
+          type: boolean
+  feature-request:
+    version: 1
+    description: "Forwarded feature request to backend"
+    schema:
+      type: object
+      required:
+        - feature_name
+        - acceptance_criteria
+      properties:
+        feature_name:
+          type: string
+        acceptance_criteria:
+          type: array
+          items:
+            type: string
+  implementation-result:
+    version: 1
+    description: "Expected result from backend"
+    schema:
+      type: object
+      required:
+        - status
+        - changed_files
+      properties:
+        status:
+          type: string
+          enum:
+            - success
+            - partial
+            - failed
+        changed_files:
+          type: array
+          items:
+            type: string
+
+workflow:
+  test-plan:
+    description: "Create and review test plan"
+    steps:
+      - type: delegate
+        task: create-test-plan
+        from_agent: qa-lead
+  execute-tests:
+    description: "Execute tests, delegating implementation to backend"
+    steps:
+      - type: team_task
+        to_team: backend
+        workflow: implement
+        handoff: feature-request
+        expects: implementation-result
+        description: "Request backend to implement the feature before testing"
+
+policies: {}
+guardrails: {}

--- a/schemas/dsl.schema.json
+++ b/schemas/dsl.schema.json
@@ -708,6 +708,100 @@
         "additionalProperties": {}
       }
     },
+    "team_interface": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "number"
+        },
+        "description": {
+          "type": "string"
+        },
+        "accepts": {
+          "type": "object",
+          "properties": {
+            "workflows": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "internal_workflow": {
+                    "type": "string"
+                  },
+                  "input_handoff": {
+                    "type": "string"
+                  },
+                  "output_handoff": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "input_handoff",
+                  "output_handoff"
+                ],
+                "additionalProperties": {}
+              }
+            }
+          },
+          "required": [
+            "workflows"
+          ],
+          "additionalProperties": {}
+        },
+        "exposes": {
+          "type": "object",
+          "properties": {
+            "artifacts": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "artifacts"
+          ],
+          "additionalProperties": {}
+        },
+        "constraints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "version"
+      ],
+      "additionalProperties": {}
+    },
+    "imports": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "interface": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "interface"
+        ],
+        "additionalProperties": {}
+      }
+    },
     "workflow": {
       "default": {},
       "type": "object",
@@ -909,6 +1003,41 @@
                   "required": [
                     "type",
                     "branches"
+                  ],
+                  "additionalProperties": {}
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "team_task"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "to_team": {
+                      "type": "string"
+                    },
+                    "workflow": {
+                      "type": "string"
+                    },
+                    "handoff": {
+                      "type": "string"
+                    },
+                    "expects": {
+                      "type": "string"
+                    },
+                    "group": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "to_team",
+                    "workflow",
+                    "handoff",
+                    "expects"
                   ],
                   "additionalProperties": {}
                 }

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -1,10 +1,14 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { Command } from "commander";
+import { parse as parseYaml, stringify } from "yaml";
 import { loadConfig, loadBindings, ConfigLoadError } from "../../config/index.js";
 import { resolve, substituteVars } from "../../resolver/index.js";
 import { validateSchema, checkReferences, validateHandoffSchemas } from "../../validator/index.js";
 import { lint, spectralLint } from "../../linter/index.js";
 import { checkDriftFromConfig, type RenderOptions } from "../../renderer/index.js";
 import { formatDiagnostics, type OutputFormat } from "../format.js";
+import { generateInterface } from "../../interface-generator/index.js";
 
 export const checkCommand = new Command("check")
   .description("Run full pipeline: resolve → validate → lint → render --check")
@@ -99,6 +103,34 @@ export const checkCommand = new Command("check")
             process.stderr.write(`  ${f}\n`);
           }
           hasErrors = true;
+        }
+
+        if (schemaResult.data!.team_interface) {
+          const interfacePath = join(config.configDir, "team-interface.yaml");
+          if (existsSync(interfacePath)) {
+            const result = generateInterface({
+              dsl: schemaResult.data!,
+              dryRun: true,
+              format: "yaml",
+            });
+            const existing = readFileSync(interfacePath, "utf8");
+            const normalize = (raw: string): string => {
+              try {
+                const parsed = parseYaml(raw) as Record<string, unknown>;
+                if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+                  const { generated_at: _t, ...rest } = parsed;
+                  return `${stringify(rest, { sortMapEntries: true })}\n`;
+                }
+              } catch {
+                /* fall through */
+              }
+              return raw.trim();
+            };
+            if (normalize(existing) !== normalize(result.content)) {
+              process.stderr.write("Drift detected in team-interface.yaml\n");
+              hasErrors = true;
+            }
+          }
         }
 
         if (hasErrors) {

--- a/src/cli/commands/generate-guardrails.ts
+++ b/src/cli/commands/generate-guardrails.ts
@@ -3,21 +3,43 @@ import { loadConfig, ConfigLoadError, loadBindings } from "../../config/index.js
 import { resolve, substituteVars } from "../../resolver/index.js";
 import { validateSchema } from "../../validator/index.js";
 import { generateGuardrails } from "../../guardrail-generator/index.js";
+import { runGenerateInterfaceCli } from "./generate-interface.js";
 
 export const generateGuardrailsCommand = new Command("generate")
   .description("Generate guardrail runtime artifacts from DSL, policies, and bindings")
-  .argument("[type]", "Type of artifacts to generate", "guardrails")
+  .argument("[type]", "Type of artifacts to generate (guardrails|interface)", "guardrails")
   .option("-c, --config <path>", "Path to agent-contracts.config.yaml")
   .option("--binding <name...>", "Filter to specific software binding(s)")
+  .option(
+    "-o, --output <path>",
+    "Output path for generated team interface (interface type only)",
+  )
+  .option(
+    "--format <format>",
+    "Output format for team interface: yaml or json",
+    "yaml",
+  )
   .option("--dry-run", "Print what would be generated without writing files", false)
   .option("--quiet", "Suppress output on success", false)
   .action(
     async (
       type: string,
-      opts: { config?: string; binding?: string[]; dryRun: boolean; quiet: boolean },
+      opts: {
+        config?: string;
+        binding?: string[];
+        output?: string;
+        format: string;
+        dryRun: boolean;
+        quiet: boolean;
+      },
     ) => {
-      if (type !== "guardrails") {
+      if (type !== "guardrails" && type !== "interface") {
         process.stderr.write(`Unknown generate type: ${type}\n`);
+        process.exit(1);
+      }
+
+      if (type === "interface" && opts.format !== "yaml" && opts.format !== "json") {
+        process.stderr.write(`Invalid --format: expected yaml or json, got ${opts.format}\n`);
         process.exit(1);
       }
 
@@ -42,6 +64,17 @@ export const generateGuardrailsCommand = new Command("generate")
             "Schema validation failed. Run 'agent-contracts validate' for details.\n",
           );
           process.exit(1);
+        }
+
+        if (type === "interface") {
+          runGenerateInterfaceCli({
+            dsl: schemaResult.data!,
+            output: opts.output,
+            dryRun: opts.dryRun,
+            format: opts.format as "yaml" | "json",
+            quiet: opts.quiet,
+          });
+          return;
         }
 
         // Load bindings

--- a/src/cli/commands/generate-interface.ts
+++ b/src/cli/commands/generate-interface.ts
@@ -1,0 +1,38 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Dsl } from "../../schema/index.js";
+import { generateInterface } from "../../interface-generator/index.js";
+
+export interface RunGenerateInterfaceCliOptions {
+  dsl: Dsl;
+  output?: string;
+  dryRun: boolean;
+  format: "yaml" | "json";
+  quiet: boolean;
+}
+
+export function runGenerateInterfaceCli(opts: RunGenerateInterfaceCliOptions): void {
+  if (!opts.dsl.team_interface) {
+    process.stderr.write("Error: DSL has no team_interface section.\n");
+    process.exit(1);
+  }
+
+  const outputPath = resolve(process.cwd(), opts.output ?? "team-interface.yaml");
+  const result = generateInterface({
+    dsl: opts.dsl,
+    output: outputPath,
+    dryRun: opts.dryRun,
+    format: opts.format,
+  });
+
+  if (opts.dryRun) {
+    process.stdout.write(result.content);
+    return;
+  }
+
+  writeFileSync(result.outputPath, result.content, "utf8");
+
+  if (!opts.quiet) {
+    process.stdout.write(`Wrote ${result.outputPath}\n`);
+  }
+}

--- a/src/interface-generator/generator.ts
+++ b/src/interface-generator/generator.ts
@@ -1,0 +1,100 @@
+import { stringify } from "yaml";
+import type { Dsl } from "../schema/index.js";
+
+export interface GenerateInterfaceOptions {
+  dsl: Dsl;
+  output?: string;
+  dryRun: boolean;
+  format: "yaml" | "json";
+}
+
+export interface GenerateInterfaceResult {
+  outputPath: string;
+  content: string;
+}
+
+function buildInterfaceDocument(dsl: Dsl, generatedAt: string): Record<string, unknown> {
+  const ti = dsl.team_interface!;
+  const doc: Record<string, unknown> = {
+    team_id: dsl.system.id,
+    team_name: dsl.system.name,
+    version: ti.version,
+    generated_at: generatedAt,
+  };
+
+  if (ti.description !== undefined) {
+    doc.description = ti.description;
+  }
+
+  if (ti.accepts?.workflows && Object.keys(ti.accepts.workflows).length > 0) {
+    doc.accepts = { workflows: { ...ti.accepts.workflows } };
+  }
+
+  const handoffKeys = new Set<string>();
+  if (ti.accepts?.workflows) {
+    for (const spec of Object.values(ti.accepts.workflows)) {
+      handoffKeys.add(spec.input_handoff);
+      handoffKeys.add(spec.output_handoff);
+    }
+  }
+
+  const handoff_types: Record<string, unknown> = {};
+  for (const k of [...handoffKeys].sort()) {
+    const ht = dsl.handoff_types[k];
+    if (ht) {
+      const entry: Record<string, unknown> = {
+        version: ht.version,
+        schema: ht.schema,
+      };
+      if (ht.description !== undefined) {
+        entry.description = ht.description;
+      }
+      handoff_types[k] = entry;
+    }
+  }
+  if (Object.keys(handoff_types).length > 0) {
+    doc.handoff_types = handoff_types;
+  }
+
+  const artifactsOut: Record<string, unknown> = {};
+  if (ti.exposes?.artifacts) {
+    for (const key of [...ti.exposes.artifacts].sort()) {
+      const art = dsl.artifacts[key];
+      if (art) {
+        const entry: Record<string, unknown> = {
+          type: art.type,
+          states: art.states,
+        };
+        if (art.description !== undefined) {
+          entry.description = art.description;
+        }
+        artifactsOut[key] = entry;
+      }
+    }
+  }
+  if (Object.keys(artifactsOut).length > 0) {
+    doc.exposes = { artifacts: artifactsOut };
+  }
+
+  if (ti.constraints !== undefined && ti.constraints.length > 0) {
+    doc.constraints = ti.constraints;
+  }
+
+  return doc;
+}
+
+export function generateInterface(options: GenerateInterfaceOptions): GenerateInterfaceResult {
+  if (!options.dsl.team_interface) {
+    throw new Error("DSL has no team_interface section");
+  }
+
+  const doc = buildInterfaceDocument(options.dsl, new Date().toISOString());
+  const content =
+    options.format === "json"
+      ? `${JSON.stringify(doc, null, 2)}\n`
+      : `${stringify(doc, { sortMapEntries: true })}\n`;
+
+  const outputPath = options.output ?? "team-interface.yaml";
+
+  return { outputPath, content };
+}

--- a/src/interface-generator/index.ts
+++ b/src/interface-generator/index.ts
@@ -1,0 +1,5 @@
+export {
+  generateInterface,
+  type GenerateInterfaceOptions,
+  type GenerateInterfaceResult,
+} from "./generator.js";

--- a/src/resolver/merger.ts
+++ b/src/resolver/merger.ts
@@ -249,6 +249,7 @@ const MERGE_SECTIONS = [
   "tools",
   "validations",
   "handoff_types",
+  "imports",
   "workflow",
   "policies",
   "guardrails",

--- a/src/schema/dsl.ts
+++ b/src/schema/dsl.ts
@@ -6,6 +6,8 @@ import { GuardrailPolicySchema, GuardrailSchema } from "./guardrail.js";
 import { PolicySchema } from "./policy.js";
 import { SystemSchema } from "./system.js";
 import { TaskSchema } from "./task.js";
+import { TeamImportSchema } from "./team-import.js";
+import { TeamInterfaceSchema } from "./team-interface.js";
 import { ToolSchema } from "./tool.js";
 import { ValidationSchema } from "./validation.js";
 import { WorkflowSchema } from "./workflow.js";
@@ -74,6 +76,8 @@ export const DslSchema = z
     tools: z.record(z.string(), ToolSchema).default({}),
     validations: z.record(z.string(), ValidationSchema).default({}),
     handoff_types: z.record(z.string(), HandoffTypeSchema).default({}),
+    team_interface: TeamInterfaceSchema.optional(),
+    imports: z.record(z.string(), TeamImportSchema).optional(),
     workflow: z.record(z.string(), WorkflowSchema).default({}),
     policies: z.record(z.string(), PolicySchema).default({}),
     guardrails: z.record(z.string(), GuardrailSchema).default({}),

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -82,6 +82,16 @@ export {
   type VersionLiteral,
 } from "./system.js";
 export {
+  TeamImportSchema,
+  type TeamImport,
+} from "./team-import.js";
+export {
+  TeamInterfaceAcceptWorkflowSchema,
+  TeamInterfaceSchema,
+  type TeamInterface,
+  type TeamInterfaceAcceptWorkflow,
+} from "./team-interface.js";
+export {
   ExecutionStepSchema,
   TaskSchema,
   type ExecutionStep,

--- a/src/schema/team-import.ts
+++ b/src/schema/team-import.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const TeamImportSchema = z
+  .object({
+    interface: z.string(),
+    version: z.string().optional(),
+  })
+  .passthrough();
+export type TeamImport = z.infer<typeof TeamImportSchema>;

--- a/src/schema/team-interface.ts
+++ b/src/schema/team-interface.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+export const TeamInterfaceAcceptWorkflowSchema = z
+  .object({
+    internal_workflow: z.string().optional(),
+    input_handoff: z.string(),
+    output_handoff: z.string(),
+    description: z.string().optional(),
+  })
+  .passthrough();
+export type TeamInterfaceAcceptWorkflow = z.infer<
+  typeof TeamInterfaceAcceptWorkflowSchema
+>;
+
+export const TeamInterfaceSchema = z
+  .object({
+    version: z.number(),
+    description: z.string().optional(),
+    accepts: z
+      .object({
+        workflows: z.record(z.string(), TeamInterfaceAcceptWorkflowSchema),
+      })
+      .passthrough()
+      .optional(),
+    exposes: z
+      .object({
+        artifacts: z.array(z.string()),
+      })
+      .passthrough()
+      .optional(),
+    constraints: z.array(z.string()).optional(),
+  })
+  .passthrough();
+export type TeamInterface = z.infer<typeof TeamInterfaceSchema>;

--- a/src/schema/workflow.ts
+++ b/src/schema/workflow.ts
@@ -70,12 +70,25 @@ const WorkflowDecisionStepSchema = z
   })
   .passthrough();
 
+const WorkflowTeamTaskStepSchema = z
+  .object({
+    type: z.literal("team_task"),
+    description: z.string().optional(),
+    to_team: z.string(),
+    workflow: z.string(),
+    handoff: z.string(),
+    expects: z.string(),
+    group: z.string().optional(),
+  })
+  .passthrough();
+
 export const WorkflowStepSchema = z.discriminatedUnion("type", [
   WorkflowDelegateStepSchema,
   WorkflowGateStepSchema,
   WorkflowHandoffStepSchema,
   WorkflowValidationStepSchema,
   WorkflowDecisionStepSchema,
+  WorkflowTeamTaskStepSchema,
 ]);
 export type WorkflowStep = z.infer<typeof WorkflowStepSchema>;
 

--- a/src/validator/reference-resolver.ts
+++ b/src/validator/reference-resolver.ts
@@ -145,6 +145,26 @@ export function checkReferences(dsl: Dsl): ReferenceDiagnostic[] {
         }
       } else if (step.type === "validation") {
         checkExists(step.validation, validationIds, "validations", `workflow.${wfId}.steps[${j}].validation`);
+      } else if (step.type === "team_task") {
+        const importKeys =
+          dsl.imports !== undefined ? new Set(Object.keys(dsl.imports)) : null;
+        if (importKeys) {
+          checkExists(
+            step.to_team,
+            importKeys,
+            "imports",
+            `workflow.${wfId}.steps[${j}].to_team`,
+            "team-import-not-found",
+          );
+        } else {
+          diagnostics.push({
+            path: `workflow.${wfId}.steps[${j}].to_team`,
+            message: `team_task step references team "${step.to_team}" but dsl.imports is not defined`,
+            code: "team-task-missing-imports",
+          });
+        }
+        checkExists(step.handoff, handoffKinds, "handoff_types", `workflow.${wfId}.steps[${j}].handoff`);
+        checkExists(step.expects, handoffKinds, "handoff_types", `workflow.${wfId}.steps[${j}].expects`);
       }
     }
   }
@@ -344,6 +364,50 @@ export function checkReferences(dsl: Dsl): ReferenceDiagnostic[] {
         `guardrail_policies.${policyId}.rules[${i}].guardrail`,
         "guardrail-policy-ref-not-found",
       );
+    }
+  }
+
+  const workflowDefinitionIds = new Set(Object.keys(dsl.workflow));
+
+  if (dsl.team_interface) {
+    const ti = dsl.team_interface;
+    if (ti.accepts?.workflows) {
+      for (const [wfKey, spec] of Object.entries(ti.accepts.workflows)) {
+        const internalWf = spec.internal_workflow ?? wfKey;
+        checkExists(
+          internalWf,
+          workflowDefinitionIds,
+          "workflow",
+          `team_interface.accepts.workflows.${wfKey}.internal_workflow`,
+          "team-interface-workflow-not-found",
+        );
+        checkExists(
+          spec.input_handoff,
+          handoffKinds,
+          "handoff_types",
+          `team_interface.accepts.workflows.${wfKey}.input_handoff`,
+          "team-interface-handoff-not-found",
+        );
+        checkExists(
+          spec.output_handoff,
+          handoffKinds,
+          "handoff_types",
+          `team_interface.accepts.workflows.${wfKey}.output_handoff`,
+          "team-interface-handoff-not-found",
+        );
+      }
+    }
+    if (ti.exposes?.artifacts) {
+      for (let i = 0; i < ti.exposes.artifacts.length; i++) {
+        const artKey = ti.exposes.artifacts[i];
+        checkExists(
+          artKey,
+          artifactIds,
+          "artifacts",
+          `team_interface.exposes.artifacts[${i}]`,
+          "team-interface-artifact-not-found",
+        );
+      }
     }
   }
 

--- a/test/interface-generator/generator.test.ts
+++ b/test/interface-generator/generator.test.ts
@@ -1,0 +1,141 @@
+import { parse as parseYaml } from "yaml";
+import { describe, expect, it } from "vitest";
+import { generateInterface } from "../../src/interface-generator/index.js";
+import { DslSchema, type Dsl } from "../../src/schema/index.js";
+
+function dslWithInterface(overrides: Partial<Record<string, unknown>> = {}): Dsl {
+  const base = {
+    version: 1,
+    system: {
+      id: "team-backend",
+      name: "Backend Team",
+      default_workflow_order: ["impl"],
+    },
+    agents: { a1: { role_name: "R", purpose: "P" } },
+    artifacts: {
+      spec: {
+        type: "doc",
+        owner: "a1",
+        producers: ["a1"],
+        editors: ["a1"],
+        consumers: ["a1"],
+        states: ["draft", "approved"],
+        description: "Specification artifact",
+      },
+    },
+    handoff_types: {
+      in: { version: 1, schema: { type: "object" }, description: "Inbound" },
+      out: { version: 1, schema: { type: "object" } },
+      unused: { version: 1, schema: { type: "object" } },
+    },
+    workflow: {
+      impl: {
+        steps: [{ type: "handoff" as const, handoff_kind: "task-delegation" }],
+      },
+    },
+    team_interface: {
+      version: 3,
+      description: "Public contract",
+      accepts: {
+        workflows: {
+          implement: {
+            internal_workflow: "impl",
+            input_handoff: "in",
+            output_handoff: "out",
+          },
+        },
+      },
+      exposes: { artifacts: ["spec"] },
+      constraints: ["must include acceptance_criteria"],
+    },
+  };
+  return DslSchema.parse({ ...base, ...overrides } as Record<string, unknown>);
+}
+
+describe("generateInterface", () => {
+  it("generates YAML with team_id, team_name, version, and generated_at", () => {
+    const dsl = dslWithInterface();
+    const { content } = generateInterface({ dsl, dryRun: true, format: "yaml" });
+    const doc = parseYaml(content) as Record<string, unknown>;
+    expect(doc.team_id).toBe("team-backend");
+    expect(doc.team_name).toBe("Backend Team");
+    expect(doc.version).toBe(3);
+    expect(typeof doc.generated_at).toBe("string");
+    expect(doc.generated_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("generates JSON when format is json", () => {
+    const dsl = dslWithInterface();
+    const { content } = generateInterface({ dsl, dryRun: true, format: "json" });
+    const doc = JSON.parse(content) as Record<string, unknown>;
+    expect(doc.team_id).toBe("team-backend");
+    expect(doc.version).toBe(3);
+  });
+
+  it("includes only handoff_types referenced by accepted workflows", () => {
+    const dsl = dslWithInterface();
+    const { content } = generateInterface({ dsl, dryRun: true, format: "yaml" });
+    const doc = parseYaml(content) as Record<string, unknown>;
+    const ht = doc.handoff_types as Record<string, unknown>;
+    expect(Object.keys(ht).sort()).toEqual(["in", "out"]);
+    expect(ht.unused).toBeUndefined();
+  });
+
+  it("includes exposed artifacts with type, description, and states", () => {
+    const dsl = dslWithInterface();
+    const { content } = generateInterface({ dsl, dryRun: true, format: "yaml" });
+    const doc = parseYaml(content) as Record<string, unknown>;
+    const exposed = (doc.exposes as { artifacts: Record<string, unknown> }).artifacts
+      .spec as Record<string, unknown>;
+    expect(exposed.type).toBe("doc");
+    expect(exposed.description).toBe("Specification artifact");
+    expect(exposed.states).toEqual(["draft", "approved"]);
+  });
+
+  it("includes constraints from team_interface", () => {
+    const dsl = dslWithInterface();
+    const { content } = generateInterface({ dsl, dryRun: true, format: "yaml" });
+    const doc = parseYaml(content) as Record<string, unknown>;
+    expect(doc.constraints).toEqual(["must include acceptance_criteria"]);
+  });
+
+  it("throws when DSL has no team_interface", () => {
+    const dsl = DslSchema.parse({
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: [] },
+    });
+    expect(() =>
+      generateInterface({ dsl, dryRun: true, format: "yaml" }),
+    ).toThrow("DSL has no team_interface section");
+  });
+
+  it("omits handoff_types when no workflows are accepted", () => {
+    const dsl = dslWithInterface({
+      team_interface: { version: 1 },
+    });
+    const { content } = generateInterface({ dsl, dryRun: true, format: "yaml" });
+    const doc = parseYaml(content) as Record<string, unknown>;
+    expect(doc.handoff_types).toBeUndefined();
+  });
+
+  it("omits exposes when no artifacts are exposed", () => {
+    const dsl = dslWithInterface({
+      team_interface: {
+        version: 1,
+        accepts: {
+          workflows: {
+            w: {
+              internal_workflow: "impl",
+              input_handoff: "in",
+              output_handoff: "out",
+            },
+          },
+        },
+      },
+    });
+    const { content } = generateInterface({ dsl, dryRun: true, format: "yaml" });
+    const doc = parseYaml(content) as Record<string, unknown>;
+    expect(doc.exposes).toBeUndefined();
+    expect(doc.handoff_types).toBeDefined();
+  });
+});

--- a/test/schema/schema.test.ts
+++ b/test/schema/schema.test.ts
@@ -20,6 +20,8 @@ import {
   RuleSchema,
   SystemSchema,
   TaskSchema,
+  TeamImportSchema,
+  TeamInterfaceSchema,
   ToolSchema,
   ValidationSchema,
   WorkflowSchema,
@@ -407,6 +409,50 @@ describe("WorkflowStepSchema discriminated union", () => {
       extra: 1,
     });
     expect(r.success).toBe(true);
+  });
+
+  it("parses team_task step", () => {
+    const s = WorkflowStepSchema.parse({
+      type: "team_task",
+      to_team: "backend",
+      workflow: "implement",
+      handoff: "feature-request",
+      expects: "implementation-result",
+    });
+    expect(s.type).toBe("team_task");
+    if (s.type === "team_task") {
+      expect(s.to_team).toBe("backend");
+      expect(s.workflow).toBe("implement");
+    }
+  });
+
+  it("parses team_task step with description and group", () => {
+    const s = WorkflowStepSchema.parse({
+      type: "team_task",
+      to_team: "backend",
+      workflow: "implement",
+      handoff: "feature-request",
+      expects: "implementation-result",
+      description: "Delegate to backend",
+      group: "cross-team",
+    });
+    expect(s.type).toBe("team_task");
+    if (s.type === "team_task") {
+      expect(s.description).toBe("Delegate to backend");
+      expect(s.group).toBe("cross-team");
+    }
+  });
+
+  it("allows x- properties on team_task step", () => {
+    const s = WorkflowStepSchema.parse({
+      type: "team_task",
+      to_team: "backend",
+      workflow: "implement",
+      handoff: "h1",
+      expects: "h2",
+      "x-meta": true,
+    });
+    expect((s as Record<string, unknown>)["x-meta"]).toBe(true);
   });
 });
 
@@ -838,6 +884,177 @@ describe("new standard properties", () => {
   });
 });
 
+describe("TeamInterfaceSchema", () => {
+  it("parses a full team_interface", () => {
+    const ti = TeamInterfaceSchema.parse({
+      version: 1,
+      description: "Backend team interface",
+      accepts: {
+        workflows: {
+          implement: {
+            internal_workflow: "feature-implement",
+            input_handoff: "feature-request",
+            output_handoff: "implementation-result",
+            description: "Request implementation",
+          },
+        },
+      },
+      exposes: { artifacts: ["api-contract"] },
+      constraints: ["must include acceptance_criteria"],
+    });
+    expect(ti.version).toBe(1);
+    expect(ti.accepts!.workflows.implement.input_handoff).toBe("feature-request");
+    expect(ti.exposes!.artifacts).toEqual(["api-contract"]);
+  });
+
+  it("parses minimal team_interface (version only)", () => {
+    const ti = TeamInterfaceSchema.parse({ version: 1 });
+    expect(ti.version).toBe(1);
+    expect(ti.accepts).toBeUndefined();
+    expect(ti.exposes).toBeUndefined();
+  });
+
+  it("allows x- properties", () => {
+    const ti = TeamInterfaceSchema.parse({ version: 1, "x-meta": true });
+    expect((ti as Record<string, unknown>)["x-meta"]).toBe(true);
+  });
+});
+
+describe("TeamImportSchema", () => {
+  it("parses a full import entry", () => {
+    const imp = TeamImportSchema.parse({
+      interface: "./teams/backend/team-interface.yaml",
+      version: ">=1",
+    });
+    expect(imp.interface).toBe("./teams/backend/team-interface.yaml");
+    expect(imp.version).toBe(">=1");
+  });
+
+  it("parses import without version", () => {
+    const imp = TeamImportSchema.parse({
+      interface: "./backend-interface.yaml",
+    });
+    expect(imp.version).toBeUndefined();
+  });
+
+  it("allows x- properties", () => {
+    const imp = TeamImportSchema.parse({
+      interface: "./x.yaml",
+      "x-source": "generated",
+    });
+    expect((imp as Record<string, unknown>)["x-source"]).toBe("generated");
+  });
+});
+
+describe("DslSchema with team_interface and imports", () => {
+  it("parses DSL with team_interface", () => {
+    const d = DslSchema.parse({
+      version: 1,
+      system: minimalValidSystem,
+      team_interface: {
+        version: 1,
+        accepts: {
+          workflows: {
+            implement: {
+              input_handoff: "h-in",
+              output_handoff: "h-out",
+            },
+          },
+        },
+      },
+    });
+    expect(d.team_interface).toBeDefined();
+    expect(d.team_interface!.version).toBe(1);
+  });
+
+  it("parses DSL with imports", () => {
+    const d = DslSchema.parse({
+      version: 1,
+      system: minimalValidSystem,
+      imports: {
+        backend: {
+          interface: "./backend-interface.yaml",
+          version: ">=1",
+        },
+      },
+    });
+    expect(d.imports).toBeDefined();
+    expect(d.imports!.backend.interface).toBe("./backend-interface.yaml");
+  });
+
+  it("omits team_interface and imports when absent", () => {
+    const d = DslSchema.parse({
+      version: 1,
+      system: minimalValidSystem,
+    });
+    expect(d.team_interface).toBeUndefined();
+    expect(d.imports).toBeUndefined();
+  });
+});
+
+describe("multi-team schema error cases", () => {
+  it("rejects team_task step missing required to_team", () => {
+    const r = WorkflowStepSchema.safeParse({
+      type: "team_task",
+      workflow: "implement",
+      handoff: "h1",
+      expects: "h2",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects team_task step missing required workflow", () => {
+    const r = WorkflowStepSchema.safeParse({
+      type: "team_task",
+      to_team: "backend",
+      handoff: "h1",
+      expects: "h2",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects team_task step missing required handoff", () => {
+    const r = WorkflowStepSchema.safeParse({
+      type: "team_task",
+      to_team: "backend",
+      workflow: "implement",
+      expects: "h2",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects team_task step missing required expects", () => {
+    const r = WorkflowStepSchema.safeParse({
+      type: "team_task",
+      to_team: "backend",
+      workflow: "implement",
+      handoff: "h1",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects TeamInterfaceSchema without version", () => {
+    const r = TeamInterfaceSchema.safeParse({
+      description: "no version",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects TeamImportSchema without interface field", () => {
+    const r = TeamImportSchema.safeParse({
+      version: ">=1",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects TeamInterfaceSchema with non-number version", () => {
+    const r = TeamInterfaceSchema.safeParse({
+      version: "1",
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
 describe("generated JSON Schema (dsl.schema.json)", () => {
   it("exists and has expected top-level structure", () => {
     const schemaPath = join(__dirname, "../../schemas/dsl.schema.json");
@@ -864,6 +1081,8 @@ describe("generated JSON Schema (dsl.schema.json)", () => {
     expect(props).toHaveProperty("guardrail_policies");
     expect(props).toHaveProperty("extensions");
     expect(props).toHaveProperty("extensions_strict");
+    expect(props).toHaveProperty("team_interface");
+    expect(props).toHaveProperty("imports");
     expect(raw.required).toEqual([
       "version",
       "system",

--- a/test/validator/team-interface-refs.test.ts
+++ b/test/validator/team-interface-refs.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import { DslSchema } from "../../src/schema/index.js";
+import { checkReferences } from "../../src/validator/reference-resolver.js";
+
+const handoff = { version: 1, schema: { type: "object" } };
+
+function minimalArtifact(owner = "a1") {
+  return {
+    type: "code",
+    owner,
+    producers: [owner],
+    editors: [owner],
+    consumers: [owner],
+    states: ["draft"],
+  };
+}
+
+function buildBaseDsl() {
+  return {
+    version: 1,
+    system: {
+      id: "sys",
+      name: "System",
+      default_workflow_order: ["feature-implement", "w1"],
+    },
+    agents: {
+      a1: {
+        role_name: "R",
+        purpose: "P",
+        can_read_artifacts: ["api_contract"],
+      },
+    },
+    artifacts: {
+      api_contract: minimalArtifact(),
+    },
+    handoff_types: {
+      "feature-request": handoff,
+      "implementation-result": handoff,
+      "h-in": handoff,
+      "h-out": handoff,
+    },
+    workflow: {
+      "feature-implement": {
+        steps: [{ type: "handoff" as const, handoff_kind: "task-delegation" }],
+      },
+      w1: {
+        steps: [
+          {
+            type: "team_task" as const,
+            to_team: "backend",
+            workflow: "implement",
+            handoff: "h-in",
+            expects: "h-out",
+          },
+        ],
+      },
+    },
+    imports: {
+      backend: { interface: "./teams/backend/team-interface.yaml" },
+    },
+    team_interface: {
+      version: 1,
+      accepts: {
+        workflows: {
+          implement: {
+            internal_workflow: "feature-implement",
+            input_handoff: "feature-request",
+            output_handoff: "implementation-result",
+          },
+        },
+      },
+      exposes: { artifacts: ["api_contract"] },
+    },
+  };
+}
+
+describe("checkReferences team_interface and team_task", () => {
+  it("has no diagnostics for team_interface with valid internal refs", () => {
+    const dsl = DslSchema.parse(buildBaseDsl());
+    expect(checkReferences(dsl)).toEqual([]);
+  });
+
+  it("reports team-interface-workflow-not-found for unknown internal workflow", () => {
+    const raw = buildBaseDsl();
+    raw.team_interface = {
+      version: 1,
+      accepts: {
+        workflows: {
+          implement: {
+            internal_workflow: "missing-workflow",
+            input_handoff: "feature-request",
+            output_handoff: "implementation-result",
+          },
+        },
+      },
+    };
+    const dsl = DslSchema.parse(raw);
+    const diagnostics = checkReferences(dsl);
+    expect(diagnostics.some((d) => d.code === "team-interface-workflow-not-found")).toBe(true);
+  });
+
+  it("reports team-interface-handoff-not-found for unknown handoff ref", () => {
+    const raw = buildBaseDsl();
+    raw.team_interface = {
+      version: 1,
+      accepts: {
+        workflows: {
+          implement: {
+            internal_workflow: "feature-implement",
+            input_handoff: "no-such-handoff",
+            output_handoff: "implementation-result",
+          },
+        },
+      },
+    };
+    const dsl = DslSchema.parse(raw);
+    const diagnostics = checkReferences(dsl);
+    expect(diagnostics.some((d) => d.code === "team-interface-handoff-not-found")).toBe(true);
+  });
+
+  it("reports team-interface-artifact-not-found for unknown exposed artifact", () => {
+    const raw = buildBaseDsl();
+    raw.team_interface = {
+      version: 1,
+      accepts: {
+        workflows: {
+          implement: {
+            internal_workflow: "feature-implement",
+            input_handoff: "feature-request",
+            output_handoff: "implementation-result",
+          },
+        },
+      },
+      exposes: { artifacts: ["ghost-artifact"] },
+    };
+    const dsl = DslSchema.parse(raw);
+    const diagnostics = checkReferences(dsl);
+    expect(diagnostics.some((d) => d.code === "team-interface-artifact-not-found")).toBe(true);
+  });
+
+  it("has no diagnostics for team_task step when imports and handoffs are valid", () => {
+    const dsl = DslSchema.parse(buildBaseDsl());
+    const teamTaskDiags = checkReferences(dsl).filter((d) =>
+      d.path.includes("steps[0]"),
+    );
+    expect(teamTaskDiags).toEqual([]);
+  });
+
+  it("reports team-task-missing-imports when dsl.imports is absent", () => {
+    const raw = buildBaseDsl();
+    delete (raw as { imports?: unknown }).imports;
+    const dsl = DslSchema.parse(raw);
+    const diagnostics = checkReferences(dsl);
+    expect(diagnostics.some((d) => d.code === "team-task-missing-imports")).toBe(true);
+  });
+
+  it("reports team-import-not-found for team_task to_team not in imports", () => {
+    const raw = buildBaseDsl();
+    raw.imports = { other_team: { interface: "./other.yaml" } };
+    const dsl = DslSchema.parse(raw);
+    const diagnostics = checkReferences(dsl);
+    expect(diagnostics.some((d) => d.code === "team-import-not-found")).toBe(true);
+  });
+
+  it("reports reference-not-found for team_task handoff / expects", () => {
+    const raw = buildBaseDsl();
+    raw.workflow = {
+      ...raw.workflow,
+      w1: {
+        steps: [
+          {
+            type: "team_task" as const,
+            to_team: "backend",
+            workflow: "implement",
+            handoff: "unknown-handoff",
+            expects: "h-out",
+          },
+        ],
+      },
+    };
+    const dsl = DslSchema.parse(raw);
+    const diagnostics = checkReferences(dsl);
+    const handoffRefs = diagnostics.filter(
+      (d) => d.code === "reference-not-found" && d.path.includes("handoff"),
+    );
+    expect(handoffRefs.length).toBeGreaterThan(0);
+
+    const raw2 = buildBaseDsl();
+    raw2.workflow = {
+      ...raw2.workflow,
+      w1: {
+        steps: [
+          {
+            type: "team_task" as const,
+            to_team: "backend",
+            workflow: "implement",
+            handoff: "h-in",
+            expects: "unknown-expects",
+          },
+        ],
+      },
+    };
+    const dsl2 = DslSchema.parse(raw2);
+    const diagnostics2 = checkReferences(dsl2);
+    expect(
+      diagnostics2.some(
+        (d) => d.code === "reference-not-found" && d.path.includes("expects"),
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `team_interface` and `imports` as optional top-level DSL sections (Zod + JSON Schema)
- Add `team_task` workflow step type to the discriminated union for cross-team delegation
- Add `generate interface` CLI command that produces a self-contained `team-interface.yaml`
- Extend `check` command with interface-output drift detection
- Add reference validation for `team_interface` internals and `team_task` cross-team references
- Add sample multi-team YAML files demonstrating provider and consumer scenarios

## Changes

| Area | Files |
|------|-------|
| Schema | `src/schema/team-interface.ts` (new), `src/schema/team-import.ts` (new), `src/schema/workflow.ts`, `src/schema/dsl.ts`, `src/schema/index.ts` |
| Resolver | `src/resolver/merger.ts` (imports in MERGE_SECTIONS) |
| Validator | `src/validator/reference-resolver.ts` (team_interface + team_task checks) |
| CLI | `src/cli/commands/generate-guardrails.ts`, `src/cli/commands/generate-interface.ts` (new), `src/cli/commands/check.ts` |
| Generator | `src/interface-generator/generator.ts` (new), `src/interface-generator/index.ts` (new) |
| JSON Schema | `schemas/dsl.schema.json` (regenerated) |
| Samples | `sample/multi-team/backend-team.yaml`, `sample/multi-team/qa-consumer.yaml`, `sample/multi-team/README.md` |
| Tests | `test/schema/schema.test.ts`, `test/validator/team-interface-refs.test.ts` (new), `test/interface-generator/generator.test.ts` (new) |

## Test plan

- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [x] All 666 tests pass (631 existing + 35 new)
- [x] No linter errors on changed files
- [x] Existing DSL files without `team_interface` continue to work
- [x] Schema tests cover both valid and invalid inputs
- [x] Reference resolver tests cover team_interface refs and team_task cross-team refs
- [x] Interface generator tests cover YAML/JSON output, handoff filtering, error paths
- [x] Test Police audit: PASS (0 violations)

Closes #25

Made with [Cursor](https://cursor.com)