### PR TITLE
feat: add CLI contract specification using cli-contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,6 +1005,10 @@ VarsSubstitutionError: Undefined variable "repo_url" in value "Repository: ${var
 
 ## CLI
 
+For the full CLI reference with all commands, options, arguments, exit codes, and AI agent policies, see the [CLI Reference](docs/cli-reference.md).
+
+The CLI contract specification is defined in [`cli-contract.yaml`](cli-contract.yaml) using [CLI Contracts](https://github.com/foo-ogawa/cli-contracts).
+
 ### Installation
 
 ````bash

--- a/cli-contract.yaml
+++ b/cli-contract.yaml
@@ -1,0 +1,610 @@
+# yaml-language-server: $schema=./node_modules/cli-contracts/schemas/cli-contract.schema.json
+cliContracts: 0.1.0
+
+info:
+  title: agent-contracts CLI
+  version: 0.16.2
+  description: >-
+    Declarative YAML DSL toolkit for defining, validating, and rendering
+    multi-agent development workflows. Provides static validation,
+    semantic linting, prompt rendering, guardrail generation, and
+    completeness scoring for agent contract definitions.
+  license:
+    name: MIT
+  contact:
+    name: foo-ogawa
+    url: https://github.com/foo-ogawa/agent-contracts
+
+commandSets:
+  agent-contracts:
+    summary: Agent contracts tooling — validate, lint, render DSL files.
+    executable: agent-contracts
+
+    globalOptions:
+      - name: version
+        aliases: [V]
+        description: Print version and exit.
+        schema:
+          type: boolean
+
+      - name: help
+        aliases: [h]
+        description: Show help and exit.
+        schema:
+          type: boolean
+
+    commands:
+      # ── resolve ───────────────────────────────────────
+      resolve:
+        summary: Resolve DSL (load + merge extends) and output YAML.
+        description: >-
+          Loads the agent-contracts DSL file, merges all extends
+          inheritance chains, substitutes variables from config, and
+          outputs the fully resolved result as YAML or JSON.
+        usage:
+          - agent-contracts resolve
+          - agent-contracts resolve path/to/agent-contracts.yaml
+          - agent-contracts resolve --format json
+          - agent-contracts resolve --expand-defaults
+          - agent-contracts resolve -c agent-contracts.config.yaml
+
+        arguments:
+          - name: dir
+            index: 0
+            required: false
+            description: Path to agent-contracts.yaml.
+            schema:
+              type: string
+              default: agent-contracts.yaml
+            file:
+              mode: read
+              exists: true
+              mediaType: application/yaml
+              encoding: utf-8
+
+        options:
+          - name: config
+            aliases: [c]
+            description: Path to agent-contracts.config.yaml.
+            valueName: path
+            schema:
+              type: string
+            file:
+              mode: read
+              exists: false
+              mediaType: application/yaml
+              encoding: utf-8
+
+          - name: team
+            description: Limit to one team (multi-team config only).
+            valueName: id
+            schema:
+              type: string
+
+          - name: format
+            description: Output format.
+            valueName: format
+            schema:
+              type: string
+              enum: [text, json]
+              default: text
+
+          - name: expand-defaults
+            description: >-
+              Expand all Zod default values in output. Fields like
+              required_validations, tags, and can_read_artifacts are
+              written explicitly instead of relying on schema defaults.
+            schema:
+              type: boolean
+              default: false
+
+        exits:
+          '0':
+            description: Resolved DSL output successfully.
+            stdout:
+              format: text
+
+          '1':
+            description: Resolution failed (file not found, parse error, or config error).
+            stderr:
+              format: text
+
+        x-agent:
+          riskLevel: low
+          requiresConfirmation: false
+          idempotent: true
+          sideEffects: []
+
+      # ── validate ──────────────────────────────────────
+      validate:
+        summary: Validate DSL against schema and check references.
+        description: >-
+          Validates the resolved DSL against the Zod schema, checks
+          inter-entity references (agent→task, task→artifact, etc.),
+          and validates handoff schemas. Reports diagnostics with
+          severity levels.
+        usage:
+          - agent-contracts validate
+          - agent-contracts validate path/to/agent-contracts.yaml
+          - agent-contracts validate --strict
+          - agent-contracts validate --format json
+          - agent-contracts validate --quiet
+
+        arguments:
+          - name: dir
+            index: 0
+            required: false
+            description: Path to agent-contracts.yaml.
+            schema:
+              type: string
+              default: agent-contracts.yaml
+            file:
+              mode: read
+              exists: true
+              mediaType: application/yaml
+              encoding: utf-8
+
+        options:
+          - name: config
+            aliases: [c]
+            description: Path to agent-contracts.config.yaml.
+            valueName: path
+            schema:
+              type: string
+            file:
+              mode: read
+              exists: false
+              mediaType: application/yaml
+              encoding: utf-8
+
+          - name: team
+            description: Limit to one team (multi-team config only).
+            valueName: id
+            schema:
+              type: string
+
+          - name: format
+            description: Diagnostic output format.
+            valueName: format
+            schema:
+              type: string
+              enum: [text, json]
+              default: text
+
+          - name: quiet
+            description: Suppress output on success.
+            schema:
+              type: boolean
+              default: false
+
+          - name: strict
+            description: Treat warnings as errors.
+            schema:
+              type: boolean
+              default: false
+
+        exits:
+          '0':
+            description: Validation passed. No errors found.
+            stdout:
+              format: text
+
+          '1':
+            description: Validation failed or unexpected error.
+            stderr:
+              format: text
+
+        x-agent:
+          riskLevel: low
+          requiresConfirmation: false
+          idempotent: true
+          sideEffects: []
+
+      # ── lint ──────────────────────────────────────────
+      lint:
+        summary: Run semantic lint rules on resolved DSL.
+        description: >-
+          Runs TypeScript-based semantic lint rules and Spectral rules
+          on the resolved DSL. Checks for best-practice violations,
+          naming conventions, and structural issues beyond schema
+          conformance.
+        usage:
+          - agent-contracts lint
+          - agent-contracts lint path/to/agent-contracts.yaml
+          - agent-contracts lint --strict
+          - agent-contracts lint --format json
+
+        arguments:
+          - name: dir
+            index: 0
+            required: false
+            description: Path to agent-contracts.yaml.
+            schema:
+              type: string
+              default: agent-contracts.yaml
+            file:
+              mode: read
+              exists: true
+              mediaType: application/yaml
+              encoding: utf-8
+
+        options:
+          - name: config
+            aliases: [c]
+            description: Path to agent-contracts.config.yaml.
+            valueName: path
+            schema:
+              type: string
+            file:
+              mode: read
+              exists: false
+              mediaType: application/yaml
+              encoding: utf-8
+
+          - name: team
+            description: Limit to one team (multi-team config only).
+            valueName: id
+            schema:
+              type: string
+
+          - name: format
+            description: Output format.
+            valueName: format
+            schema:
+              type: string
+              enum: [text, json]
+              default: text
+
+          - name: quiet
+            description: Suppress output on success.
+            schema:
+              type: boolean
+              default: false
+
+          - name: strict
+            description: Treat warnings as errors.
+            schema:
+              type: boolean
+              default: false
+
+        exits:
+          '0':
+            description: Lint passed. No errors or warnings.
+            stdout:
+              format: text
+
+          '1':
+            description: Lint failed or unexpected error.
+            stderr:
+              format: text
+
+        x-agent:
+          riskLevel: low
+          requiresConfirmation: false
+          idempotent: true
+          sideEffects: []
+
+      # ── render ────────────────────────────────────────
+      render:
+        summary: Render resolved DSL with Handlebars templates.
+        description: >-
+          Renders output files from the resolved DSL using Handlebars
+          templates configured in agent-contracts.config.yaml. Supports
+          drift detection via --check mode. Requires a config file.
+        usage:
+          - agent-contracts render -c agent-contracts.config.yaml
+          - agent-contracts render -c agent-contracts.config.yaml --check
+          - agent-contracts render --quiet
+
+        options:
+          - name: config
+            aliases: [c]
+            description: Path to agent-contracts.config.yaml.
+            valueName: path
+            schema:
+              type: string
+            file:
+              mode: read
+              exists: false
+              mediaType: application/yaml
+              encoding: utf-8
+
+          - name: team
+            description: Limit to one team (multi-team config only).
+            valueName: id
+            schema:
+              type: string
+
+          - name: check
+            description: Check for drift without writing files.
+            schema:
+              type: boolean
+              default: false
+
+          - name: quiet
+            description: Suppress output on success.
+            schema:
+              type: boolean
+              default: false
+
+        exits:
+          '0':
+            description: Render succeeded (or no drift detected in --check mode).
+            stdout:
+              format: text
+
+          '1':
+            description: >-
+              Render failed, config not found, schema validation failed,
+              or drift detected in --check mode.
+            stderr:
+              format: text
+
+        x-agent:
+          riskLevel: medium
+          requiresConfirmation: false
+          idempotent: true
+          sideEffects:
+            - file_write
+          recommendedBeforeUse:
+            - Ensure agent-contracts.config.yaml exists with render targets.
+            - Run validate first to confirm DSL is valid.
+
+      # ── check ─────────────────────────────────────────
+      check:
+        summary: Run full pipeline — resolve, validate, lint, render --check.
+        description: >-
+          Executes the complete verification pipeline in order: resolve
+          DSL, validate schema and references, run lint rules, and check
+          for render drift. Also verifies cross-team interface imports
+          and team-interface.yaml drift when applicable.
+        usage:
+          - agent-contracts check -c agent-contracts.config.yaml
+          - agent-contracts check -c agent-contracts.config.yaml --strict
+          - agent-contracts check --format json --quiet
+
+        options:
+          - name: config
+            aliases: [c]
+            description: Path to agent-contracts.config.yaml.
+            valueName: path
+            schema:
+              type: string
+            file:
+              mode: read
+              exists: false
+              mediaType: application/yaml
+              encoding: utf-8
+
+          - name: team
+            description: Limit to one team (multi-team config only).
+            valueName: id
+            schema:
+              type: string
+
+          - name: format
+            description: Diagnostic output format.
+            valueName: format
+            schema:
+              type: string
+              enum: [text, json]
+              default: text
+
+          - name: quiet
+            description: Suppress output on success.
+            schema:
+              type: boolean
+              default: false
+
+          - name: strict
+            description: Treat warnings as errors.
+            schema:
+              type: boolean
+              default: false
+
+        exits:
+          '0':
+            description: All checks passed.
+            stdout:
+              format: text
+
+          '1':
+            description: >-
+              One or more checks failed — validation errors, lint errors,
+              render drift, or missing interface files.
+            stderr:
+              format: text
+
+        x-agent:
+          riskLevel: low
+          requiresConfirmation: false
+          idempotent: true
+          sideEffects: []
+          recommendedBeforeUse:
+            - Ensure agent-contracts.config.yaml exists.
+
+      # ── score ─────────────────────────────────────────
+      score:
+        summary: Calculate DSL completeness score.
+        description: >-
+          Evaluates the resolved DSL across 7 dimensions including
+          artifact validation coverage, task validation coverage,
+          guardrail policy coverage, workflow validation integration,
+          schema completeness, cross-reference bidirectionality, and
+          guardrail scope resolution. Returns a score out of 100 with
+          optional CI gating via --threshold.
+        usage:
+          - agent-contracts score
+          - agent-contracts score --format json
+          - agent-contracts score --threshold 70
+          - agent-contracts score -c agent-contracts.config.yaml
+
+        arguments:
+          - name: dir
+            index: 0
+            required: false
+            description: Path to agent-contracts.yaml.
+            schema:
+              type: string
+              default: agent-contracts.yaml
+            file:
+              mode: read
+              exists: true
+              mediaType: application/yaml
+              encoding: utf-8
+
+        options:
+          - name: config
+            aliases: [c]
+            description: Path to agent-contracts.config.yaml.
+            valueName: path
+            schema:
+              type: string
+            file:
+              mode: read
+              exists: false
+              mediaType: application/yaml
+              encoding: utf-8
+
+          - name: team
+            description: Limit to one team (multi-team config only).
+            valueName: id
+            schema:
+              type: string
+
+          - name: format
+            description: Output format.
+            valueName: format
+            schema:
+              type: string
+              enum: [text, json]
+              default: text
+
+          - name: threshold
+            description: Minimum score; exit 1 if below (for CI gates).
+            valueName: number
+            schema:
+              type: integer
+
+        exits:
+          '0':
+            description: Score calculated (and above threshold if specified).
+            stdout:
+              format: text
+
+          '1':
+            description: >-
+              Score below threshold, schema validation failed,
+              or unexpected error.
+            stderr:
+              format: text
+
+        x-agent:
+          riskLevel: low
+          requiresConfirmation: false
+          idempotent: true
+          sideEffects: []
+
+      # ── generate ──────────────────────────────────────
+      generate:
+        summary: Generate guardrail or interface artifacts from DSL.
+        description: >-
+          Generates runtime artifacts from the DSL. When type is
+          "guardrails" (default), produces guardrail binding files from
+          DSL, policies, and software bindings. When type is "interface",
+          generates a team interface YAML/JSON file from the DSL's
+          team_interface section.
+        usage:
+          - agent-contracts generate -c agent-contracts.config.yaml
+          - agent-contracts generate guardrails -c agent-contracts.config.yaml
+          - agent-contracts generate guardrails --binding cursor-rules
+          - agent-contracts generate guardrails --dry-run
+          - agent-contracts generate interface -c agent-contracts.config.yaml
+          - agent-contracts generate interface --format json
+          - agent-contracts generate interface -o team-interface.yaml --dry-run
+
+        arguments:
+          - name: type
+            index: 0
+            required: false
+            description: Type of artifacts to generate.
+            schema:
+              type: string
+              enum: [guardrails, interface]
+              default: guardrails
+
+        options:
+          - name: config
+            aliases: [c]
+            description: Path to agent-contracts.config.yaml.
+            valueName: path
+            schema:
+              type: string
+            file:
+              mode: read
+              exists: false
+              mediaType: application/yaml
+              encoding: utf-8
+
+          - name: team
+            description: Limit to one team (multi-team config only).
+            valueName: id
+            schema:
+              type: string
+
+          - name: binding
+            description: Filter to specific software binding(s). Guardrails type only.
+            valueName: name
+            repeatable: true
+            schema:
+              type: string
+
+          - name: output
+            aliases: [o]
+            description: Output path for generated team interface. Interface type only.
+            valueName: path
+            schema:
+              type: string
+
+          - name: format
+            description: Output format for team interface (yaml or json). Interface type only.
+            valueName: format
+            schema:
+              type: string
+              enum: [yaml, json]
+              default: yaml
+
+          - name: dry-run
+            description: Print what would be generated without writing files.
+            schema:
+              type: boolean
+              default: false
+
+          - name: quiet
+            description: Suppress output on success.
+            schema:
+              type: boolean
+              default: false
+
+        exits:
+          '0':
+            description: Generation succeeded.
+            stdout:
+              format: text
+
+          '1':
+            description: >-
+              Generation failed — unknown type, schema validation failed,
+              config not found, or error-level diagnostics.
+            stderr:
+              format: text
+
+        x-agent:
+          riskLevel: medium
+          requiresConfirmation: false
+          idempotent: true
+          sideEffects:
+            - file_write
+          recommendedBeforeUse:
+            - Ensure agent-contracts.config.yaml exists with binding definitions.
+            - Run validate first to confirm DSL is valid.

--- a/cli-contracts.config.yaml
+++ b/cli-contracts.config.yaml
@@ -1,0 +1,14 @@
+version: 0.1.0
+
+input:
+  files:
+    - cli-contract.yaml
+
+generators:
+  markdown:
+    enabled: true
+    output: ./docs/cli-reference.md
+    templates: builtin:markdown
+    options:
+      includeSchemas: false
+      includeExtensions: true

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,453 @@
+# agent-contracts CLI
+
+Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows. Provides static validation, semantic linting, prompt rendering, guardrail generation, and completeness scoring for agent contract definitions.
+
+**Version:** 0.16.2
+
+## Table of Contents
+
+- [agent-contracts](#agent-contracts)
+  - [resolve](#agent-contracts-resolve)
+  - [validate](#agent-contracts-validate)
+  - [lint](#agent-contracts-lint)
+  - [render](#agent-contracts-render)
+  - [check](#agent-contracts-check)
+  - [score](#agent-contracts-score)
+  - [generate](#agent-contracts-generate)
+
+---
+
+## agent-contracts
+
+Agent contracts tooling — validate, lint, render DSL files.
+
+### Global Options
+
+| Option | Aliases | Required | Default | Description |
+|---|---|---|---|---|
+| `--version` | -V | No |  | Print version and exit. |
+| `--help` | -h | No |  | Show help and exit. |
+
+### resolve
+
+Resolve DSL (load + merge extends) and output YAML.
+
+Loads the agent-contracts DSL file, merges all extends inheritance chains, substitutes variables from config, and outputs the fully resolved result as YAML or JSON.
+
+**Usage:**
+
+```
+agent-contracts resolve
+```
+```
+agent-contracts resolve path/to/agent-contracts.yaml
+```
+```
+agent-contracts resolve --format json
+```
+```
+agent-contracts resolve --expand-defaults
+```
+```
+agent-contracts resolve -c agent-contracts.config.yaml
+```
+
+#### Arguments
+
+| Name | Required | Description |
+|---|---|---|
+| `dir` | No | Path to agent-contracts.yaml. |
+
+#### Options
+
+| Option | Aliases | Required | Default | Description |
+|---|---|---|---|---|
+| `--config` | -c | No |  | Path to agent-contracts.config.yaml. |
+| `--team` |  | No |  | Limit to one team (multi-team config only). |
+| `--format` |  | No | `"text"` | Output format. |
+| `--expand-defaults` |  | No | `false` | Expand all Zod default values in output. Fields like required_validations, tags, and can_read_artifacts are written explicitly instead of relying on schema defaults. |
+
+#### Exit Codes
+
+**Exit 0:** Resolved DSL output successfully.
+
+- **stdout:** format=`text`
+
+**Exit 1:** Resolution failed (file not found, parse error, or config error).
+
+- **stderr:** format=`text`
+
+#### Extensions
+
+```yaml
+x-agent: 
+  riskLevel: low
+  requiresConfirmation: false
+  idempotent: true
+  sideEffects: 
+
+```
+
+---
+
+### validate
+
+Validate DSL against schema and check references.
+
+Validates the resolved DSL against the Zod schema, checks inter-entity references (agent→task, task→artifact, etc.), and validates handoff schemas. Reports diagnostics with severity levels.
+
+**Usage:**
+
+```
+agent-contracts validate
+```
+```
+agent-contracts validate path/to/agent-contracts.yaml
+```
+```
+agent-contracts validate --strict
+```
+```
+agent-contracts validate --format json
+```
+```
+agent-contracts validate --quiet
+```
+
+#### Arguments
+
+| Name | Required | Description |
+|---|---|---|
+| `dir` | No | Path to agent-contracts.yaml. |
+
+#### Options
+
+| Option | Aliases | Required | Default | Description |
+|---|---|---|---|---|
+| `--config` | -c | No |  | Path to agent-contracts.config.yaml. |
+| `--team` |  | No |  | Limit to one team (multi-team config only). |
+| `--format` |  | No | `"text"` | Diagnostic output format. |
+| `--quiet` |  | No | `false` | Suppress output on success. |
+| `--strict` |  | No | `false` | Treat warnings as errors. |
+
+#### Exit Codes
+
+**Exit 0:** Validation passed. No errors found.
+
+- **stdout:** format=`text`
+
+**Exit 1:** Validation failed or unexpected error.
+
+- **stderr:** format=`text`
+
+#### Extensions
+
+```yaml
+x-agent: 
+  riskLevel: low
+  requiresConfirmation: false
+  idempotent: true
+  sideEffects: 
+
+```
+
+---
+
+### lint
+
+Run semantic lint rules on resolved DSL.
+
+Runs TypeScript-based semantic lint rules and Spectral rules on the resolved DSL. Checks for best-practice violations, naming conventions, and structural issues beyond schema conformance.
+
+**Usage:**
+
+```
+agent-contracts lint
+```
+```
+agent-contracts lint path/to/agent-contracts.yaml
+```
+```
+agent-contracts lint --strict
+```
+```
+agent-contracts lint --format json
+```
+
+#### Arguments
+
+| Name | Required | Description |
+|---|---|---|
+| `dir` | No | Path to agent-contracts.yaml. |
+
+#### Options
+
+| Option | Aliases | Required | Default | Description |
+|---|---|---|---|---|
+| `--config` | -c | No |  | Path to agent-contracts.config.yaml. |
+| `--team` |  | No |  | Limit to one team (multi-team config only). |
+| `--format` |  | No | `"text"` | Output format. |
+| `--quiet` |  | No | `false` | Suppress output on success. |
+| `--strict` |  | No | `false` | Treat warnings as errors. |
+
+#### Exit Codes
+
+**Exit 0:** Lint passed. No errors or warnings.
+
+- **stdout:** format=`text`
+
+**Exit 1:** Lint failed or unexpected error.
+
+- **stderr:** format=`text`
+
+#### Extensions
+
+```yaml
+x-agent: 
+  riskLevel: low
+  requiresConfirmation: false
+  idempotent: true
+  sideEffects: 
+
+```
+
+---
+
+### render
+
+Render resolved DSL with Handlebars templates.
+
+Renders output files from the resolved DSL using Handlebars templates configured in agent-contracts.config.yaml. Supports drift detection via --check mode. Requires a config file.
+
+**Usage:**
+
+```
+agent-contracts render -c agent-contracts.config.yaml
+```
+```
+agent-contracts render -c agent-contracts.config.yaml --check
+```
+```
+agent-contracts render --quiet
+```
+
+#### Options
+
+| Option | Aliases | Required | Default | Description |
+|---|---|---|---|---|
+| `--config` | -c | No |  | Path to agent-contracts.config.yaml. |
+| `--team` |  | No |  | Limit to one team (multi-team config only). |
+| `--check` |  | No | `false` | Check for drift without writing files. |
+| `--quiet` |  | No | `false` | Suppress output on success. |
+
+#### Exit Codes
+
+**Exit 0:** Render succeeded (or no drift detected in --check mode).
+
+- **stdout:** format=`text`
+
+**Exit 1:** Render failed, config not found, schema validation failed, or drift detected in --check mode.
+
+- **stderr:** format=`text`
+
+#### Extensions
+
+```yaml
+x-agent: 
+  riskLevel: medium
+  requiresConfirmation: false
+  idempotent: true
+  sideEffects: 
+    - file_write
+  recommendedBeforeUse: 
+    - Ensure agent-contracts.config.yaml exists with render targets.
+    - Run validate first to confirm DSL is valid.
+```
+
+---
+
+### check
+
+Run full pipeline — resolve, validate, lint, render --check.
+
+Executes the complete verification pipeline in order: resolve DSL, validate schema and references, run lint rules, and check for render drift. Also verifies cross-team interface imports and team-interface.yaml drift when applicable.
+
+**Usage:**
+
+```
+agent-contracts check -c agent-contracts.config.yaml
+```
+```
+agent-contracts check -c agent-contracts.config.yaml --strict
+```
+```
+agent-contracts check --format json --quiet
+```
+
+#### Options
+
+| Option | Aliases | Required | Default | Description |
+|---|---|---|---|---|
+| `--config` | -c | No |  | Path to agent-contracts.config.yaml. |
+| `--team` |  | No |  | Limit to one team (multi-team config only). |
+| `--format` |  | No | `"text"` | Diagnostic output format. |
+| `--quiet` |  | No | `false` | Suppress output on success. |
+| `--strict` |  | No | `false` | Treat warnings as errors. |
+
+#### Exit Codes
+
+**Exit 0:** All checks passed.
+
+- **stdout:** format=`text`
+
+**Exit 1:** One or more checks failed — validation errors, lint errors, render drift, or missing interface files.
+
+- **stderr:** format=`text`
+
+#### Extensions
+
+```yaml
+x-agent: 
+  riskLevel: low
+  requiresConfirmation: false
+  idempotent: true
+  sideEffects: 
+
+  recommendedBeforeUse: 
+    - Ensure agent-contracts.config.yaml exists.
+```
+
+---
+
+### score
+
+Calculate DSL completeness score.
+
+Evaluates the resolved DSL across 7 dimensions including artifact validation coverage, task validation coverage, guardrail policy coverage, workflow validation integration, schema completeness, cross-reference bidirectionality, and guardrail scope resolution. Returns a score out of 100 with optional CI gating via --threshold.
+
+**Usage:**
+
+```
+agent-contracts score
+```
+```
+agent-contracts score --format json
+```
+```
+agent-contracts score --threshold 70
+```
+```
+agent-contracts score -c agent-contracts.config.yaml
+```
+
+#### Arguments
+
+| Name | Required | Description |
+|---|---|---|
+| `dir` | No | Path to agent-contracts.yaml. |
+
+#### Options
+
+| Option | Aliases | Required | Default | Description |
+|---|---|---|---|---|
+| `--config` | -c | No |  | Path to agent-contracts.config.yaml. |
+| `--team` |  | No |  | Limit to one team (multi-team config only). |
+| `--format` |  | No | `"text"` | Output format. |
+| `--threshold` |  | No |  | Minimum score; exit 1 if below (for CI gates). |
+
+#### Exit Codes
+
+**Exit 0:** Score calculated (and above threshold if specified).
+
+- **stdout:** format=`text`
+
+**Exit 1:** Score below threshold, schema validation failed, or unexpected error.
+
+- **stderr:** format=`text`
+
+#### Extensions
+
+```yaml
+x-agent: 
+  riskLevel: low
+  requiresConfirmation: false
+  idempotent: true
+  sideEffects: 
+
+```
+
+---
+
+### generate
+
+Generate guardrail or interface artifacts from DSL.
+
+Generates runtime artifacts from the DSL. When type is "guardrails" (default), produces guardrail binding files from DSL, policies, and software bindings. When type is "interface", generates a team interface YAML/JSON file from the DSL's team_interface section.
+
+**Usage:**
+
+```
+agent-contracts generate -c agent-contracts.config.yaml
+```
+```
+agent-contracts generate guardrails -c agent-contracts.config.yaml
+```
+```
+agent-contracts generate guardrails --binding cursor-rules
+```
+```
+agent-contracts generate guardrails --dry-run
+```
+```
+agent-contracts generate interface -c agent-contracts.config.yaml
+```
+```
+agent-contracts generate interface --format json
+```
+```
+agent-contracts generate interface -o team-interface.yaml --dry-run
+```
+
+#### Arguments
+
+| Name | Required | Description |
+|---|---|---|
+| `type` | No | Type of artifacts to generate. |
+
+#### Options
+
+| Option | Aliases | Required | Default | Description |
+|---|---|---|---|---|
+| `--config` | -c | No |  | Path to agent-contracts.config.yaml. |
+| `--team` |  | No |  | Limit to one team (multi-team config only). |
+| `--binding` |  | No |  | Filter to specific software binding(s). Guardrails type only. |
+| `--output` | -o | No |  | Output path for generated team interface. Interface type only. |
+| `--format` |  | No | `"yaml"` | Output format for team interface (yaml or json). Interface type only. |
+| `--dry-run` |  | No | `false` | Print what would be generated without writing files. |
+| `--quiet` |  | No | `false` | Suppress output on success. |
+
+#### Exit Codes
+
+**Exit 0:** Generation succeeded.
+
+- **stdout:** format=`text`
+
+**Exit 1:** Generation failed — unknown type, schema validation failed, config not found, or error-level diagnostics.
+
+- **stderr:** format=`text`
+
+#### Extensions
+
+```yaml
+x-agent: 
+  riskLevel: medium
+  requiresConfirmation: false
+  idempotent: true
+  sideEffects: 
+    - file_write
+  recommendedBeforeUse: 
+    - Ensure agent-contracts.config.yaml exists with binding definitions.
+    - Run validate first to confirm DSL is valid.
+```
+
+---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-contracts",
-  "version": "0.16.0",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-contracts",
-      "version": "0.16.0",
+      "version": "0.16.2",
       "license": "MIT",
       "dependencies": {
         "@stoplight/spectral-core": "^1.22.0",
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.6.0",
+        "cli-contracts": "^0.2.0",
         "eslint": "^10.2.0",
         "globals": "^17.5.0",
         "prettier": "^3.8.2",
@@ -742,6 +743,24 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -844,6 +863,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2314,12 +2344,45 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -2515,6 +2578,68 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/cli-contracts": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/cli-contracts/-/cli-contracts-0.2.0.tgz",
+      "integrity": "sha512-lip3jChTfSkTiiQ5vW0X4P1UuJMtHj7miBUydywOE0N1uSDCmZJzYTwf+SwQro0xiHuuiPGA9KmHKwD3tsp4qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "commander": "^12.1.0",
+        "glob": "^10.3.10",
+        "handlebars": "^4.7.8",
+        "js-yaml": "^4.1.0",
+        "yaml": "^2.8.2",
+        "zod": "^3.24.4"
+      },
+      "bin": {
+        "cli-contracts": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/cli-contracts/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cli-contracts/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "14.0.3",
@@ -2712,6 +2837,20 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
@@ -3318,6 +3457,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3447,6 +3603,28 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3458,6 +3636,32 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -3781,6 +3985,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -4002,6 +4216,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -4010,6 +4240,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/jsep": {
@@ -4426,6 +4669,13 @@
       "integrity": "sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg==",
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4464,6 +4714,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mlly": {
@@ -4698,6 +4958,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4716,6 +4983,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/pathe": {
@@ -5276,6 +5560,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5320,6 +5617,70 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string.prototype.trim": {
@@ -5376,6 +5737,46 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/sucrase": {
@@ -6121,6 +6522,104 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yaml": {
       "version": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",
@@ -16,6 +16,8 @@
   },
   "files": [
     "dist",
+    "cli-contract.yaml",
+    "docs/cli-reference.md",
     "README.md",
     "LICENSE"
   ],
@@ -28,6 +30,7 @@
     "lint": "eslint src/ test/",
     "typecheck": "tsc --noEmit",
     "generate:schema": "tsx scripts/generate-json-schema.ts",
+    "generate:docs": "cli-contracts docs",
     "prepublishOnly": "npm run clean && npm run build"
   },
   "keywords": [
@@ -69,6 +72,7 @@
     "@types/node": "^25.6.0",
     "eslint": "^10.2.0",
     "globals": "^17.5.0",
+    "cli-contracts": "^0.2.0",
     "prettier": "^3.8.2",
     "tsup": "^8.5.1",
     "tsx": "^4.21.0",


### PR DESCRIPTION
## Summary

- Add `cli-contract.yaml` defining the full agent-contracts CLI interface (all 7 commands with arguments, options, exit codes, and `x-agent` policies) using [CLI Contracts](https://github.com/foo-ogawa/cli-contracts)
- Add `cli-contracts.config.yaml` and generate `docs/cli-reference.md` via the cli-contracts Markdown generator
- Include `cli-contract.yaml` and `docs/cli-reference.md` in the npm package (`files` array)
- Add link to CLI Reference and contract file from the README CLI section
- Bump version to 0.16.2

## Test plan

- [x] `npx cli-contracts validate` passes
- [x] `npx cli-contracts docs` generates `docs/cli-reference.md` successfully
- [ ] Verify generated CLI reference matches the actual CLI behavior


Made with [Cursor](https://cursor.com)