### PR TITLE
chore: bump version to 0.22.3

### DIFF
--- a/cli-contract.yaml
+++ b/cli-contract.yaml
@@ -3,7 +3,7 @@ cliContracts: 0.1.0
 
 info:
   title: agent-contracts CLI
-  version: 0.22.1
+  version: 0.22.3
   description: >-
     Declarative YAML DSL toolkit for defining, validating, and rendering
     multi-agent development workflows. Provides static validation,

--- a/dsl_base/agents/dsl-auditor.yaml
+++ b/dsl_base/agents/dsl-auditor.yaml
@@ -157,6 +157,7 @@ dsl-auditor:
         | 8 | Task with no completion_criteria defined | warning |
         | 9 | Agent can_write without corresponding required_validations | warning |
         | 10 | Circular delegation chains in workflow steps | critical |
+        | 11 | Custom x- properties replicating standard DSL control-flow (e.g. x-exit-conditions instead of gate steps, x-routing instead of decision steps) | warning |
 
     - title: "Prompt Audit Dimensions"
       content: |

--- a/dsl_base/tasks.yaml
+++ b/dsl_base/tasks.yaml
@@ -203,10 +203,12 @@ audit-semantic-design:
     - Check workflow gates are placed effectively
     - Detect guardrails declared but absent from execution path
     - Check semantic validations are distributed across phases
+    - Detect custom x- properties that replicate standard DSL control-flow features (gate, decision, entry_conditions)
   completion_criteria:
     - All agents reviewed for scope and overlap
     - Workflow gate placement analyzed
     - Guardrail enforcement path verified
+    - Custom x- property misuse flagged
     - Findings classified with severity and category
   execution_steps:
     - id: load-dsl

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version from 0.22.2 to 0.22.3
- Update cli-contract.yaml version to match

## Changes since v0.22.2
- feat: add semantic audit dimension for x- control-flow property misuse

Made with [Cursor](https://cursor.com)