### PR TITLE
fix: include delegatable task handoff types in coordinator prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/renderer/context.ts
+++ b/src/renderer/context.ts
@@ -799,6 +799,8 @@ export function buildPerAgentContext(
     ...agent.can_return_handoffs,
     ...receivableTasks.map((t) => t.invocation_handoff),
     ...receivableTasks.map((t) => t.result_handoff),
+    ...delegatableTasks.map((t) => t.invocation_handoff),
+    ...delegatableTasks.map((t) => t.result_handoff),
   ]);
   const relatedHandoffTypes: Dsl["handoff_types"] = {};
   for (const [kind, ht] of Object.entries(dsl.handoff_types)) {

--- a/test/context-builders.test.ts
+++ b/test/context-builders.test.ts
@@ -175,6 +175,44 @@ describe("buildPerAgentContext", () => {
     expect(entry.blocking).toBe(true);
   });
 
+  it("includes handoff types from delegatable tasks", () => {
+    const dsl = createMinimalDsl();
+    dsl.handoff_types["delegation-request"] = {
+      version: 1,
+      description: "Delegation invocation",
+      schema: { properties: { target: { type: "string" } } },
+    };
+    dsl.handoff_types["delegation-result"] = {
+      version: 1,
+      description: "Delegation result",
+      schema: { properties: { status: { type: "string" } } },
+    };
+    dsl.tasks["delegated-work"] = {
+      description: "Work delegated by coordinator",
+      target_agent: "dev",
+      allowed_from_agents: ["coordinator"],
+      workflow: "implement",
+      input_artifacts: [],
+      invocation_handoff: "delegation-request",
+      result_handoff: "delegation-result",
+    };
+    dsl.agents["coordinator"] = {
+      role_name: "Coordinator",
+      purpose: "Dispatch only",
+      can_read_artifacts: [],
+      can_write_artifacts: [],
+      can_execute_tools: [],
+      can_perform_validations: [],
+      can_invoke_agents: ["dev"],
+      can_return_handoffs: [],
+    };
+    const ctx = buildPerAgentContext(dsl, { ...dsl.agents["coordinator"], id: "coordinator" });
+    expect(ctx.relatedHandoffTypes).toHaveProperty("delegation-request");
+    expect(ctx.relatedHandoffTypes).toHaveProperty("delegation-result");
+    expect(ctx.delegatableTasks).toHaveLength(1);
+    expect(ctx.delegatableTasks[0].id).toBe("delegated-work");
+  });
+
   it("has empty relatedValidations when agent runs no validations", () => {
     const dsl = createMinimalDsl();
     const ctx = buildPerAgentContext(dsl, { ...dsl.agents["dev"], id: "dev" });


### PR DESCRIPTION
## Summary

- **Fix**: `relatedHandoffTypes` in `buildPerAgentContext` now includes handoff types referenced by delegatable tasks, not just receivable tasks. This ensures dispatch-only agents (coordinators) see full handoff schemas (types, required, enum, example) in their rendered prompts.
- **Test**: Added test case verifying coordinator agents get delegatable task handoff types in `relatedHandoffTypes`.
- **Version**: Bump to 0.16.1.

## Test plan

- [x] All 688 existing + new tests pass (`npm test`)
- [ ] Verify a coordinator prompt now renders delegatable handoff schemas in the Handoff Types section


Made with [Cursor](https://cursor.com)