### PR TITLE
feat: add depends_on to workflow steps for parallel execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ A **Workflow** defines a phase-level execution sequence:
 Workflow steps support additional properties:
 
 * `group` — consecutive steps with the same group are rendered as `par` (parallel) blocks in sequence diagrams
+* `depends_on` — list of step task IDs that must complete before this step starts. When specified, the runtime can execute independent steps in parallel. When omitted, the step implicitly depends on all preceding steps (sequential execution)
 * `max_retries` (delegate steps) — maximum number of full task re-executions (new sessions) allowed per step. Defaults to `0` (no retries), or `1` when a `retry` block is present
 * `max_follow_ups` (delegate steps) — maximum number of lightweight same-session follow-up messages for output format corrections
 * `retry` (delegate steps) — defines a conditional retry loop with `condition`, `fix_task`, and optional `revalidate_task`. These are rendered as recovery instructions in the LLM prompt

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/schemas/dsl.schema.json
+++ b/schemas/dsl.schema.json
@@ -921,6 +921,12 @@
                     "group": {
                       "type": "string"
                     },
+                    "depends_on": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "max_retries": {
                       "type": "integer",
                       "minimum": 0,
@@ -973,6 +979,12 @@
                     },
                     "group": {
                       "type": "string"
+                    },
+                    "depends_on": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
@@ -1002,6 +1014,12 @@
                     },
                     "group": {
                       "type": "string"
+                    },
+                    "depends_on": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "retry": {
                       "type": "object",
@@ -1044,6 +1062,12 @@
                     },
                     "group": {
                       "type": "string"
+                    },
+                    "depends_on": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
@@ -1082,6 +1106,12 @@
                     },
                     "group": {
                       "type": "string"
+                    },
+                    "depends_on": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
@@ -1114,6 +1144,12 @@
                     },
                     "group": {
                       "type": "string"
+                    },
+                    "depends_on": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [

--- a/src/schema/workflow.ts
+++ b/src/schema/workflow.ts
@@ -23,6 +23,7 @@ const WorkflowDelegateStepSchema = z
     task: z.string(),
     from_agent: z.string(),
     group: z.string().optional(),
+    depends_on: z.array(z.string()).optional(),
     max_retries: z.number().int().min(0).optional(),
     max_follow_ups: z.number().int().min(0).optional(),
     retry: RetrySchema.optional(),
@@ -35,6 +36,7 @@ const WorkflowGateStepSchema = z
     description: z.string().optional(),
     gate_kind: z.string(),
     group: z.string().optional(),
+    depends_on: z.array(z.string()).optional(),
   })
   .passthrough();
 
@@ -47,6 +49,7 @@ const WorkflowHandoffStepSchema = z
     task: z.string().optional(),
     from_agent: z.string().optional(),
     group: z.string().optional(),
+    depends_on: z.array(z.string()).optional(),
     retry: RetrySchema.optional(),
   })
   .passthrough();
@@ -58,6 +61,7 @@ const WorkflowValidationStepSchema = z
     description: z.string().optional(),
     validation: z.string(),
     group: z.string().optional(),
+    depends_on: z.array(z.string()).optional(),
   })
   .passthrough();
 
@@ -70,6 +74,7 @@ const WorkflowDecisionStepSchema = z
     routing_key: z.string().optional(),
     branches: z.record(z.string(), z.array(z.string())),
     group: z.string().optional(),
+    depends_on: z.array(z.string()).optional(),
   })
   .passthrough();
 
@@ -82,6 +87,7 @@ const WorkflowTeamTaskStepSchema = z
     handoff: z.string(),
     expects: z.string(),
     group: z.string().optional(),
+    depends_on: z.array(z.string()).optional(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Summary
- Add `depends_on` property to all workflow step types (delegate, gate, handoff, validation, decision, team_task)
- When specified, only the listed dependency steps must complete before execution; enables runtime parallel scheduling
- When omitted, the step implicitly depends on all preceding steps (preserves sequential behaviour)
- Regenerate JSON Schema from Zod
- Document in README
- Bump version to 0.19.3

## Test plan
- [x] All 705 existing tests pass
- [x] JSON Schema regenerated and verified

Made with [Cursor](https://cursor.com)