### PR TITLE
feat: support file $ref with JSON Pointer fragment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-contracts",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-contracts",
-      "version": "0.19.3",
+      "version": "0.19.4",
       "license": "MIT",
       "dependencies": {
         "@stoplight/spectral-core": "^1.22.0",
@@ -30,7 +30,7 @@
         "@openai/agents": "^0.11.1",
         "@types/node": "^25.6.0",
         "agent-contracts-runtime": "^0.12.0",
-        "cli-contracts": "^0.5.1",
+        "cli-contracts": "^0.5.2",
         "eslint": "^10.2.0",
         "globals": "^17.5.0",
         "prettier": "^3.8.2",
@@ -3587,9 +3587,9 @@
       }
     },
     "node_modules/cli-contracts": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cli-contracts/-/cli-contracts-0.5.1.tgz",
-      "integrity": "sha512-n2hhfNDHSK89KrX/yUaQKtNzOTtbp/U3SB+nXrweBDgoYquSDSOsmiMx/wP7YVoBbw1UAUTR/stbCwyZ93KKFg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/cli-contracts/-/cli-contracts-0.5.2.tgz",
+      "integrity": "sha512-e9hDnxXtbIH2SeakRlklye12xi3RlR4GBzIb9mmJVtK/GKYxgZU9y7SzlyZob4b3h7m3iYy+Duk9UlK3Str6Jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",
@@ -16,6 +16,7 @@
   },
   "files": [
     "dist",
+    "dsl_base",
     "cli-contract.yaml",
     "docs/cli-reference.md",
     "README.md",
@@ -76,7 +77,7 @@
     "@openai/agents": "^0.11.1",
     "@types/node": "^25.6.0",
     "agent-contracts-runtime": "^0.12.0",
-    "cli-contracts": "^0.5.1",
+    "cli-contracts": "^0.5.2",
     "eslint": "^10.2.0",
     "globals": "^17.5.0",
     "prettier": "^3.8.2",

--- a/src/loader/loader.ts
+++ b/src/loader/loader.ts
@@ -284,11 +284,21 @@ async function resolveRefsDeep(
       return resolved;
     }
 
-    // File/directory reference
-    const refTarget = resolve(baseDir, refValue);
+    // File reference with optional JSON Pointer fragment (file.yaml#/path)
+    const hashIdx = refValue.indexOf("#");
+    const filePart = hashIdx >= 0 ? refValue.slice(0, hashIdx) : refValue;
+    const fragment = hashIdx >= 0 ? refValue.slice(hashIdx) : null;
+
+    const refTarget = resolve(baseDir, filePart);
     const s = await fsStat(refTarget).catch(() => null);
 
     if (s?.isDirectory()) {
+      if (fragment) {
+        throw new DslLoadError(
+          `Cannot use JSON Pointer fragment with directory $ref: ${refValue}`,
+          refTarget,
+        );
+      }
       if (resolving.has(refTarget)) {
         throw new DslLoadError(
           `Circular $ref detected: ${refTarget}`,
@@ -313,14 +323,26 @@ async function resolveRefsDeep(
     }
     resolving.add(refTarget);
     const content = await readYaml(refTarget);
-    const resolved = await resolveRefsDeep(
+    const fileRoot = fragment ? content as AnyRecord : rootDoc;
+    let fileData = await resolveRefsDeep(
       content,
       dirname(refTarget),
       resolving,
-      rootDoc,
+      fileRoot,
     );
     resolving.delete(refTarget);
-    return resolved;
+
+    if (fragment && fragment.startsWith("#/")) {
+      if (!isRecord(fileData)) {
+        throw new DslLoadError(
+          `Cannot resolve fragment "${fragment}" in ${refTarget}: file content is not an object`,
+          refTarget,
+        );
+      }
+      fileData = resolveJsonPointer(fileData as AnyRecord, fragment);
+    }
+
+    return fileData;
   }
 
   let obj = data as AnyRecord;

--- a/test/fixtures/file-fragment-ref/agent-contracts.yaml
+++ b/test/fixtures/file-fragment-ref/agent-contracts.yaml
@@ -1,0 +1,36 @@
+version: 1
+system:
+  id: file-fragment-test
+  name: File Fragment Ref Test
+  default_workflow_order:
+    - implement
+
+agents:
+  worker:
+    role_name: Worker
+    purpose: Do work
+    can_return_handoffs: [work-result]
+
+tasks:
+  do-work:
+    description: A task
+    target_agent: worker
+    allowed_from_agents: [worker]
+    workflow: implement
+    input_artifacts: []
+    invocation_handoff: work-result
+    result_handoff: work-result
+
+artifacts: {}
+tools: {}
+validations: {}
+
+handoff_types:
+  work-result:
+    version: 1
+    description: Work result with schema from external file fragment
+    schema:
+      $ref: './components.yaml#/schemas/result-payload'
+
+workflow: {}
+policies: {}

--- a/test/fixtures/file-fragment-ref/components.yaml
+++ b/test/fixtures/file-fragment-ref/components.yaml
@@ -1,0 +1,18 @@
+schemas:
+  common-handoff:
+    type: object
+    required: [from_agent, to_agent]
+    properties:
+      from_agent:
+        type: string
+      to_agent:
+        type: string
+  result-payload:
+    type: object
+    required: [summary]
+    properties:
+      summary:
+        type: string
+      details:
+        type: object
+        additionalProperties: true

--- a/test/loader/loader.test.ts
+++ b/test/loader/loader.test.ts
@@ -269,4 +269,93 @@ describe("loadDsl", () => {
       }
     });
   });
+
+  describe("file $ref with JSON Pointer fragment (file.yaml#/path)", () => {
+    it("resolves external file with fragment", async () => {
+      const result = await loadDsl(
+        join(fixturesDir, "file-fragment-ref/agent-contracts.yaml"),
+      );
+      const handoffTypes = result.data["handoff_types"] as Record<string, Record<string, unknown>>;
+      const workResult = handoffTypes["work-result"];
+      const schema = workResult["schema"] as Record<string, unknown>;
+
+      expect(schema["type"]).toBe("object");
+      expect(schema["required"]).toEqual(["summary"]);
+      const props = schema["properties"] as Record<string, unknown>;
+      expect(props["summary"]).toEqual({ type: "string" });
+      expect(props["details"]).toEqual({
+        type: "object",
+        additionalProperties: true,
+      });
+    });
+
+    it("resolves internal $ref within an externally-loaded file", async () => {
+      const { writeFileSync, unlinkSync } = await import("node:fs");
+      const tempDsl = join(fixturesDir, "file-fragment-ref/temp-internal-ref.yaml");
+      const tempComp = join(fixturesDir, "file-fragment-ref/temp-components.yaml");
+      writeFileSync(tempComp, [
+        "schemas:",
+        "  base:",
+        "    type: object",
+        "    properties:",
+        "      id:",
+        "        type: string",
+        "  extended:",
+        "    type: object",
+        "    properties:",
+        "      base:",
+        '        $ref: "#/schemas/base"',
+        "      extra:",
+        "        type: string",
+      ].join("\n"));
+      writeFileSync(tempDsl, [
+        "version: 1",
+        "system:",
+        "  id: t",
+        "  name: T",
+        "  default_workflow_order: []",
+        "handoff_types:",
+        "  h:",
+        "    version: 1",
+        "    schema:",
+        "      $ref: './temp-components.yaml#/schemas/extended'",
+      ].join("\n"));
+      try {
+        const result = await loadDsl(tempDsl);
+        const ht = result.data["handoff_types"] as Record<string, Record<string, unknown>>;
+        const schema = ht["h"]["schema"] as Record<string, unknown>;
+        expect(schema["type"]).toBe("object");
+        const props = schema["properties"] as Record<string, unknown>;
+        expect(props["extra"]).toEqual({ type: "string" });
+        const base = props["base"] as Record<string, unknown>;
+        expect(base["type"]).toBe("object");
+        expect((base["properties"] as Record<string, unknown>)["id"]).toEqual({ type: "string" });
+      } finally {
+        unlinkSync(tempDsl);
+        unlinkSync(tempComp);
+      }
+    });
+
+    it("errors on file $ref with fragment pointing to non-existent path", async () => {
+      const { writeFileSync, unlinkSync } = await import("node:fs");
+      const tempDsl = join(fixturesDir, "file-fragment-ref/temp-bad-fragment.yaml");
+      writeFileSync(tempDsl, [
+        "version: 1",
+        "system:",
+        "  id: t",
+        "  name: T",
+        "  default_workflow_order: []",
+        "handoff_types:",
+        "  h:",
+        "    version: 1",
+        "    schema:",
+        "      $ref: './components.yaml#/schemas/nonexistent'",
+      ].join("\n"));
+      try {
+        await expect(loadDsl(tempDsl)).rejects.toThrow("not found");
+      } finally {
+        unlinkSync(tempDsl);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- DSL loader now supports `file.yaml#/json-pointer` syntax in $ref values
- Internal $ref within external files are resolved against that file's own root (not the parent DSL root)
- `dsl_base/` is now included in the published npm package via `files` field
- 3 new test cases covering fragment resolution, nested internal refs, and error handling

## Motivation
Enables DSL consumers (e.g. cli-contracts) to reference specific schemas within shared component files without inlining them.

## Test plan
- [x] 711 tests pass (708 existing + 3 new)
- [x] Build succeeds

Made with [Cursor](https://cursor.com)