### PR TITLE
feat: parallelize dsl-audit workflow steps

### DIFF
--- a/cli-contract.yaml
+++ b/cli-contract.yaml
@@ -3,7 +3,7 @@ cliContracts: 0.1.0
 
 info:
   title: agent-contracts CLI
-  version: 0.22.0
+  version: 0.22.1
   description: >-
     Declarative YAML DSL toolkit for defining, validating, and rendering
     multi-agent development workflows. Provides static validation,

--- a/dsl_base/workflow.yaml
+++ b/dsl_base/workflow.yaml
@@ -72,6 +72,7 @@ dsl-audit:
     - type: delegate
       task: audit-semantic-design
       from_agent: dsl-auditor
+      depends_on: ["gate:dsl-audit-result"]
       description: >-
         DSL Auditor reviews DSL design for semantic coherence —
         role overlap, scope breadth, gate placement, guardrail
@@ -79,12 +80,14 @@ dsl-audit:
     - type: delegate
       task: audit-generated-prompts
       from_agent: dsl-auditor
+      depends_on: ["gate:dsl-audit-result"]
       description: >-
         DSL Auditor compares generated prompts against DSL intent —
         detects missing requirements, hallucinated permissions,
         ambiguous instructions.
     - type: gate
-      gate_kind: dsl-audit-result
+      gate_kind: dsl-audit-terminal
+      depends_on: [audit-semantic-design, audit-generated-prompts]
       description: >-
         Terminal gate — block if audit-generated-prompts detected
         hallucinated permissions (enforces dsl-no-hallucinated-permissions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- `dsl-audit` ワークフローの `audit-semantic-design` と `audit-generated-prompts` を `depends_on` で並列化
- ランタイム (`workflow-runner.ts`) の DAG スケジューラが `Promise.all` で並列実行
- terminal gate の `gate_kind` を `dsl-audit-terminal` にリネーム（`stepId` の一意性確保）
- v0.22.1

## Execution flow (before → after)

```
Before: completeness → gate → semantic → prompts → gate (sequential)
After:  completeness → gate → semantic ─┐
                             → prompts  ─┤→ terminal gate
```

## Related

- foo-ogawa/agent-contracts-runtime#49 — gate auto-approve issue

## Test plan

- [x] `npx tsc --noEmit` pass
- [x] `npm test` — 711 tests pass


Made with [Cursor](https://cursor.com)