### PR TITLE
chore: bump version to 0.17.1

### DIFF
--- a/cli-contract.yaml
+++ b/cli-contract.yaml
@@ -3,7 +3,7 @@ cliContracts: 0.1.0
 
 info:
   title: agent-contracts CLI
-  version: 0.17.0
+  version: 0.17.1
   description: >-
     Declarative YAML DSL toolkit for defining, validating, and rendering
     multi-agent development workflows. Provides static validation,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-contracts",
-  "version": "0.16.2",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-contracts",
-      "version": "0.16.2",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
         "@stoplight/spectral-core": "^1.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",
@@ -31,6 +31,7 @@
     "typecheck": "tsc --noEmit",
     "generate:schema": "tsx scripts/generate-json-schema.ts",
     "generate:docs": "cli-contracts docs",
+    "version": "node -e \"const fs=require('fs');const f='cli-contract.yaml';fs.writeFileSync(f,fs.readFileSync(f,'utf8').replace(/^  version: .*/m,'  version: '+process.env.npm_package_version))\" && git add cli-contract.yaml",
     "prepublishOnly": "npm run clean && npm run build"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

- Bump version `0.17.0` → `0.17.1`
- Add npm `version` lifecycle hook to auto-sync `cli-contract.yaml` version from `package.json`, eliminating hardcoded version duplication

## Changed files

- `package.json` — version bump + `version` script added
- `cli-contract.yaml` — version updated automatically via new hook
- `package-lock.json` — lockfile sync

Made with [Cursor](https://cursor.com)