### PR TITLE
fix: resolve 3 dependency vulnerabilities (lodash, postcss)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1636,9 +1636,9 @@
       }
     },
     "node_modules/@stoplight/spectral-functions": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.10.1.tgz",
-      "integrity": "sha512-obu8ZfoHxELOapfGsCJixKZXZcffjg+lSoNuttpmUFuDzVLT3VmH8QkPXfOGOL5Pz80BR35ClNAToDkdnYIURg==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.10.2.tgz",
+      "integrity": "sha512-PIfPUgTRo8EtAnL1MIrzhHoUuojSaE8shGSMaHS3BxGyc8d079BE5+TqJa1/WLUb9YT9JQnZ0Aj4xfi8NcJOIw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/better-ajv-errors": "1.0.3",
@@ -1646,22 +1646,16 @@
         "@stoplight/spectral-core": "^1.19.4",
         "@stoplight/spectral-formats": "^1.8.1",
         "@stoplight/spectral-runtime": "^1.1.2",
-        "ajv": "^8.17.1",
+        "ajv": "^8.18.0",
         "ajv-draft-04": "~1.0.0",
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.1",
-        "lodash": "~4.17.21",
+        "lodash": "^4.18.1",
         "tslib": "^2.8.1"
       },
       "engines": {
         "node": "^16.20 || ^18.18 || >= 20.17"
       }
-    },
-    "node_modules/@stoplight/spectral-functions/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
     },
     "node_modules/@stoplight/spectral-parsers": {
       "version": "1.0.5",
@@ -5070,9 +5064,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Resolve **3 Dependabot alerts** (1 high, 2 moderate) via `npm audit fix`
- **lodash** (high): Code Injection via `_.template` + Prototype Pollution via `_.unset`/`_.omit` — updated through `@stoplight/spectral-functions`
- **postcss** (moderate): XSS via unescaped `</style>` in CSS stringify — updated to 8.5.10+

## Test plan
- [x] `npm audit` reports 0 vulnerabilities
- [x] All 688 tests passing (`vitest run`)
- [ ] CI passes on Node 20 and 22

Made with [Cursor](https://cursor.com)