### PR TITLE
feat: standardize sections property and bump to v0.18.0

### DIFF
--- a/cli-contract.yaml
+++ b/cli-contract.yaml
@@ -3,7 +3,7 @@ cliContracts: 0.1.0
 
 info:
   title: agent-contracts CLI
-  version: 0.17.1
+  version: 0.18.0
   description: >-
     Declarative YAML DSL toolkit for defining, validating, and rendering
     multi-agent development workflows. Provides static validation,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-contracts",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-contracts",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "@stoplight/spectral-core": "^1.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -193,6 +193,11 @@ Handlebars.registerHelper("or", (...args: unknown[]): boolean => {
   return args.some((a) => !!a);
 });
 
+Handlebars.registerHelper("coalesce", (...args: unknown[]): unknown => {
+  const _options = args.pop();
+  return args.find((a) => a != null && a !== false && a !== "");
+});
+
 Handlebars.registerHelper("and", (...args: unknown[]): boolean => {
   const _options = args.pop();
   return args.every((a) => !!a);

--- a/src/schema/agent.ts
+++ b/src/schema/agent.ts
@@ -1,5 +1,16 @@
 import { z } from "zod";
 
+export const SectionSchema = z
+  .object({
+    title: z.string(),
+    content: z.string().optional(),
+    list: z
+      .enum(["agents", "workflow", "validations", "guardrails"])
+      .optional(),
+  })
+  .passthrough();
+export type Section = z.infer<typeof SectionSchema>;
+
 export const RuleSchema = z
   .object({
     id: z.string(),
@@ -51,14 +62,7 @@ export const AgentSchema = z
     rules: z.array(RuleSchema).optional(),
     anti_patterns: z.array(z.string()).optional(),
     escalation_criteria: z.array(EscalationCriterionSchema).optional(),
-    sections: z
-      .array(
-        z.object({
-          title: z.string(),
-          content: z.string(),
-        }),
-      )
-      .optional(),
+    sections: z.array(SectionSchema).optional(),
     prerequisites: z.array(PrerequisiteSchema).optional(),
     guardrails: z.array(z.string()).optional(),
   })

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -7,6 +7,8 @@ export {
   type Prerequisite,
   RuleSchema,
   type Rule,
+  SectionSchema,
+  type Section,
 } from "./agent.js";
 export { ArtifactSchema, type Artifact } from "./artifact.js";
 export {
@@ -74,9 +76,11 @@ export {
   type PolicyWhen,
 } from "./policy.js";
 export {
+  ContextLoadingSchema,
   ExtendsSchema,
   SystemSchema,
   VersionLiteralSchema,
+  type ContextLoading,
   type Extends,
   type System,
   type VersionLiteral,

--- a/src/schema/system.ts
+++ b/src/schema/system.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { SectionSchema } from "./agent.js";
 
 export const VersionLiteralSchema = z.literal(1);
 export type VersionLiteral = z.infer<typeof VersionLiteralSchema>;
@@ -6,11 +7,18 @@ export type VersionLiteral = z.infer<typeof VersionLiteralSchema>;
 export const ExtendsSchema = z.string().optional();
 export type Extends = z.infer<typeof ExtendsSchema>;
 
+export const ContextLoadingSchema = z
+  .record(z.string(), z.array(z.string()))
+  .optional();
+export type ContextLoading = z.infer<typeof ContextLoadingSchema>;
+
 export const SystemSchema = z
   .object({
     id: z.string(),
     name: z.string(),
     default_workflow_order: z.array(z.string()),
+    sections: z.array(SectionSchema).optional(),
+    context_loading: ContextLoadingSchema,
   })
   .passthrough();
 export type System = z.infer<typeof SystemSchema>;

--- a/src/schema/task.ts
+++ b/src/schema/task.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { EscalationCriterionSchema, RuleSchema } from "./agent.js";
+import { EscalationCriterionSchema, RuleSchema, SectionSchema } from "./agent.js";
 
 export const ExecutionStepSchema = z
   .object({
@@ -35,6 +35,7 @@ export const TaskSchema = z
     rules: z.array(RuleSchema).optional(),
     anti_patterns: z.array(z.string()).optional(),
     escalation_criteria: z.array(EscalationCriterionSchema).optional(),
+    sections: z.array(SectionSchema).optional(),
     validations: z.array(z.string()).default([]),
     guardrails: z.array(z.string()).optional(),
   })

--- a/src/schema/workflow.ts
+++ b/src/schema/workflow.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { SectionSchema } from "./agent.js";
 
 const RetrySchema = z.object({
   condition: z.string(),
@@ -100,6 +101,7 @@ export const WorkflowSchema = z
     entry_conditions: z.array(z.string()).default([]),
     trigger: z.string().optional(),
     steps: z.array(WorkflowStepSchema),
+    sections: z.array(SectionSchema).optional(),
     external_participants: z.array(ExternalParticipantSchema).default([]),
   })
   .passthrough();


### PR DESCRIPTION
## Summary
- `SectionSchema` を共通型として定義し、`SystemSchema` / `WorkflowSchema` / `TaskSchema` に `sections` 標準プロパティを追加
- `SystemSchema` に `context_loading` プロパティを追加（タスク種別ごとの必読ファイル宣言）
- `coalesce` Handlebars ヘルパーを追加（`sections` / `x-sections` 後方互換テンプレート移行用）
- v0.18.0 にバージョンアップ

## Test plan
- [x] 688 テスト全通過
- [x] ビルド成功
- [x] aidev-skeleton agent-kit / agent-kit-lite で `check` + `render` 正常動作確認済み


Made with [Cursor](https://cursor.com)