### PR TITLE
chore: bump version to 0.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-contracts",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-contracts",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "@stoplight/spectral-core": "^1.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Bump version from 0.15.0 to 0.16.0
- Includes post-merge documentation fixes (sample/multi-team, guardrail-di spec, README cross-links)


Made with [Cursor](https://cursor.com)