### PR TITLE
chore: bump version to 0.19.1

### DIFF
--- a/cli-contract.yaml
+++ b/cli-contract.yaml
@@ -3,7 +3,7 @@ cliContracts: 0.1.0
 
 info:
   title: agent-contracts CLI
-  version: 0.19.0
+  version: 0.19.1
   description: >-
     Declarative YAML DSL toolkit for defining, validating, and rendering
     multi-agent development workflows. Provides static validation,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2,7 +2,7 @@
 
 Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows. Provides static validation, semantic linting, prompt rendering, guardrail generation, and completeness scoring for agent contract definitions.
 
-**Version:** 0.19.0
+**Version:** 0.19.1
 
 ## Table of Contents
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump to 0.19.1 after dependabot fast-uri update.

Made with [Cursor](https://cursor.com)