### PR TITLE
feat: Multi-team config support (teams + _defaults)

### DIFF
--- a/README.md
+++ b/README.md
@@ -916,6 +916,8 @@ npx agent-contracts
 The `[path]` argument defaults to `agent-contracts.yaml` in the current directory.
 If `-c` / `--config` is specified, the DSL path from the config file is used.
 
+All commands also accept `--team <id>` to limit execution to a single team when using a [multi-team configuration](#multi-team-configuration).
+
 #### `resolve` options
 
 | Option | Description |
@@ -923,6 +925,7 @@ If `-c` / `--config` is specified, the DSL path from the config file is used.
 | `--format <text\|json>` | Output format (default: `text`) |
 | `--expand-defaults` | Expand all Zod default values in output. Fields like `required_validations: []`, `tags: []`, and `can_read_artifacts: []` are written explicitly instead of being silently applied by schema defaults. |
 | `-c, --config <path>` | Path to `agent-contracts.config.yaml` |
+| `--team <id>` | Limit to one team (multi-team config only) |
 
 #### `score` options
 
@@ -931,6 +934,7 @@ If `-c` / `--config` is specified, the DSL path from the config file is used.
 | `--format <text\|json>` | Output format (default: `text`) |
 | `--threshold <number>` | Minimum score; exit 1 if below (for CI gates) |
 | `-c, --config <path>` | Path to `agent-contracts.config.yaml` |
+| `--team <id>` | Limit to one team (multi-team config only) |
 
 The score command evaluates 7 dimensions:
 

--- a/README.md
+++ b/README.md
@@ -994,6 +994,60 @@ This lets you generate static outputs for:
 
 all from the same resolved DSL.
 
+### Multi-team configuration
+
+When several teams (for example backend, QA, infra) are managed from one workspace, you can list every team in a single config file instead of maintaining separate configs.
+
+````yaml
+teams:
+  _defaults:
+    bindings:
+      - ./bindings/cursor.yaml
+    vars:
+      language: TypeScript
+    paths:
+      cursor_root: .cursor
+    active_guardrail_policy: default-enforcement
+
+  backend:
+    dsl: ./teams/backend/agent-contracts.yaml
+    interface_output: ./teams/backend/team-interface.yaml
+    bindings:
+      - ./teams/backend/bindings/observability.yaml
+    vars:
+      team_name: backend
+
+  qa:
+    dsl: ./teams/qa/agent-contracts.yaml
+    vars:
+      team_name: qa
+````
+
+**`_defaults`:** Reserved meta-entry in the `teams` map. It uses the same schema as team entries except `dsl` is not required. Values are inherited by all teams. The underscore prefix avoids colliding with real team IDs.
+
+**Merge with `_defaults`:**
+
+* `bindings` — `_defaults` bindings are prepended before team-specific bindings
+* `vars` — shallow merge; team values win
+* `paths` — shallow merge; team values win
+* `active_guardrail_policy` — team wins when present
+
+All commands accept `--team <id>` to run against a single team:
+
+````bash
+agent-contracts validate -c config.yaml              # all teams
+agent-contracts validate -c config.yaml --team backend  # one team
+agent-contracts check -c config.yaml --team qa          # one team
+````
+
+The `check` command also validates that imported interface files exist on disk (cross-team references).
+
+**Design constraints:**
+
+* `dsl` and `teams` are mutually exclusive at the config root
+* Every team except `_defaults` must specify `dsl`
+* Existing single-team configs (top-level `dsl` only) remain valid unchanged
+
 ### Render target options
 
 Each entry in `renders` supports these fields:

--- a/docs/spec/guardrail-di.md
+++ b/docs/spec/guardrail-di.md
@@ -318,14 +318,24 @@ export const DslSchema = z
 
 ```typescript
 // src/config/types.ts
-export const AgentContractsConfigSchema = z.object({
-  dsl: z.string(),
+export const TeamConfigSchema = z.object({
+  dsl: z.string().optional(),
+  bindings: z.array(z.string()).default([]),
   vars: z.record(z.string(), z.string()).optional(),
-  renders: z.array(RenderTargetSchema).min(1),
-  bindings: z.array(z.string()).default([]),                   // NEW
-  active_guardrail_policy: z.string().optional(),              // NEW
-  paths: z.record(z.string(), z.string()).optional(),          // NEW
+  paths: z.record(z.string(), z.string()).optional(),
+  active_guardrail_policy: z.string().optional(),
+  interface_output: z.string().optional(),
 });
+
+export const AgentContractsConfigSchema = z.object({
+  dsl: z.string().optional(),
+  vars: z.record(z.string(), z.string()).optional(),
+  renders: z.array(RenderTargetSchema).default([]),
+  bindings: z.array(z.string()).default([]),
+  active_guardrail_policy: z.string().optional(),
+  paths: z.record(z.string(), z.string()).optional(),
+  teams: z.record(z.string(), TeamConfigSchema).optional(),    // NEW: multi-team
+}).superRefine(/* dsl ↔ teams mutual exclusion; each team (except _defaults) must set dsl */);
 ```
 
 ### 3.2 New Fields
@@ -335,6 +345,7 @@ export const AgentContractsConfigSchema = z.object({
 | `bindings` | no | Array of file paths to software binding YAML files |
 | `active_guardrail_policy` | no | Key in DSL `guardrail_policies` to use for generation |
 | `paths` | no | Logical root directory mapping for output path resolution |
+| `teams` | no | Map of team ID → team config; mutually exclusive with top-level `dsl` |
 
 ### 3.3 `paths` — Project Placement Knowledge
 
@@ -383,7 +394,7 @@ All new fields are optional with safe defaults:
 - `active_guardrail_policy` defaults to `undefined` (no policy applied)
 - `paths` defaults to `undefined` (binding targets used as-is)
 
-Existing configs without guardrail fields continue to work without modification. The `renders` field remains required with `.min(1)`.
+Existing configs without guardrail fields continue to work without modification. The `renders` field defaults to `[]`. When `teams` is present, top-level `dsl` is omitted; each team entry must specify its own `dsl`.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-contracts",
-  "version": "0.11.5",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-contracts",
-      "version": "0.11.5",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "@stoplight/spectral-core": "^1.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/sample/multi-team/config.yaml
+++ b/sample/multi-team/config.yaml
@@ -1,0 +1,18 @@
+# Multi-team configuration example
+# Rename to agent-contracts.config.yaml in your project, or use -c to specify.
+# Each team uses the sample DSL; real setups usually point each team at its own YAML.
+
+teams:
+  _defaults:
+    vars:
+      language: TypeScript
+
+  backend:
+    dsl: ../agent-contracts.yaml
+    vars:
+      team_name: backend
+
+  qa:
+    dsl: ../agent-contracts.yaml
+    vars:
+      team_name: qa

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -1,20 +1,25 @@
 import { Command } from "commander";
+import { access } from "node:fs/promises";
+import { resolve as pathResolve, dirname } from "node:path";
 import { loadConfig, loadBindings, ConfigLoadError } from "../../config/index.js";
 import { resolve, substituteVars } from "../../resolver/index.js";
 import { validateSchema, checkReferences, validateHandoffSchemas } from "../../validator/index.js";
 import { lint, spectralLint } from "../../linter/index.js";
 import { checkDriftFromConfig, type RenderOptions } from "../../renderer/index.js";
 import { formatDiagnostics, type OutputFormat } from "../format.js";
+import { getTeamEntries, isMultiTeamConfig } from "../multi-team.js";
 
 export const checkCommand = new Command("check")
   .description("Run full pipeline: resolve → validate → lint → render --check")
   .option("-c, --config <path>", "Path to agent-contracts.config.yaml")
+  .option("--team <id>", "Limit to one team (multi-team config only)")
   .option("--format <format>", "Output format (text|json)", "text")
   .option("--quiet", "Suppress output on success", false)
   .option("--strict", "Treat warnings as errors", false)
   .action(
     async (opts: {
       config?: string;
+      team?: string;
       format: OutputFormat;
       quiet: boolean;
       strict: boolean;
@@ -28,6 +33,124 @@ export const checkCommand = new Command("check")
             "Error: agent-contracts.config.yaml not found. Use --config to specify path.\n",
           );
           process.exit(1);
+        }
+
+        if (isMultiTeamConfig(config)) {
+          const teamEntries = getTeamEntries(config, opts.team);
+          for (const [teamId, teamConfig] of teamEntries) {
+            if (!opts.quiet) process.stderr.write(`\n--- Team: ${teamId} ---\n`);
+            const resolved = await resolve(teamConfig.dsl);
+            const data = teamConfig.vars
+              ? substituteVars(resolved.data, teamConfig.vars)
+              : resolved.data;
+
+            const schemaResult = validateSchema(data);
+            const schemaWarnings = schemaResult.diagnostics.filter(
+              (d) => d.severity === "warning",
+            );
+            if (!schemaResult.success) {
+              const output = formatDiagnostics(schemaResult.diagnostics, {
+                format: opts.format,
+                quiet: opts.quiet,
+              });
+              if (output) process.stderr.write(output + "\n");
+              hasErrors = true;
+              continue;
+            }
+
+            const refDiags = checkReferences(schemaResult.data!);
+            const handoffDiags = validateHandoffSchemas(schemaResult.data!);
+            const allRefDiags = [...refDiags, ...handoffDiags, ...schemaWarnings];
+            if (allRefDiags.length > 0) {
+              const output = formatDiagnostics(allRefDiags, {
+                format: opts.format,
+                quiet: opts.quiet,
+              });
+              if (output) process.stderr.write(output + "\n");
+              hasErrors = true;
+            }
+
+            const tsLintDiags = lint(schemaResult.data!);
+            const spectralDiags = await spectralLint(
+              schemaResult.data! as unknown as Record<string, unknown>,
+            );
+            const lintDiags = [...tsLintDiags, ...spectralDiags];
+            if (lintDiags.length > 0) {
+              const output = formatDiagnostics(lintDiags, {
+                format: opts.format,
+                quiet: opts.quiet,
+              });
+              if (output) process.stderr.write(output + "\n");
+
+              if (lintDiags.some((d) => d.severity === "error")) {
+                hasErrors = true;
+              }
+              if (opts.strict && lintDiags.some((d) => d.severity === "warning")) {
+                hasErrors = true;
+              }
+            }
+
+            let renderOptions: RenderOptions | undefined;
+            if (teamConfig.bindings.length > 0) {
+              const loadedBindings = await loadBindings(teamConfig.bindings);
+              renderOptions = {
+                loadedBindings,
+                activeGuardrailPolicy: teamConfig.activeGuardrailPolicy,
+              };
+            }
+
+            const drift = await checkDriftFromConfig(
+              schemaResult.data!,
+              config.renders,
+              renderOptions,
+            );
+
+            if (drift.hasDrift) {
+              process.stderr.write(`Drift detected for team ${teamId} in:\n`);
+              for (const f of drift.diffs) {
+                process.stderr.write(`  ${f}\n`);
+              }
+              hasErrors = true;
+            }
+          }
+
+          if (!hasErrors) {
+            // Cross-team: verify imported interface files exist
+            for (const [teamId, teamConfig] of teamEntries) {
+              const resolved = await resolve(teamConfig.dsl);
+              const data = teamConfig.vars
+                ? substituteVars(resolved.data, teamConfig.vars)
+                : resolved.data;
+              const schemaResult = validateSchema(data);
+              if (!schemaResult.success || !schemaResult.data) continue;
+              const dsl = schemaResult.data as Record<string, unknown>;
+              const imports = dsl.imports as
+                | Record<string, { interface?: string }>
+                | undefined;
+              if (!imports) continue;
+              for (const [importName, importDef] of Object.entries(imports)) {
+                const interfacePathRel = importDef?.interface;
+                if (typeof interfacePathRel !== "string") continue;
+                const interfacePath = pathResolve(
+                  dirname(teamConfig.dsl),
+                  interfacePathRel,
+                );
+                try {
+                  await access(interfacePath);
+                } catch {
+                  process.stderr.write(
+                    `Cross-team error: Team "${teamId}" imports "${importName}" ` +
+                      `but interface file not found: ${interfacePath}\n`,
+                  );
+                  hasErrors = true;
+                }
+              }
+            }
+          }
+
+          if (hasErrors) process.exit(1);
+          if (!opts.quiet) process.stdout.write("All checks passed.\n");
+          return;
         }
 
         const resolved = await resolve(config.dsl);

--- a/src/cli/commands/generate-guardrails.ts
+++ b/src/cli/commands/generate-guardrails.ts
@@ -1,20 +1,44 @@
 import { Command } from "commander";
+import type { ResolvedConfig, ResolvedTeamConfig } from "../../config/types.js";
 import { loadConfig, ConfigLoadError, loadBindings } from "../../config/index.js";
 import { resolve, substituteVars } from "../../resolver/index.js";
 import { validateSchema } from "../../validator/index.js";
 import { generateGuardrails } from "../../guardrail-generator/index.js";
+import { getTeamEntries, isMultiTeamConfig } from "../multi-team.js";
+
+function resolvedConfigForTeam(
+  workspace: ResolvedConfig,
+  teamConfig: ResolvedTeamConfig,
+): ResolvedConfig {
+  return {
+    dsl: "",
+    vars: teamConfig.vars,
+    renders: workspace.renders,
+    configDir: workspace.configDir,
+    bindings: teamConfig.bindings,
+    activeGuardrailPolicy: teamConfig.activeGuardrailPolicy,
+    paths: teamConfig.paths,
+  };
+}
 
 export const generateGuardrailsCommand = new Command("generate")
   .description("Generate guardrail runtime artifacts from DSL, policies, and bindings")
   .argument("[type]", "Type of artifacts to generate", "guardrails")
   .option("-c, --config <path>", "Path to agent-contracts.config.yaml")
+  .option("--team <id>", "Limit to one team (multi-team config only)")
   .option("--binding <name...>", "Filter to specific software binding(s)")
   .option("--dry-run", "Print what would be generated without writing files", false)
   .option("--quiet", "Suppress output on success", false)
   .action(
     async (
       type: string,
-      opts: { config?: string; binding?: string[]; dryRun: boolean; quiet: boolean },
+      opts: {
+        config?: string;
+        team?: string;
+        binding?: string[];
+        dryRun: boolean;
+        quiet: boolean;
+      },
     ) => {
       if (type !== "guardrails") {
         process.stderr.write(`Unknown generate type: ${type}\n`);
@@ -28,6 +52,73 @@ export const generateGuardrailsCommand = new Command("generate")
             "Error: agent-contracts.config.yaml not found. Use --config to specify path.\n",
           );
           process.exit(1);
+        }
+
+        if (isMultiTeamConfig(config)) {
+          const teamEntries = getTeamEntries(config, opts.team);
+          let exitWithError = false;
+          for (const [teamId, teamConfig] of teamEntries) {
+            if (!opts.quiet) process.stdout.write(`\n--- Team: ${teamId} ---\n`);
+            const resolved = await resolve(teamConfig.dsl);
+            const data = teamConfig.vars
+              ? substituteVars(resolved.data, teamConfig.vars)
+              : resolved.data;
+            const schemaResult = validateSchema(data);
+
+            if (!schemaResult.success) {
+              process.stderr.write(
+                `Schema validation failed for team ${teamId}. Run 'agent-contracts validate' for details.\n`,
+              );
+              exitWithError = true;
+              continue;
+            }
+
+            const loadedBindings = await loadBindings(teamConfig.bindings);
+            const result = await generateGuardrails({
+              dsl: schemaResult.data!,
+              config: resolvedConfigForTeam(config, teamConfig),
+              loadedBindings,
+              filterBindings: opts.binding,
+              dryRun: opts.dryRun,
+            });
+
+            const errors = result.diagnostics.filter((d) => d.severity === "error");
+            const warnings = result.diagnostics.filter((d) => d.severity === "warning");
+            const infos = result.diagnostics.filter((d) => d.severity === "info");
+
+            if (errors.length > 0) {
+              process.stderr.write(`Errors (team ${teamId}):\n`);
+              for (const d of errors) {
+                process.stderr.write(`  error [${d.path}] ${d.message}\n`);
+              }
+              exitWithError = true;
+            }
+
+            if (warnings.length > 0 && !opts.quiet) {
+              process.stderr.write(`Warnings (team ${teamId}):\n`);
+              for (const d of warnings) {
+                process.stderr.write(`  warning [${d.path}] ${d.message}\n`);
+              }
+            }
+
+            if (infos.length > 0 && !opts.quiet) {
+              for (const d of infos) {
+                process.stderr.write(`  info [${d.path}] ${d.message}\n`);
+              }
+            }
+
+            if (!opts.quiet) {
+              const action = opts.dryRun ? "Would generate" : "Generated";
+              process.stdout.write(
+                `${action} ${result.outputFiles.length} file(s):\n`,
+              );
+              for (const f of result.outputFiles) {
+                process.stdout.write(`  ${f}\n`);
+              }
+            }
+          }
+          if (exitWithError) process.exit(1);
+          return;
         }
 
         // Load and validate DSL

--- a/src/cli/commands/lint.ts
+++ b/src/cli/commands/lint.ts
@@ -4,6 +4,7 @@ import { resolve, substituteVars } from "../../resolver/index.js";
 import { validateSchema } from "../../validator/index.js";
 import { lint, spectralLint } from "../../linter/index.js";
 import { formatDiagnostics, type OutputFormat } from "../format.js";
+import { getTeamEntries, isMultiTeamConfig } from "../multi-team.js";
 
 const DIR_DEFAULT = "agent-contracts.yaml";
 
@@ -11,16 +12,83 @@ export const lintCommand = new Command("lint")
   .description("Run semantic lint rules on resolved DSL")
   .argument("[dir]", "Path to agent-contracts.yaml", DIR_DEFAULT)
   .option("-c, --config <path>", "Path to agent-contracts.config.yaml")
+  .option("--team <id>", "Limit to one team (multi-team config only)")
   .option("--format <format>", "Output format (text|json)", "text")
   .option("--quiet", "Suppress output on success", false)
   .option("--strict", "Treat warnings as errors", false)
   .action(
     async (
       dir: string,
-      opts: { config?: string; format: OutputFormat; quiet: boolean; strict: boolean },
+      opts: {
+        config?: string;
+        team?: string;
+        format: OutputFormat;
+        quiet: boolean;
+        strict: boolean;
+      },
     ) => {
       try {
         const config = await loadConfig(opts.config);
+
+        if (config !== null && isMultiTeamConfig(config)) {
+          const teamEntries = getTeamEntries(config, opts.team);
+          let hasErrors = false;
+          let allClean = true;
+          for (const [teamId, teamConfig] of teamEntries) {
+            if (!opts.quiet) process.stdout.write(`\n--- Team: ${teamId} ---\n`);
+            const resolved = await resolve(teamConfig.dsl);
+            const data = teamConfig.vars
+              ? substituteVars(resolved.data, teamConfig.vars)
+              : resolved.data;
+            const schemaResult = validateSchema(data);
+            const schemaWarnings = schemaResult.diagnostics.filter(
+              (d) => d.severity === "warning",
+            );
+
+            if (!schemaResult.success) {
+              const output = formatDiagnostics(schemaResult.diagnostics, {
+                format: opts.format,
+                quiet: opts.quiet,
+              });
+              if (output) process.stderr.write(output + "\n");
+              hasErrors = true;
+              allClean = false;
+              continue;
+            }
+
+            const tsDiagnostics = lint(schemaResult.data!);
+            const spectralDiagnostics = await spectralLint(
+              schemaResult.data! as unknown as Record<string, unknown>,
+            );
+            const diagnostics = [
+              ...tsDiagnostics,
+              ...spectralDiagnostics,
+              ...schemaWarnings,
+            ];
+            if (diagnostics.length > 0) {
+              allClean = false;
+              const output = formatDiagnostics(diagnostics, {
+                format: opts.format,
+                quiet: opts.quiet,
+              });
+              if (output) process.stderr.write(output + "\n");
+
+              const teamHasErrors = diagnostics.some((d) => d.severity === "error");
+              const teamHasWarnings = diagnostics.some((d) => d.severity === "warning");
+
+              if (teamHasErrors || (opts.strict && teamHasWarnings)) {
+                hasErrors = true;
+              }
+            }
+          }
+
+          if (hasErrors) process.exit(1);
+          if (!opts.quiet && allClean) {
+            process.stdout.write("Lint passed.\n");
+          }
+          return;
+        }
+
         const dslPath = resolveDslPath(dir, DIR_DEFAULT, config);
         const resolved = await resolve(dslPath);
         const data = config?.vars

--- a/src/cli/commands/render.ts
+++ b/src/cli/commands/render.ts
@@ -3,14 +3,16 @@ import { loadConfig, loadBindings, ConfigLoadError } from "../../config/index.js
 import { resolve, substituteVars } from "../../resolver/index.js";
 import { validateSchema } from "../../validator/index.js";
 import { renderFromConfig, checkDriftFromConfig, type RenderOptions } from "../../renderer/index.js";
+import { getTeamEntries, isMultiTeamConfig } from "../multi-team.js";
 
 export const renderCommand = new Command("render")
   .description("Render resolved DSL with Handlebars templates (requires config)")
   .option("-c, --config <path>", "Path to agent-contracts.config.yaml")
+  .option("--team <id>", "Limit to one team (multi-team config only)")
   .option("--check", "Check for drift without writing files", false)
   .option("--quiet", "Suppress output on success", false)
   .action(
-    async (opts: { config?: string; check: boolean; quiet: boolean }) => {
+    async (opts: { config?: string; team?: string; check: boolean; quiet: boolean }) => {
       try {
         const config = await loadConfig(opts.config);
         if (!config) {
@@ -18,6 +20,64 @@ export const renderCommand = new Command("render")
             "Error: agent-contracts.config.yaml not found. Use --config to specify path.\n",
           );
           process.exit(1);
+        }
+
+        if (isMultiTeamConfig(config)) {
+          const teamEntries = getTeamEntries(config, opts.team);
+          for (const [teamId, teamConfig] of teamEntries) {
+            if (!opts.quiet) process.stdout.write(`\n--- Team: ${teamId} ---\n`);
+            const resolved = await resolve(teamConfig.dsl);
+            const data = teamConfig.vars
+              ? substituteVars(resolved.data, teamConfig.vars)
+              : resolved.data;
+            const schemaResult = validateSchema(data);
+            if (!schemaResult.success) {
+              process.stderr.write(
+                `Schema validation failed for team ${teamId}. Run 'agent-contracts validate' for details.\n`,
+              );
+              process.exit(1);
+            }
+            let renderOptions: RenderOptions | undefined;
+            if (teamConfig.bindings.length > 0) {
+              const loadedBindings = await loadBindings(teamConfig.bindings);
+              renderOptions = {
+                loadedBindings,
+                activeGuardrailPolicy: teamConfig.activeGuardrailPolicy,
+              };
+            }
+            if (opts.check) {
+              const drift = await checkDriftFromConfig(
+                schemaResult.data!,
+                config.renders,
+                renderOptions,
+              );
+              if (drift.hasDrift) {
+                process.stderr.write(
+                  `Drift detected for team ${teamId} in the following files:\n`,
+                );
+                for (const f of drift.diffs) {
+                  process.stderr.write(`  ${f}\n`);
+                }
+                process.exit(1);
+              }
+              if (!opts.quiet) {
+                process.stdout.write("No drift detected.\n");
+              }
+            } else {
+              const files = await renderFromConfig(
+                schemaResult.data!,
+                config.renders,
+                renderOptions,
+              );
+              if (!opts.quiet) {
+                process.stdout.write(`Rendered ${files.length} file(s):\n`);
+                for (const f of files) {
+                  process.stdout.write(`  ${f}\n`);
+                }
+              }
+            }
+          }
+          return;
         }
 
         const resolved = await resolve(config.dsl);

--- a/src/cli/commands/resolve.ts
+++ b/src/cli/commands/resolve.ts
@@ -3,6 +3,7 @@ import { loadConfig, resolveDslPath } from "../../config/index.js";
 import { resolve, substituteVars } from "../../resolver/index.js";
 import { expandDefaults } from "../../resolver/expand-defaults.js";
 import { stringify } from "yaml";
+import { getTeamEntries, isMultiTeamConfig } from "../multi-team.js";
 
 const DIR_DEFAULT = "agent-contracts.yaml";
 
@@ -10,11 +11,48 @@ export const resolveCommand = new Command("resolve")
   .description("Resolve DSL (load + merge extends) and output YAML")
   .argument("[dir]", "Path to agent-contracts.yaml", DIR_DEFAULT)
   .option("-c, --config <path>", "Path to agent-contracts.config.yaml")
+  .option("--team <id>", "Limit to one team (multi-team config only)")
   .option("--format <format>", "Output format (text|json)", "text")
   .option("--expand-defaults", "Expand all Zod default values in output", false)
-  .action(async (dir: string, opts: { config?: string; format: string; expandDefaults: boolean }) => {
+  .action(
+    async (
+      dir: string,
+      opts: { config?: string; team?: string; format: string; expandDefaults: boolean },
+    ) => {
     try {
       const config = await loadConfig(opts.config);
+
+      if (config !== null && isMultiTeamConfig(config)) {
+        const teamEntries = getTeamEntries(config, opts.team);
+        if (opts.format === "json") {
+          const out: Record<string, unknown> = {};
+          for (const [teamId, teamConfig] of teamEntries) {
+            const result = await resolve(teamConfig.dsl);
+            let data = teamConfig.vars
+              ? substituteVars(result.data, teamConfig.vars)
+              : result.data;
+            if (opts.expandDefaults) {
+              data = expandDefaults(data);
+            }
+            out[teamId] = data;
+          }
+          process.stdout.write(JSON.stringify(out, null, 2) + "\n");
+        } else {
+          for (const [teamId, teamConfig] of teamEntries) {
+            process.stdout.write(`\n--- Team: ${teamId} ---\n`);
+            const result = await resolve(teamConfig.dsl);
+            let data = teamConfig.vars
+              ? substituteVars(result.data, teamConfig.vars)
+              : result.data;
+            if (opts.expandDefaults) {
+              data = expandDefaults(data);
+            }
+            process.stdout.write(stringify(data));
+          }
+        }
+        return;
+      }
+
       const dslPath = resolveDslPath(dir, DIR_DEFAULT, config);
       const result = await resolve(dslPath);
       let data = config?.vars
@@ -33,4 +71,5 @@ export const resolveCommand = new Command("resolve")
       process.stderr.write(`Error: ${msg}\n`);
       process.exit(1);
     }
-  });
+  },
+  );

--- a/src/cli/commands/score.ts
+++ b/src/cli/commands/score.ts
@@ -5,6 +5,7 @@ import { validateSchema } from "../../validator/index.js";
 import { score } from "../../scorer/index.js";
 import type { ScoreResult } from "../../scorer/index.js";
 import type { OutputFormat } from "../format.js";
+import { getTeamEntries, isMultiTeamConfig } from "../multi-team.js";
 
 const DIR_DEFAULT = "agent-contracts.yaml";
 
@@ -37,6 +38,7 @@ export const scoreCommand = new Command("score")
   .description("Calculate DSL completeness score")
   .argument("[dir]", "Path to agent-contracts.yaml", DIR_DEFAULT)
   .option("-c, --config <path>", "Path to agent-contracts.config.yaml")
+  .option("--team <id>", "Limit to one team (multi-team config only)")
   .option("--format <format>", "Output format (text|json)", "text")
   .option("--threshold <number>", "Minimum score (exit 1 if below)", undefined)
   .action(
@@ -44,12 +46,64 @@ export const scoreCommand = new Command("score")
       dir: string,
       opts: {
         config?: string;
+        team?: string;
         format: OutputFormat;
         threshold?: string;
       },
     ) => {
       try {
         const config = await loadConfig(opts.config);
+
+        if (config !== null && isMultiTeamConfig(config)) {
+          const teamEntries = getTeamEntries(config, opts.team);
+          let thresholdNum: number | undefined;
+          if (opts.threshold !== undefined) {
+            thresholdNum = parseInt(opts.threshold, 10);
+            if (isNaN(thresholdNum)) {
+              process.stderr.write(
+                `Error: --threshold must be a number, got "${opts.threshold}"\n`,
+              );
+              process.exit(1);
+            }
+          }
+
+          let hasErrors = false;
+          for (const [teamId, teamConfig] of teamEntries) {
+            process.stdout.write(`\n--- Team: ${teamId} ---\n`);
+            const resolved = await resolve(teamConfig.dsl);
+            const data = teamConfig.vars
+              ? substituteVars(resolved.data, teamConfig.vars)
+              : resolved.data;
+            const schemaResult = validateSchema(data);
+
+            if (!schemaResult.success) {
+              const issues = schemaResult.diagnostics
+                .map((d) => `  ${d.path}: ${d.message}`)
+                .join("\n");
+              process.stderr.write(`Schema validation failed:\n${issues}\n`);
+              hasErrors = true;
+              continue;
+            }
+
+            const result = score(schemaResult.data!);
+
+            if (opts.format === "json") {
+              process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+            } else {
+              process.stdout.write(formatText(result) + "\n");
+            }
+
+            if (thresholdNum !== undefined && result.overall < thresholdNum) {
+              process.stderr.write(
+                `Score ${result.overall} is below threshold ${thresholdNum}\n`,
+              );
+              hasErrors = true;
+            }
+          }
+          if (hasErrors) process.exit(1);
+          return;
+        }
+
         const dslPath = resolveDslPath(dir, DIR_DEFAULT, config);
         const resolved = await resolve(dslPath);
         const data = config?.vars

--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -3,6 +3,7 @@ import { loadConfig, resolveDslPath } from "../../config/index.js";
 import { resolve, substituteVars } from "../../resolver/index.js";
 import { validateSchema, checkReferences, validateHandoffSchemas } from "../../validator/index.js";
 import { formatDiagnostics, type FormatOptions } from "../format.js";
+import { getTeamEntries, isMultiTeamConfig } from "../multi-team.js";
 
 const DIR_DEFAULT = "agent-contracts.yaml";
 
@@ -10,12 +11,67 @@ export const validateCommand = new Command("validate")
   .description("Validate DSL against schema and check references")
   .argument("[dir]", "Path to agent-contracts.yaml", DIR_DEFAULT)
   .option("-c, --config <path>", "Path to agent-contracts.config.yaml")
+  .option("--team <id>", "Limit to one team (multi-team config only)")
   .option("--format <format>", "Output format (text|json)", "text")
   .option("--quiet", "Suppress output on success", false)
   .option("--strict", "Treat warnings as errors", false)
-  .action(async (dir: string, opts: FormatOptions & { config?: string; strict: boolean }) => {
+  .action(
+    async (
+      dir: string,
+      opts: FormatOptions & { config?: string; team?: string; strict: boolean },
+    ) => {
     try {
       const config = await loadConfig(opts.config);
+
+      if (config !== null && isMultiTeamConfig(config)) {
+        const teamEntries = getTeamEntries(config, opts.team);
+        let hasErrors = false;
+        let allTeamsFullyClean = true;
+        for (const [teamId, teamConfig] of teamEntries) {
+          if (!opts.quiet) process.stdout.write(`\n--- Team: ${teamId} ---\n`);
+          const resolved = await resolve(teamConfig.dsl);
+          const data = teamConfig.vars
+            ? substituteVars(resolved.data, teamConfig.vars)
+            : resolved.data;
+          const schemaResult = validateSchema(data);
+          const schemaWarnings = schemaResult.diagnostics.filter(
+            (d) => d.severity === "warning",
+          );
+
+          if (!schemaResult.success) {
+            const output = formatDiagnostics(schemaResult.diagnostics, opts);
+            if (output) process.stderr.write(output + "\n");
+            hasErrors = true;
+            allTeamsFullyClean = false;
+            continue;
+          }
+
+          const refDiags = checkReferences(schemaResult.data!);
+          const handoffDiags = validateHandoffSchemas(schemaResult.data!);
+          const allDiags = [...refDiags, ...handoffDiags, ...schemaWarnings];
+          const hasWarnings = allDiags.some(
+            (d) => "severity" in d && d.severity === "warning",
+          );
+          if (allDiags.length > 0) {
+            allTeamsFullyClean = false;
+            const output = formatDiagnostics(allDiags, opts);
+            if (output) process.stderr.write(output + "\n");
+            if (
+              refDiags.length > 0 ||
+              handoffDiags.length > 0 ||
+              (opts.strict && hasWarnings)
+            ) {
+              hasErrors = true;
+            }
+          }
+        }
+        if (hasErrors) process.exit(1);
+        if (!opts.quiet && allTeamsFullyClean) {
+          process.stdout.write("Validation passed.\n");
+        }
+        return;
+      }
+
       const dslPath = resolveDslPath(dir, DIR_DEFAULT, config);
       const resolved = await resolve(dslPath);
       const data = config?.vars
@@ -58,4 +114,5 @@ export const validateCommand = new Command("validate")
       process.stderr.write(`Error: ${msg}\n`);
       process.exit(1);
     }
-  });
+  },
+  );

--- a/src/cli/multi-team.ts
+++ b/src/cli/multi-team.ts
@@ -1,0 +1,23 @@
+import type { ResolvedConfig, ResolvedTeamConfig } from "../config/types.js";
+
+export function isMultiTeamConfig(config: ResolvedConfig): boolean {
+  return config.teams !== undefined && Object.keys(config.teams).length > 0;
+}
+
+export function getTeamEntries(
+  config: ResolvedConfig,
+  teamFilter?: string,
+): [string, ResolvedTeamConfig][] {
+  if (!config.teams) return [];
+  const entries = Object.entries(config.teams);
+  if (teamFilter) {
+    const found = entries.filter(([k]) => k === teamFilter);
+    if (found.length === 0) {
+      throw new Error(
+        `Team "${teamFilter}" not found. Available teams: ${entries.map(([k]) => k).join(", ")}`,
+      );
+    }
+    return found;
+  }
+  return entries;
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,12 +5,15 @@ export {
 export {
   type AgentContractsConfig,
   type ResolvedConfig,
+  type ResolvedTeamConfig,
   type RenderTarget,
   type ResolvedRenderTarget,
+  type TeamConfig,
   type ContextType,
   CONTEXT_TYPES,
   AgentContractsConfigSchema,
   RenderTargetSchema,
+  TeamConfigSchema,
   ContextTypeSchema,
 } from "./types.js";
 export { loadConfig, resolveDslPath, ConfigLoadError } from "./loader.js";

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,7 +1,12 @@
 import { readFile, access } from "node:fs/promises";
 import { resolve, dirname } from "node:path";
 import { parse as parseYaml } from "yaml";
-import { AgentContractsConfigSchema, type ResolvedConfig } from "./types.js";
+import {
+  AgentContractsConfigSchema,
+  type ResolvedConfig,
+  type ResolvedTeamConfig,
+  type TeamConfig,
+} from "./types.js";
 
 const DEFAULT_CONFIG_NAME = "agent-contracts.config.yaml";
 
@@ -22,6 +27,46 @@ async function fileExists(filePath: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+function resolveTeamConfigs(
+  teams: Record<string, TeamConfig>,
+  configDir: string,
+): Record<string, ResolvedTeamConfig> {
+  const defaults = teams._defaults;
+  const result: Record<string, ResolvedTeamConfig> = {};
+
+  for (const [key, team] of Object.entries(teams)) {
+    if (key === "_defaults") continue;
+
+    const mergedBindings = [...(defaults?.bindings ?? []), ...team.bindings].map(
+      (b) => resolve(configDir, b),
+    );
+
+    const mergedVars =
+      defaults?.vars || team.vars
+        ? { ...(defaults?.vars ?? {}), ...(team.vars ?? {}) }
+        : undefined;
+
+    const mergedPaths =
+      defaults?.paths || team.paths
+        ? { ...(defaults?.paths ?? {}), ...(team.paths ?? {}) }
+        : undefined;
+
+    result[key] = {
+      dsl: resolve(configDir, team.dsl!),
+      bindings: mergedBindings,
+      vars: mergedVars,
+      activeGuardrailPolicy:
+        team.active_guardrail_policy ?? defaults?.active_guardrail_policy,
+      paths: mergedPaths,
+      interfaceOutput: team.interface_output
+        ? resolve(configDir, team.interface_output)
+        : undefined,
+    };
+  }
+
+  return result;
 }
 
 export async function loadConfig(
@@ -75,14 +120,29 @@ export async function loadConfig(
   const configDir = dirname(targetPath);
   const config = result.data;
 
+  const renders = config.renders.map((r) => ({
+    ...r,
+    template: resolve(configDir, r.template),
+    output: resolve(configDir, r.output),
+  }));
+
+  if (config.teams) {
+    return {
+      dsl: "",
+      vars: undefined,
+      renders,
+      configDir,
+      bindings: [],
+      activeGuardrailPolicy: undefined,
+      paths: undefined,
+      teams: resolveTeamConfigs(config.teams, configDir),
+    };
+  }
+
   return {
-    dsl: resolve(configDir, config.dsl),
+    dsl: resolve(configDir, config.dsl!),
     vars: config.vars,
-    renders: config.renders.map((r) => ({
-      ...r,
-      template: resolve(configDir, r.template),
-      output: resolve(configDir, r.output),
-    })),
+    renders,
     configDir,
     bindings: (config.bindings ?? []).map((b) => resolve(configDir, b)),
     activeGuardrailPolicy: config.active_guardrail_policy,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -34,14 +34,57 @@ export const RenderTargetSchema = z
 
 export type RenderTarget = z.infer<typeof RenderTargetSchema>;
 
-export const AgentContractsConfigSchema = z.object({
-  dsl: z.string(),
-  vars: z.record(z.string(), z.string()).optional(),
-  renders: z.array(RenderTargetSchema).default([]),
+export const TeamConfigSchema = z.object({
+  dsl: z.string().optional(),
   bindings: z.array(z.string()).default([]),
-  active_guardrail_policy: z.string().optional(),
+  vars: z.record(z.string(), z.string()).optional(),
   paths: z.record(z.string(), z.string()).optional(),
+  active_guardrail_policy: z.string().optional(),
+  interface_output: z.string().optional(),
 });
+
+export type TeamConfig = z.infer<typeof TeamConfigSchema>;
+
+export const AgentContractsConfigSchema = z
+  .object({
+    dsl: z.string().optional(),
+    vars: z.record(z.string(), z.string()).optional(),
+    renders: z.array(RenderTargetSchema).default([]),
+    bindings: z.array(z.string()).default([]),
+    active_guardrail_policy: z.string().optional(),
+    paths: z.record(z.string(), z.string()).optional(),
+    teams: z.record(z.string(), TeamConfigSchema).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.dsl !== undefined && data.teams !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "dsl and teams are mutually exclusive",
+        path: ["teams"],
+      });
+      return;
+    }
+    if (data.dsl === undefined && data.teams === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Either dsl or teams must be specified",
+        path: [],
+      });
+      return;
+    }
+    if (data.teams) {
+      for (const [key, team] of Object.entries(data.teams)) {
+        if (key === "_defaults") continue;
+        if (team.dsl === undefined) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Team "${key}" must specify dsl`,
+            path: ["teams", key, "dsl"],
+          });
+        }
+      }
+    }
+  });
 
 export type AgentContractsConfig = z.infer<typeof AgentContractsConfigSchema>;
 
@@ -54,6 +97,15 @@ export interface ResolvedRenderTarget {
   skip_empty?: boolean;
 }
 
+export interface ResolvedTeamConfig {
+  dsl: string;
+  vars?: Record<string, string>;
+  bindings: string[];
+  activeGuardrailPolicy?: string;
+  paths?: Record<string, string>;
+  interfaceOutput?: string;
+}
+
 export interface ResolvedConfig {
   dsl: string;
   vars?: Record<string, string>;
@@ -62,4 +114,5 @@ export interface ResolvedConfig {
   bindings: string[];
   activeGuardrailPolicy?: string;
   paths?: Record<string, string>;
+  teams?: Record<string, ResolvedTeamConfig>;
 }

--- a/test/cli/multi-team.test.ts
+++ b/test/cli/multi-team.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { isMultiTeamConfig, getTeamEntries } from "../../src/cli/multi-team.js";
+import type { ResolvedConfig, ResolvedTeamConfig } from "../../src/config/types.js";
+
+function makeConfig(teams?: Record<string, ResolvedTeamConfig>): ResolvedConfig {
+  return {
+    dsl: teams ? "" : "./test.yaml",
+    renders: [],
+    configDir: "/tmp",
+    bindings: teams ? [] : ["./b.yaml"],
+    teams,
+  };
+}
+
+describe("isMultiTeamConfig", () => {
+  it("returns true when teams present with entries", () => {
+    expect(
+      isMultiTeamConfig(makeConfig({ t1: { dsl: "a.yaml", bindings: [] } })),
+    ).toBe(true);
+  });
+
+  it("returns false when no teams", () => {
+    expect(isMultiTeamConfig(makeConfig())).toBe(false);
+  });
+
+  it("returns false when teams is empty", () => {
+    expect(isMultiTeamConfig(makeConfig({}))).toBe(false);
+  });
+});
+
+describe("getTeamEntries", () => {
+  const config = makeConfig({
+    backend: { dsl: "b.yaml", bindings: [] },
+    qa: { dsl: "q.yaml", bindings: [] },
+  });
+
+  it("returns all teams when no filter", () => {
+    const entries = getTeamEntries(config);
+    expect(entries).toHaveLength(2);
+    expect(entries.map(([k]) => k)).toEqual(["backend", "qa"]);
+  });
+
+  it("filters to single team", () => {
+    const entries = getTeamEntries(config, "backend");
+    expect(entries).toHaveLength(1);
+    expect(entries[0][0]).toBe("backend");
+  });
+
+  it("throws for unknown team", () => {
+    expect(() => getTeamEntries(config, "nonexistent")).toThrow(
+      /Team "nonexistent" not found/,
+    );
+  });
+
+  it("returns empty array when config has no teams", () => {
+    expect(getTeamEntries(makeConfig())).toEqual([]);
+  });
+});

--- a/test/config/multi-team-config.test.ts
+++ b/test/config/multi-team-config.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { AgentContractsConfigSchema } from "../../src/config/types.js";
+import { loadConfig } from "../../src/config/loader.js";
+
+// Test schema validation
+describe("AgentContractsConfigSchema multi-team", () => {
+  it("accepts single-team config (backward compatible)", () => {
+    const result = AgentContractsConfigSchema.safeParse({
+      dsl: "./agent-contracts.yaml",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts multi-team config with _defaults", () => {
+    const result = AgentContractsConfigSchema.safeParse({
+      teams: {
+        _defaults: {
+          bindings: ["./bindings/common.yaml"],
+          vars: { language: "TypeScript" },
+          active_guardrail_policy: "default-enforcement",
+        },
+        backend: {
+          dsl: "./teams/backend/agent-contracts.yaml",
+          interface_output: "./teams/backend/team-interface.yaml",
+          bindings: ["./teams/backend/bindings/obs.yaml"],
+          vars: { team_name: "backend" },
+        },
+        qa: {
+          dsl: "./teams/qa/agent-contracts.yaml",
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts multi-team config without _defaults", () => {
+    const result = AgentContractsConfigSchema.safeParse({
+      teams: {
+        backend: { dsl: "./backend.yaml" },
+        qa: { dsl: "./qa.yaml" },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects config with both dsl and teams", () => {
+    const result = AgentContractsConfigSchema.safeParse({
+      dsl: "./agent-contracts.yaml",
+      teams: { backend: { dsl: "./backend.yaml" } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) => i.message.includes("mutually exclusive")),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects config with neither dsl nor teams", () => {
+    const result = AgentContractsConfigSchema.safeParse({
+      bindings: ["./something.yaml"],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) =>
+          i.message.includes("Either dsl or teams"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects team without dsl", () => {
+    const result = AgentContractsConfigSchema.safeParse({
+      teams: {
+        backend: { bindings: ["./b.yaml"] },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) =>
+          i.message.includes('Team "backend" must specify dsl'),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("allows _defaults without dsl", () => {
+    const result = AgentContractsConfigSchema.safeParse({
+      teams: {
+        _defaults: { bindings: ["./common.yaml"] },
+        backend: { dsl: "./backend.yaml" },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// Test loader with file fixtures
+describe("loadConfig multi-team", () => {
+  const fixtureDir = resolve(import.meta.dirname, "__fixtures__/multi-team");
+
+  beforeAll(() => {
+    mkdirSync(resolve(fixtureDir, "teams/backend/bindings"), { recursive: true });
+    mkdirSync(resolve(fixtureDir, "teams/qa"), { recursive: true });
+    mkdirSync(resolve(fixtureDir, "bindings"), { recursive: true });
+
+    const minimalDsl = `version: 1
+system:
+  id: test-team
+  name: Test Team
+  default_workflow_order:
+    - analyze
+`;
+    writeFileSync(resolve(fixtureDir, "teams/backend/agent-contracts.yaml"), minimalDsl);
+    writeFileSync(resolve(fixtureDir, "teams/qa/agent-contracts.yaml"), minimalDsl);
+
+    writeFileSync(resolve(fixtureDir, "bindings/common.yaml"), "software: {}\n");
+    writeFileSync(
+      resolve(fixtureDir, "teams/backend/bindings/obs.yaml"),
+      "software: {}\n",
+    );
+
+    const mergeTestConfig = `
+teams:
+  _defaults:
+    bindings:
+      - ./bindings/common.yaml
+    vars:
+      language: TypeScript
+      mode: production
+    paths:
+      cursor_root: .cursor
+      output_dir: ./out
+    active_guardrail_policy: default-enforcement
+  backend:
+    dsl: ./teams/backend/agent-contracts.yaml
+    bindings:
+      - ./teams/backend/bindings/obs.yaml
+    vars:
+      mode: development
+      team_name: backend
+    paths:
+      output_dir: ./backend-out
+    active_guardrail_policy: strict-enforcement
+`;
+    writeFileSync(resolve(fixtureDir, "merge-test.config.yaml"), mergeTestConfig);
+
+    const configContent = `
+teams:
+  _defaults:
+    bindings:
+      - ./bindings/common.yaml
+    vars:
+      language: TypeScript
+    paths:
+      cursor_root: .cursor
+    active_guardrail_policy: default-enforcement
+  backend:
+    dsl: ./teams/backend/agent-contracts.yaml
+    interface_output: ./teams/backend/team-interface.yaml
+    vars:
+      team_name: backend
+  qa:
+    dsl: ./teams/qa/agent-contracts.yaml
+    vars:
+      team_name: qa
+`;
+    writeFileSync(resolve(fixtureDir, "agent-contracts.config.yaml"), configContent);
+
+    writeFileSync(
+      resolve(fixtureDir, "single-team.config.yaml"),
+      `dsl: ./teams/backend/agent-contracts.yaml\n`,
+    );
+  });
+
+  afterAll(() => {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  });
+
+  it("loads multi-team config with resolved team configs", async () => {
+    const config = await loadConfig(resolve(fixtureDir, "agent-contracts.config.yaml"));
+    expect(config).not.toBeNull();
+    expect(config!.teams).toBeDefined();
+    expect(Object.keys(config!.teams!)).toEqual(["backend", "qa"]);
+
+    const backend = config!.teams!.backend;
+    expect(backend.dsl).toContain("teams/backend/agent-contracts.yaml");
+    expect(backend.vars).toEqual({ language: "TypeScript", team_name: "backend" });
+    expect(backend.bindings).toHaveLength(1);
+    expect(backend.bindings[0]).toContain("bindings/common.yaml");
+    expect(backend.activeGuardrailPolicy).toBe("default-enforcement");
+    expect(backend.interfaceOutput).toContain("teams/backend/team-interface.yaml");
+    expect(backend.paths).toEqual({ cursor_root: ".cursor" });
+
+    const qa = config!.teams!.qa;
+    expect(qa.dsl).toContain("teams/qa/agent-contracts.yaml");
+    expect(qa.vars).toEqual({ language: "TypeScript", team_name: "qa" });
+    expect(qa.activeGuardrailPolicy).toBe("default-enforcement");
+    expect(qa.interfaceOutput).toBeUndefined();
+  });
+
+  it("loads single-team config without teams field (backward compatible)", async () => {
+    const config = await loadConfig(resolve(fixtureDir, "single-team.config.yaml"));
+    expect(config).not.toBeNull();
+    expect(config!.teams).toBeUndefined();
+    expect(config!.dsl).toContain("teams/backend/agent-contracts.yaml");
+  });
+
+  it("multi-team config has dsl as empty string", async () => {
+    const config = await loadConfig(resolve(fixtureDir, "agent-contracts.config.yaml"));
+    expect(config).not.toBeNull();
+    expect(config!.dsl).toBe("");
+  });
+
+  it("prepends _defaults bindings before team bindings", async () => {
+    const config = await loadConfig(resolve(fixtureDir, "merge-test.config.yaml"));
+    const backend = config!.teams!.backend;
+    expect(backend.bindings).toHaveLength(2);
+    expect(backend.bindings[0]).toContain("bindings/common.yaml");
+    expect(backend.bindings[1]).toContain("teams/backend/bindings/obs.yaml");
+  });
+
+  it("team vars override _defaults vars (shallow merge)", async () => {
+    const config = await loadConfig(resolve(fixtureDir, "merge-test.config.yaml"));
+    const backend = config!.teams!.backend;
+    expect(backend.vars).toEqual({
+      language: "TypeScript",
+      mode: "development",
+      team_name: "backend",
+    });
+  });
+
+  it("team paths override _defaults paths (shallow merge)", async () => {
+    const config = await loadConfig(resolve(fixtureDir, "merge-test.config.yaml"));
+    const backend = config!.teams!.backend;
+    expect(backend.paths).toEqual({
+      cursor_root: ".cursor",
+      output_dir: "./backend-out",
+    });
+  });
+
+  it("team active_guardrail_policy overrides _defaults", async () => {
+    const config = await loadConfig(resolve(fixtureDir, "merge-test.config.yaml"));
+    const backend = config!.teams!.backend;
+    expect(backend.activeGuardrailPolicy).toBe("strict-enforcement");
+  });
+});


### PR DESCRIPTION
## Summary

- Add optional `teams` map to `agent-contracts.config.yaml` for managing multiple teams from a single config file
- `_defaults` meta-entry inside `teams` provides shared settings (bindings, vars, paths, active_guardrail_policy) inherited by all teams
- All CLI commands support `--team <id>` to filter execution to a single team
- `check` command performs cross-team validation (imported interface file existence)
- Full backward compatibility — existing single-team configs work unchanged

## Changes

| Area | Files | Description |
|------|-------|-------------|
| Schema | `src/config/types.ts` | `TeamConfigSchema`, `ResolvedTeamConfig`, `AgentContractsConfigSchema` with `superRefine` (mutual exclusion, per-team dsl requirement) |
| Loader | `src/config/loader.ts` | `resolveTeamConfigs()` merges `_defaults` into each team; bindings prepended, vars/paths shallow-merged |
| CLI helper | `src/cli/multi-team.ts` | `isMultiTeamConfig()`, `getTeamEntries()` |
| CLI commands | `src/cli/commands/*.ts` | `--team` option on all 7 commands with per-team iteration |
| Tests | `test/config/multi-team-config.test.ts`, `test/cli/multi-team.test.ts` | Schema validation, loader merge, CLI helpers (21 new tests) |
| Docs | `README.md` | Multi-team configuration section |

## Test plan

- [x] All 652 tests pass (631 existing + 21 new)
- [x] `npx tsc --noEmit` passes
- [x] Schema: accepts single-team, multi-team with/without `_defaults`; rejects dsl+teams, neither, team without dsl
- [x] Loader: merge order (bindings prepend, vars/paths override, guardrail policy override)
- [x] CLI helpers: `isMultiTeamConfig`, `getTeamEntries` with filter and unknown team
- [x] Backward compatibility: single-team configs unchanged

Closes #32

Made with [Cursor](https://cursor.com)