### PR TITLE
chore: add CODEOWNERS for public repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @foo-ogawa


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` file assigning `@foo-ogawa` as default code owner for all files
- Required for enforcing code owner reviews on the newly public repository

## Context
Part of the public release hardening — see branch protection and ruleset configuration.

Made with [Cursor](https://cursor.com)