### PR TITLE
feat: extension consumption audit, $ref resolution fix, DSL design improvements

### DIFF
--- a/cli-contract.yaml
+++ b/cli-contract.yaml
@@ -515,17 +515,19 @@ commandSets:
         summary: Run LLM-based semantic audit on DSL definitions and generated outputs.
         description: >-
           Performs LLM-based semantic analysis on DSL definitions and/or
-          generated outputs. Three audit types are available: "render"
+          generated outputs. Four audit types are available: "render"
           checks whether generated files faithfully reflect the resolved
-          DSL, "dsl" reviews DSL design for semantic coherence, and
-          "prompt" verifies that generated prompts accurately express
-          DSL intent. Uses agent-contracts-runtime (optional peer
-          dependency) for LLM execution with handoff schema validation
-          and follow-up recovery.
+          DSL, "dsl" reviews DSL design for semantic coherence, "prompt"
+          verifies that generated prompts accurately express DSL intent,
+          and "extensions" detects declared x-* properties that are not
+          consumed by render templates or runtime codegen. Uses
+          agent-contracts-runtime (optional peer dependency) for LLM
+          execution with handoff schema validation and follow-up recovery.
         usage:
           - agent-contracts audit render -c agent-contracts.config.yaml
           - agent-contracts audit dsl -c agent-contracts.config.yaml
           - agent-contracts audit prompt -c agent-contracts.config.yaml
+          - agent-contracts audit extensions -c agent-contracts.config.yaml
           - agent-contracts audit all -c agent-contracts.config.yaml
           - agent-contracts audit dsl --dry-run -c agent-contracts.config.yaml
           - agent-contracts audit render --format json -c agent-contracts.config.yaml
@@ -550,10 +552,11 @@ commandSets:
             description: >-
               Audit type to run: render (semantic diff of generated
               outputs vs DSL), dsl (design coherence review), prompt
-              (generated prompt fidelity check), or all (run all three).
+              (generated prompt fidelity check), extensions (unconsumed
+              x-* property detection), or all (run all four).
             schema:
               type: string
-              enum: [render, dsl, prompt, all]
+              enum: [render, dsl, prompt, extensions, all]
               default: all
 
         options:

--- a/dsl_base/agents/dsl-auditor.yaml
+++ b/dsl_base/agents/dsl-auditor.yaml
@@ -11,8 +11,6 @@ dsl-auditor:
     - dsl-score-report
   can_write_artifacts:
     - dsl-audit-report
-  can_invoke_agents:
-    - dsl-auditor
   can_execute_tools:
     - agent-contracts-cli
   can_perform_validations:
@@ -29,6 +27,7 @@ dsl-auditor:
     - Report score-based improvement areas as audit recommendations (read-only; consumes dsl-score-report produced by dsl-designer)
     - Review DSL design for semantic coherence (role overlap, scope breadth, gate placement)
     - Verify generated prompts faithfully represent DSL intent (no hallucinated permissions)
+    - Audit x-* extension consumption across render templates and runtime codegen paths
   constraints:
     - Do not directly modify DSL definitions (read-only analysis)
     - Do not execute agent-contracts score independently; consume dsl-score-report produced by dsl-designer only
@@ -48,6 +47,15 @@ dsl-auditor:
         When a MISS is detected, classify the root cause as one of:
         template gap, data gap, or DSL gap.
       severity: mandatory
+  anti_patterns:
+    - >-
+      Directly editing DSL source files or generated outputs —
+      dsl-auditor is read-only; produce fix proposals in
+      dsl-audit-report instead and let dsl-designer apply them.
+    - >-
+      Running render or generate commands — these produce
+      side-effect file writes that belong to dsl-designer's scope;
+      use read-only commands (validate, lint, score, audit) only.
   escalation_criteria:
     - condition: 3 or more critical-level gaps detected
       action: stop_and_report
@@ -175,3 +183,24 @@ dsl-auditor:
         | 8 | Task completion criteria not reflected in prompt | warning |
         | 9 | Delegatable tasks not described in prompt | info |
         | 10 | Guardrail rules not reflected in prompt | warning |
+
+    - title: "Extension Consumption Audit Dimensions"
+      content: |
+        When performing `audit extensions` (extension consumption audit), check:
+
+        | # | Dimension | Severity |
+        |---|-----------|----------|
+        | 1 | Declared extension never populated on any entity | warning |
+        | 2 | Populated x-* not declared in extensions (when declarations exist) | info |
+        | 3 | Populated x-* not referenced in any render template | warning |
+        | 4 | Declared scope vs actual usage node type mismatch | warning |
+        | 5 | x-* with required: true but no render template consumption path | critical |
+        | 6 | x-* replicates standard DSL feature (semantic overlap) | warning |
+        | 7 | x-* unreachable in runtime codegen (not in AgentContract/TaskContract/WorkflowContract fixed fields) | info |
+        | 8 | Template references x-* key that is never populated in DSL | warning |
+
+        For each finding, recommend one of:
+        - **Remove**: Extension is dead weight — remove from declarations and entities
+        - **Migrate**: Extension duplicates a standard DSL feature — migrate to the standard field
+        - **Add template**: Extension carries useful data — add template support to consume it
+        - **Document**: Extension is metadata-only (not intended for render/runtime) — add description clarifying intent

--- a/dsl_base/agents/dsl-designer.yaml
+++ b/dsl_base/agents/dsl-designer.yaml
@@ -15,8 +15,6 @@ dsl-designer:
     - dsl-source
     - dsl-generated-output
     - dsl-score-report
-  can_invoke_agents:
-    - dsl-designer
   can_execute_tools:
     - agent-contracts-cli
   can_perform_validations:

--- a/dsl_base/artifacts.yaml
+++ b/dsl_base/artifacts.yaml
@@ -70,4 +70,4 @@ dsl-audit-report:
     - submitted
   required_validations:
     - dsl-audit-report-validation
-  x-artifact-class: evidence
+  classification: evidence

--- a/dsl_base/handoff-types.yaml
+++ b/dsl_base/handoff-types.yaml
@@ -93,8 +93,8 @@ audit-result:
     $ref: "#/components/schemas/agent-audit-result"
 
 dsl-audit-result:
-  version: 3
-  description: Result of DSL audit (completeness, semantic design, or prompt fidelity)
+  version: 4
+  description: Result of DSL audit (completeness, semantic design, prompt fidelity, or extensions)
   schema:
     type: object
     properties:
@@ -104,6 +104,7 @@ dsl-audit-result:
           - completeness
           - semantic
           - prompt
+          - extensions
         description: Which audit task produced this result
       total_dimensions:
         type: integer
@@ -123,16 +124,36 @@ dsl-audit-result:
       prompts_reviewed:
         type: integer
         description: Number of generated prompts compared (prompt audit)
-      gate_analysis_complete:
-        type: boolean
+      completion_criteria_coverage:
+        type: object
+        properties:
+          all_dimensions_inspected:
+            type: boolean
+            description: All required dimensions were inspected for all agents
+          gaps_classified:
+            type: boolean
+            description: Every detected gap has a root-cause classification
+          gate_analysis_complete:
+            type: boolean
+            description: Workflow gate placement analysis has been performed
+          guardrail_enforcement_verified:
+            type: boolean
+            description: All declared guardrails verified to exist in execution paths
+          scope_overlap_analyzed:
+            type: boolean
+            description: All agents reviewed for responsibility scope and role overlap
+          x_property_misuse_checked:
+            type: boolean
+            description: Custom x-* properties checked for standard DSL overlap
+          hallucinated_permissions_checked:
+            type: boolean
+            description: Generated prompts verified for permissions not declared in DSL
+          extension_consumption_checked:
+            type: boolean
+            description: All declared extensions checked for template/runtime consumption
         description: >-
-          True when workflow gate placement analysis has been performed
-          (semantic audit completion criterion).
-      guardrail_enforcement_verified:
-        type: boolean
-        description: >-
-          True when all declared guardrails have been verified to exist
-          in execution paths (semantic audit completion criterion).
+          Per-criterion completion status. Each field maps to a
+          completion_criteria entry in the corresponding audit task.
       critical_gaps:
         type: array
         items:
@@ -180,3 +201,4 @@ dsl-audit-result:
       - total_dimensions
       - pass_count
       - miss_count
+      - completion_criteria_coverage

--- a/dsl_base/tasks.yaml
+++ b/dsl_base/tasks.yaml
@@ -3,8 +3,6 @@
 update-dsl-definitions:
   description: Create new or update existing agent-contracts DSL definitions
   target_agent: dsl-designer
-  allowed_from_agents:
-    - dsl-designer
   workflow: dsl-update
   input_artifacts:
     - dsl-source
@@ -43,8 +41,6 @@ update-dsl-definitions:
 update-dsl-binding:
   description: Create new or update existing software bindings
   target_agent: dsl-designer
-  allowed_from_agents:
-    - dsl-designer
   workflow: dsl-update
   input_artifacts:
     - dsl-source
@@ -79,8 +75,6 @@ update-dsl-binding:
 render-dsl-outputs:
   description: Render prompts and documents from DSL and check for drift
   target_agent: dsl-designer
-  allowed_from_agents:
-    - dsl-designer
   workflow: dsl-update
   input_artifacts:
     - dsl-source
@@ -110,8 +104,6 @@ render-dsl-outputs:
 check-dsl-score:
   description: Check DSL completeness score and identify improvement areas
   target_agent: dsl-designer
-  allowed_from_agents:
-    - dsl-designer
   workflow: dsl-update
   input_artifacts:
     - dsl-source
@@ -143,8 +135,6 @@ check-dsl-score:
 audit-dsl-completeness:
   description: Audit completeness of DSL definitions against generated prompts
   target_agent: dsl-auditor
-  allowed_from_agents:
-    - dsl-auditor
   workflow: dsl-audit
   input_artifacts:
     - dsl-source
@@ -185,8 +175,6 @@ audit-dsl-completeness:
 audit-semantic-design:
   description: Audit DSL design for semantic coherence
   target_agent: dsl-auditor
-  allowed_from_agents:
-    - dsl-auditor
   workflow: dsl-audit
   input_artifacts:
     - dsl-source
@@ -231,8 +219,6 @@ audit-semantic-design:
 audit-generated-prompts:
   description: Audit generated prompts against DSL intent
   target_agent: dsl-auditor
-  allowed_from_agents:
-    - dsl-auditor
   workflow: dsl-audit
   input_artifacts:
     - dsl-source
@@ -268,4 +254,47 @@ audit-generated-prompts:
       produces_artifact: dsl-audit-report
   escalation_criteria:
     - condition: Hallucinated permissions detected in generated prompts
+      action: stop_and_report
+
+audit-extension-consumption:
+  description: Audit declared x-* extensions for consumption gaps across render and runtime paths
+  target_agent: dsl-auditor
+  workflow: dsl-audit
+  input_artifacts:
+    - dsl-source
+    - dsl-generated-output
+  invocation_handoff: dsl-task-request
+  result_handoff: dsl-audit-result
+  validations:
+    - dsl-completeness-audit
+    - dsl-audit-report-validation
+  responsibilities:
+    - Cross-check extensions declarations against entity x-* usage
+    - Identify x-* properties populated in DSL but not consumed by any render template
+    - Detect semantic overlap between x-* extensions and standard DSL features
+    - Report runtime codegen reachability for each extension
+    - Distinguish intentional metadata-only extensions from consumption gaps
+  completion_criteria:
+    - All declared extensions checked for template and runtime consumption
+    - Unused extensions flagged with suggested action (remove, migrate to standard, or add template support)
+    - Runtime-unreachable extensions documented with explanation
+    - Findings classified with severity and category
+  execution_steps:
+    - id: collect-declarations
+      action: Collect extensions declarations and x-* usage map
+      reads_artifact: dsl-source
+      required: true
+    - id: collect-templates
+      action: Collect render template x-* references
+      reads_artifact: dsl-generated-output
+      required: true
+    - id: analyze-consumption
+      action: Cross-check declarations vs usage vs template references vs runtime fields
+    - id: analyze-semantics
+      action: Detect semantic overlap with standard DSL features
+    - id: produce-report
+      action: Produce extension consumption audit report
+      produces_artifact: dsl-audit-report
+  escalation_criteria:
+    - condition: Required extension with no consumption path detected
       action: stop_and_report

--- a/dsl_base/validations.yaml
+++ b/dsl_base/validations.yaml
@@ -4,7 +4,7 @@ dsl-schema-validation:
   executor_type: tool
   executor: agent-contracts-cli
   blocking: true
-  x-description: >-
+  description: >-
     DSL schema validation via agent-contracts validate command.
     Performs type checks on all entities, verifies required fields,
     and checks cross-reference integrity.
@@ -15,7 +15,7 @@ dsl-lint-validation:
   executor_type: tool
   executor: agent-contracts-cli
   blocking: false
-  x-description: >-
+  description: >-
     Semantic validation via agent-contracts lint command.
     Checks naming conventions, unused entities, circular references,
     and other design quality aspects.
@@ -26,7 +26,7 @@ dsl-score-validation:
   executor_type: tool
   executor: agent-contracts-cli
   blocking: false
-  x-description: >-
+  description: >-
     Completeness evaluation via agent-contracts score command.
     Scores across 7 dimensions: artifact validation coverage,
     task validation coverage, guardrail policy coverage,
@@ -40,7 +40,7 @@ dsl-completeness-audit:
   executor: dsl-auditor
   blocking: false
   produces_evidence: dsl-audit-report
-  x-description: >-
+  description: >-
     19-dimension cross-check audit of DSL definitions against generated
     prompts. Verifies that all items defined in the DSL are correctly
     reflected in generated output.
@@ -51,7 +51,7 @@ dsl-score-report-validation:
   executor_type: tool
   executor: agent-contracts-cli
   blocking: false
-  x-description: >-
+  description: >-
     Validates that dsl-score-report has been produced and contains
     a valid score across all 7 dimensions.
 
@@ -61,6 +61,6 @@ dsl-audit-report-validation:
   executor_type: agent
   executor: dsl-auditor
   blocking: false
-  x-description: >-
+  description: >-
     Validates that dsl-audit-report contains findings classified
     as PASS/MISS/PARTIAL for all inspected dimensions.

--- a/dsl_base/workflow.yaml
+++ b/dsl_base/workflow.yaml
@@ -19,7 +19,8 @@ dsl-update:
       gate_kind: dsl-task-result
       description: >-
         Block if validation_result or lint_result did not pass in
-        update-dsl-definitions.
+        update-dsl-definitions.  Enforces dsl-validate-before-render
+        guardrail — prevents render from executing against invalid DSL.
     - type: delegate
       task: update-dsl-binding
       from_agent: dsl-designer
@@ -50,8 +51,9 @@ dsl-audit:
   description: >-
     DSL Audit — audit completeness of DSL definitions against generated
     prompts, detect gaps, and present improvement recommendations.
-    Executed by DSL Auditor. Supports three audit types: render (semantic
-    diff), dsl (design coherence), and prompt (prompt fidelity).
+    Executed by DSL Auditor. Supports four audit types: render (semantic
+    diff), dsl (design coherence), prompt (prompt fidelity), and
+    extensions (x-* consumption gap detection).
   entry_conditions:
     - DSL definition rendering is complete
   trigger: >-
@@ -77,6 +79,12 @@ dsl-audit:
         DSL Auditor reviews DSL design for semantic coherence —
         role overlap, scope breadth, gate placement, guardrail
         enforcement paths.
+    - type: gate
+      gate_kind: dsl-audit-result
+      depends_on: [audit-semantic-design]
+      description: >-
+        Semantic-design gate — block if critical design issues
+        detected (gate placement defects, handoff schema gaps).
     - type: delegate
       task: audit-generated-prompts
       from_agent: dsl-auditor
@@ -86,9 +94,23 @@ dsl-audit:
         detects missing requirements, hallucinated permissions,
         ambiguous instructions.
     - type: gate
-      gate_kind: dsl-audit-terminal
-      depends_on: [audit-semantic-design, audit-generated-prompts]
+      gate_kind: dsl-audit-result
+      depends_on: [audit-generated-prompts]
       description: >-
-        Terminal gate — block if audit-generated-prompts detected
-        hallucinated permissions (enforces dsl-no-hallucinated-permissions
-        guardrail at workflow level via stop_and_report escalation).
+        Hallucinated-permissions gate — block immediately if
+        audit-generated-prompts detected permissions not declared
+        in DSL (enforces dsl-no-hallucinated-permissions guardrail).
+    - type: delegate
+      task: audit-extension-consumption
+      from_agent: dsl-auditor
+      depends_on: ["gate:dsl-audit-result"]
+      description: >-
+        DSL Auditor checks x-* extension properties for consumption
+        gaps — declared but unused, populated but not rendered,
+        semantic overlap with standard DSL features.
+    - type: gate
+      gate_kind: dsl-audit-result
+      depends_on: [audit-semantic-design, audit-generated-prompts, audit-extension-consumption]
+      description: >-
+        Terminal gate — aggregates all audit results and blocks if
+        any critical-level findings remain unresolved.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-contracts",
-  "version": "0.22.1",
+  "version": "0.22.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-contracts",
-      "version": "0.22.1",
+      "version": "0.22.4",
       "license": "MIT",
       "dependencies": {
         "@stoplight/spectral-core": "^1.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/auditor/auditor.ts
+++ b/src/auditor/auditor.ts
@@ -75,6 +75,7 @@ const AUDIT_TYPE_TO_TASK: Record<AuditType, string> = {
   render: "audit-dsl-completeness",
   dsl: "audit-semantic-design",
   prompt: "audit-generated-prompts",
+  extensions: "audit-extension-consumption",
 };
 
 export interface AuditRunResult {
@@ -168,7 +169,7 @@ export async function runAllAudits(
   auditConfig: AuditConfig,
   options: Omit<AuditOptions, "auditType">,
 ): Promise<AuditRunResult[]> {
-  const types: AuditType[] = ["render", "dsl", "prompt"];
+  const types: AuditType[] = ["render", "dsl", "prompt", "extensions"];
   const results: AuditRunResult[] = [];
   for (const auditType of types) {
     results.push(await runAudit(dsl, config, auditConfig, { ...options, auditType }));

--- a/src/auditor/context-builder.ts
+++ b/src/auditor/context-builder.ts
@@ -8,7 +8,7 @@
 
 import { readFile } from "node:fs/promises";
 import * as yaml from "yaml";
-import type { Dsl } from "../schema/index.js";
+import type { Dsl, ScopeNodeType } from "../schema/index.js";
 import type { ResolvedConfig, ResolvedRenderTarget } from "../config/types.js";
 import {
   buildPerAgentContext,
@@ -99,6 +99,145 @@ function formatDslOverview(dsl: Dsl): string {
   ].join("\n");
 }
 
+interface XUsageEntry {
+  path: string;
+  nodeType: ScopeNodeType;
+  key: string;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function collectAllXUsages(dsl: Dsl): XUsageEntry[] {
+  const entries: XUsageEntry[] = [];
+
+  function walk(obj: Record<string, unknown>, path: string, nodeType: ScopeNodeType): void {
+    for (const key of Object.keys(obj)) {
+      if (key.startsWith("x-") && key !== "x-extensions" && key !== "x-extensions-strict") {
+        entries.push({ path: path ? `${path}.${key}` : key, nodeType, key });
+      }
+    }
+  }
+
+  walk(dsl as unknown as Record<string, unknown>, "", "root");
+  if (isRecord(dsl.system)) walk(dsl.system as unknown as Record<string, unknown>, "system", "system");
+
+  for (const [id, a] of Object.entries(dsl.agents))
+    walk(a as unknown as Record<string, unknown>, `agents.${id}`, "agent");
+  for (const [id, t] of Object.entries(dsl.tasks))
+    walk(t as unknown as Record<string, unknown>, `tasks.${id}`, "task");
+  for (const [id, a] of Object.entries(dsl.artifacts))
+    walk(a as unknown as Record<string, unknown>, `artifacts.${id}`, "artifact");
+  for (const [id, t] of Object.entries(dsl.tools))
+    walk(t as unknown as Record<string, unknown>, `tools.${id}`, "tool");
+  for (const [id, v] of Object.entries(dsl.validations))
+    walk(v as unknown as Record<string, unknown>, `validations.${id}`, "validation");
+  for (const [id, h] of Object.entries(dsl.handoff_types))
+    walk(h as unknown as Record<string, unknown>, `handoff_types.${id}`, "handoff_type");
+  for (const [id, w] of Object.entries(dsl.workflow))
+    walk(w as unknown as Record<string, unknown>, `workflow.${id}`, "workflow");
+  for (const [id, p] of Object.entries(dsl.policies))
+    walk(p as unknown as Record<string, unknown>, `policies.${id}`, "policy");
+  for (const [id, g] of Object.entries(dsl.guardrails))
+    walk(g as unknown as Record<string, unknown>, `guardrails.${id}`, "guardrail");
+  for (const [id, gp] of Object.entries(dsl.guardrail_policies))
+    walk(gp as unknown as Record<string, unknown>, `guardrail_policies.${id}`, "guardrail_policy");
+
+  return entries;
+}
+
+function extractTemplateXReferences(config: ResolvedConfig): string[] {
+  const refs: string[] = [];
+  try {
+    const { readFileSync } = require("node:fs") as typeof import("node:fs");
+    for (const target of config.renders) {
+      try {
+        const content = readFileSync(target.template, "utf8");
+        const matches = content.matchAll(/\{\{[^}]*?(x-[\w-]+)[^}]*?\}\}/g);
+        for (const m of matches) refs.push(m[1]);
+      } catch { /* template may not exist */ }
+    }
+  } catch { /* fallback if fs unavailable */ }
+  return [...new Set(refs)];
+}
+
+function buildExtensionsContext(dsl: Dsl, config: ResolvedConfig): string {
+  const parts: string[] = [];
+
+  parts.push("## Extension Declarations");
+  const declaredKeys = Object.keys(dsl.extensions);
+  if (declaredKeys.length === 0) {
+    parts.push("(No extensions declared in `extensions` section)");
+  } else {
+    parts.push("```yaml\n" + yaml.stringify({ extensions: dsl.extensions }) + "```");
+  }
+
+  parts.push("## x-* Usage Map");
+  const usages = collectAllXUsages(dsl);
+  if (usages.length === 0) {
+    parts.push("(No x-* properties found on any entity)");
+  } else {
+    const byKey = new Map<string, XUsageEntry[]>();
+    for (const u of usages) {
+      let list = byKey.get(u.key);
+      if (!list) { list = []; byKey.set(u.key, list); }
+      list.push(u);
+    }
+    const lines: string[] = ["| Extension | Node Type | Path |", "|-----------|-----------|------|"];
+    for (const [key, entries] of byKey) {
+      for (const e of entries) {
+        lines.push(`| ${key} | ${e.nodeType} | ${e.path} |`);
+      }
+    }
+    parts.push(lines.join("\n"));
+  }
+
+  parts.push("## Template x-* References");
+  const templateRefs = extractTemplateXReferences(config);
+  if (templateRefs.length === 0) {
+    parts.push("(No x-* references found in render templates, or no templates configured)");
+  } else {
+    parts.push(templateRefs.map((r) => `- ${r}`).join("\n"));
+  }
+
+  parts.push("## Runtime Codegen Fixed Fields");
+  parts.push(
+    "The agent-contracts-runtime codegen templates emit only these fixed fields " +
+    "(x-* properties are not included in generated TypeScript contracts):\n" +
+    "- **AgentContract**: id, role_name, purpose, mode, dispatch_only, can_read_artifacts, " +
+    "can_write_artifacts, can_execute_tools, can_invoke_agents, can_return_handoffs, " +
+    "responsibilities, constraints, rules, escalation_criteria\n" +
+    "- **TaskContract**: id, description, target_agent, allowed_from_agents, workflow, " +
+    "invocation_handoff, result_handoff, input_artifacts, responsibilities, " +
+    "completion_criteria, optional\n" +
+    "- **WorkflowContract**: id, description, trigger, entry_conditions, steps",
+  );
+
+  const declaredSet = new Set(declaredKeys);
+  const usedKeys = new Set(usages.map((u) => u.key));
+  const templateRefSet = new Set(templateRefs);
+
+  parts.push("## Gap Summary");
+  const gaps: string[] = [];
+  for (const key of declaredKeys) {
+    if (!usedKeys.has(key)) gaps.push(`- **${key}**: declared but never populated on any entity`);
+  }
+  for (const key of usedKeys) {
+    if (declaredKeys.length > 0 && !declaredSet.has(key))
+      gaps.push(`- **${key}**: used on entities but not declared in extensions`);
+    if (!templateRefSet.has(key))
+      gaps.push(`- **${key}**: populated on entities but not referenced in any render template`);
+  }
+  if (gaps.length === 0) {
+    parts.push("(No obvious gaps detected by static analysis)");
+  } else {
+    parts.push(gaps.join("\n"));
+  }
+
+  return parts.join("\n\n");
+}
+
 export async function buildAuditContext(
   auditType: AuditType,
   dsl: Dsl,
@@ -123,6 +262,10 @@ export async function buildAuditContext(
     if (renderedFiles.length === 0) {
       sections.push("(No rendered agent prompt files found. Run `agent-contracts render` first.)");
     }
+  }
+
+  if (auditType === "extensions") {
+    sections.push(buildExtensionsContext(dsl, config));
   }
 
   if (auditType === "dsl") {

--- a/src/auditor/types.ts
+++ b/src/auditor/types.ts
@@ -1,4 +1,4 @@
-export type AuditType = "render" | "dsl" | "prompt";
+export type AuditType = "render" | "dsl" | "prompt" | "extensions";
 
 export type OutputFormat = "text" | "json" | "markdown";
 

--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -593,7 +593,7 @@ const handleScore: CommandHandlers["score"] = async (dir, opts) => {
 
 // ─── audit ──────────────────────────────────────────────────────
 
-const AUDIT_TYPES = ["render", "dsl", "prompt", "all"] as const;
+const AUDIT_TYPES = ["render", "dsl", "prompt", "extensions", "all"] as const;
 
 function parseAuditConfig(configObj: Record<string, unknown> | undefined): AuditConfig {
   if (!configObj) return {};

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -136,6 +136,7 @@ export async function loadConfig(
       activeGuardrailPolicy: undefined,
       paths: undefined,
       teams: resolveTeamConfigs(config.teams, configDir),
+      audit: config.audit ?? undefined,
     };
   }
 
@@ -147,6 +148,7 @@ export async function loadConfig(
     bindings: (config.bindings ?? []).map((b) => resolve(configDir, b)),
     activeGuardrailPolicy: config.active_guardrail_policy,
     paths: config.paths,
+    audit: config.audit ?? undefined,
   };
 }
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -127,4 +127,5 @@ export interface ResolvedConfig {
   activeGuardrailPolicy?: string;
   paths?: Record<string, string>;
   teams?: Record<string, ResolvedTeamConfig>;
+  audit?: AuditConfig;
 }

--- a/src/generated/cli-contract/program.ts
+++ b/src/generated/cli-contract/program.ts
@@ -137,7 +137,7 @@ export function createProgram(
   program
     .command("audit")
     .description("Run LLM-based semantic audit on DSL definitions and generated outputs.")
-    .argument("[type]", "Audit type to run: render (semantic diff of generated outputs vs DSL), dsl (design coherence review), prompt (generated prompt fidelity check), or all (run all three).")
+    .argument("[type]", "Audit type to run: render (semantic diff of generated outputs vs DSL), dsl (design coherence review), prompt (generated prompt fidelity check), extensions (unconsumed x-* property detection), or all (run all four).")
     .option("-c, --config <path>", "Path to agent-contracts.config.yaml.")
     .option("--team <id>", "Limit to one team (multi-team config only).")
     .option("--format <format>", "Output format.", "text")

--- a/src/generated/cli-contract/types.ts
+++ b/src/generated/cli-contract/types.ts
@@ -98,7 +98,7 @@ export type ScoreExitResult =
   | { exitCode: 1; stderr: unknown };
 
 export interface AuditArgs {
-  type?: "render" | "dsl" | "prompt" | "all";
+  type?: "render" | "dsl" | "prompt" | "extensions" | "all";
 }
 
 export interface AuditOptions {

--- a/src/generated/dsl-base/.manifest.json
+++ b/src/generated/dsl-base/.manifest.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2026-05-10T01:01:15.973Z",
-  "dslHash": "65df03defc35e099a1a1a91d193ed2cd0e160991c61262f730da052b647dcd2f",
-  "generationInputHash": "65df03defc35e099a1a1a91d193ed2cd0e160991c61262f730da052b647dcd2f",
+  "generatedAt": "2026-05-13T08:31:57.187Z",
+  "dslHash": "3e64429a7b74ac1a161318cdd6f6fbe200ff1627c58cde6cb7f735388d348560",
+  "generationInputHash": "3e64429a7b74ac1a161318cdd6f6fbe200ff1627c58cde6cb7f735388d348560",
   "files": [
     "../src/generated/dsl-base/agents.ts",
     "../src/generated/dsl-base/tasks.ts",

--- a/src/generated/dsl-base/agents.ts
+++ b/src/generated/dsl-base/agents.ts
@@ -62,7 +62,8 @@ export const dslAuditor: AgentContract = {
   "Prioritize improvement recommendations (P0/P1/P2) with concrete fix proposals",
   "Report score-based improvement areas as audit recommendations (read-only; consumes dsl-score-report produced by dsl-designer)",
   "Review DSL design for semantic coherence (role overlap, scope breadth, gate placement)",
-  "Verify generated prompts faithfully represent DSL intent (no hallucinated permissions)"
+  "Verify generated prompts faithfully represent DSL intent (no hallucinated permissions)",
+  "Audit x-* extension consumption across render templates and runtime codegen paths"
 ],
   constraints: [
   "Do not directly modify DSL definitions (read-only analysis)",

--- a/src/generated/dsl-base/handoffs.ts
+++ b/src/generated/dsl-base/handoffs.ts
@@ -38,11 +38,54 @@ export const DslTaskResultSchema = z.object({
 export type DslTaskResult = z.infer<typeof DslTaskResultSchema>;
 
 // ---------------------------------------------------------------------------
+// audit-result
+// ---------------------------------------------------------------------------
+
+export const AuditResultSchema = z.object({
+  summary: z.string(),
+  riskLevel: z.enum(["low", "medium", "high", "critical"]),
+  findings: z.array(z.object({
+  id: z.string().optional(),
+  severity: z.enum(["info", "warning", "error", "critical"]),
+  category: z.string(),
+  target: z.string().optional(),
+  location: z.string().optional(),
+  message: z.string(),
+  recommendation: z.string().optional(),
+  confidence: z.number().optional(),
+  evidence: z.array(z.object({
+  kind: z.enum(["file", "command", "schema", "diff", "stdout", "stderr", "text"]),
+  target: z.string().optional(),
+  location: z.string().optional(),
+  excerpt: z.string().optional(),
+})).optional(),
+  details: z.record(z.string(), z.unknown()).optional(),
+})),
+  recommendedActions: z.array(z.object({
+  kind: z.enum(["run_command", "edit_file", "review", "confirm", "block", "ignore"]),
+  title: z.string(),
+  command: z.string().optional(),
+  target: z.string().optional(),
+  rationale: z.string().optional(),
+})).optional(),
+  metadata: z.object({
+  tool: z.string().optional(),
+  command: z.string().optional(),
+  version: z.string().optional(),
+  generatedAt: z.string().optional(),
+  adapter: z.string().optional(),
+  model: z.string().optional(),
+}).optional(),
+});
+
+export type AuditResult = z.infer<typeof AuditResultSchema>;
+
+// ---------------------------------------------------------------------------
 // dsl-audit-result
 // ---------------------------------------------------------------------------
 
 export const DslAuditResultSchema = z.object({
-  audit_type: z.enum(["completeness", "semantic", "prompt"]),
+  audit_type: z.enum(["completeness", "semantic", "prompt", "extensions"]),
   total_dimensions: z.number(),
   pass_count: z.number(),
   miss_count: z.number(),
@@ -73,6 +116,7 @@ export type DslAuditResult = z.infer<typeof DslAuditResultSchema>;
 export const handoffSchemas = {
   "dsl-task-request": DslTaskRequestSchema,
   "dsl-task-result": DslTaskResultSchema,
+  "audit-result": AuditResultSchema,
   "dsl-audit-result": DslAuditResultSchema,
 } as const;
 
@@ -105,6 +149,13 @@ export const handoffs = {
       type: "dsl-task-result" as const,
       version: 1,
       payload: DslTaskResultSchema.parse(payload),
+    };
+  },
+  auditResult(payload: AuditResult): HandoffEnvelope<"audit-result"> {
+    return {
+      type: "audit-result" as const,
+      version: 1,
+      payload: AuditResultSchema.parse(payload),
     };
   },
   dslAuditResult(payload: DslAuditResult): HandoffEnvelope<"dsl-audit-result"> {

--- a/src/generated/dsl-base/tasks.ts
+++ b/src/generated/dsl-base/tasks.ts
@@ -168,12 +168,14 @@ export const auditSemanticDesign: TaskContract = {
   "Verify handoff schemas carry sufficient fields for task completion_criteria",
   "Check workflow gates are placed effectively",
   "Detect guardrails declared but absent from execution path",
-  "Check semantic validations are distributed across phases"
+  "Check semantic validations are distributed across phases",
+  "Detect custom x- properties that replicate standard DSL control-flow features (gate, decision, entry_conditions)"
 ],
   completion_criteria: [
   "All agents reviewed for scope and overlap",
   "Workflow gate placement analyzed",
   "Guardrail enforcement path verified",
+  "Custom x- property misuse flagged",
   "Findings classified with severity and category"
 ],
   optional: false,
@@ -208,6 +210,36 @@ export const auditGeneratedPrompts: TaskContract = {
   optional: false,
 };
 
+export const auditExtensionConsumption: TaskContract = {
+  id: "audit-extension-consumption",
+  description: "Audit declared x-* extensions for consumption gaps across render and runtime paths",
+  target_agent: "dsl-auditor",
+  allowed_from_agents: [
+  "dsl-auditor"
+],
+  workflow: "dsl-audit",
+  invocation_handoff: "dsl-task-request",
+  result_handoff: "dsl-audit-result",
+  input_artifacts: [
+  "dsl-source",
+  "dsl-generated-output"
+],
+  responsibilities: [
+  "Cross-check extensions declarations against entity x-* usage",
+  "Identify x-* properties populated in DSL but not consumed by any render template",
+  "Detect semantic overlap between x-* extensions and standard DSL features",
+  "Report runtime codegen reachability for each extension",
+  "Distinguish intentional metadata-only extensions from consumption gaps"
+],
+  completion_criteria: [
+  "All declared extensions checked for template and runtime consumption",
+  "Unused extensions flagged with suggested action (remove, migrate to standard, or add template support)",
+  "Runtime-unreachable extensions documented with explanation",
+  "Findings classified with severity and category"
+],
+  optional: false,
+};
+
 export const taskRegistry: Record<string, TaskContract> = {
   "update-dsl-definitions": updateDslDefinitions,
   "update-dsl-binding": updateDslBinding,
@@ -216,4 +248,5 @@ export const taskRegistry: Record<string, TaskContract> = {
   "audit-dsl-completeness": auditDslCompleteness,
   "audit-semantic-design": auditSemanticDesign,
   "audit-generated-prompts": auditGeneratedPrompts,
+  "audit-extension-consumption": auditExtensionConsumption,
 };

--- a/src/generated/dsl-base/workflows.ts
+++ b/src/generated/dsl-base/workflows.ts
@@ -11,12 +11,14 @@ export interface DelegateStep {
   readonly description: string;
   readonly optional: boolean;
   readonly max_retries: number;
+  readonly depends_on?: readonly string[];
 }
 
 export interface GateStep {
   readonly type: "gate";
   readonly gate_kind: string;
   readonly description: string;
+  readonly depends_on?: readonly string[];
 }
 
 export type WorkflowStep = DelegateStep | GateStep;
@@ -89,7 +91,7 @@ export const dslUpdate: WorkflowContract = {
 
 export const dslAudit: WorkflowContract = {
   id: "dsl-audit",
-  description: "DSL Audit — audit completeness of DSL definitions against generated prompts, detect gaps, and present improvement recommendations. Executed by DSL Auditor. Supports three audit types: render (semantic diff), dsl (design coherence), and prompt (prompt fidelity).",
+  description: "DSL Audit — audit completeness of DSL definitions against generated prompts, detect gaps, and present improvement recommendations. Executed by DSL Auditor. Supports four audit types: render (semantic diff), dsl (design coherence), prompt (prompt fidelity), and extensions (x-* consumption gap detection).",
   trigger: "Execute when DSL completeness audit is needed. Typically run as a quality check after DSL updates.",
   entry_conditions: [
   "DSL definition rendering is complete"
@@ -115,6 +117,9 @@ export const dslAudit: WorkflowContract = {
       description: "DSL Auditor reviews DSL design for semantic coherence — role overlap, scope breadth, gate placement, guardrail enforcement paths.",
       optional: false,
       max_retries: 0,
+      depends_on: [
+  "gate:dsl-audit-result"
+],
     },
     {
       type: "delegate",
@@ -123,11 +128,30 @@ export const dslAudit: WorkflowContract = {
       description: "DSL Auditor compares generated prompts against DSL intent — detects missing requirements, hallucinated permissions, ambiguous instructions.",
       optional: false,
       max_retries: 0,
+      depends_on: [
+  "gate:dsl-audit-result"
+],
+    },
+    {
+      type: "delegate",
+      task: "audit-extension-consumption",
+      from_agent: "dsl-auditor",
+      description: "DSL Auditor checks x-* extension properties for consumption gaps — declared but unused, populated but not rendered, semantic overlap with standard DSL features.",
+      optional: false,
+      max_retries: 0,
+      depends_on: [
+  "gate:dsl-audit-result"
+],
     },
     {
       type: "gate",
-      gate_kind: "dsl-audit-result",
+      gate_kind: "dsl-audit-terminal",
       description: "Terminal gate — block if audit-generated-prompts detected hallucinated permissions (enforces dsl-no-hallucinated-permissions guardrail at workflow level via stop_and_report escalation).",
+      depends_on: [
+  "audit-semantic-design",
+  "audit-generated-prompts",
+  "audit-extension-consumption"
+],
     },
   ],
 };

--- a/src/linter/index.ts
+++ b/src/linter/index.ts
@@ -13,3 +13,4 @@ export { artifactRequiredValidationWiringRule } from "./rules/artifact-required-
 export { taskOutputValidationCompletenessRule } from "./rules/task-output-validation-completeness.js";
 export { entityGuardrailUndefinedRule, entityNoGuardrailsRule, guardrailOrphanedRule } from "./rules/entity-guardrail-binding.js";
 export { validationExecutorNoContextRule } from "./rules/validation-executor-no-context.js";
+export { extensionDeclaredButUnusedRule, extensionScopeMismatchRule, extensionUndeclaredUsageRule } from "./rules/extension-consumption.js";

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -17,6 +17,11 @@ import {
   guardrailOrphanedRule,
 } from "./rules/entity-guardrail-binding.js";
 import { validationExecutorNoContextRule } from "./rules/validation-executor-no-context.js";
+import {
+  extensionDeclaredButUnusedRule,
+  extensionScopeMismatchRule,
+  extensionUndeclaredUsageRule,
+} from "./rules/extension-consumption.js";
 
 const builtinRules: LintRule[] = [
   validationCoverageRule,
@@ -34,6 +39,9 @@ const builtinRules: LintRule[] = [
   entityNoGuardrailsRule,
   guardrailOrphanedRule,
   validationExecutorNoContextRule,
+  extensionDeclaredButUnusedRule,
+  extensionScopeMismatchRule,
+  extensionUndeclaredUsageRule,
 ];
 
 export function lint(

--- a/src/linter/rules/extension-consumption.ts
+++ b/src/linter/rules/extension-consumption.ts
@@ -1,0 +1,220 @@
+import type { Dsl, ScopeNodeType } from "../../schema/index.js";
+import type { LintRule, LintDiagnostic } from "../types.js";
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+interface XUsage {
+  path: string;
+  nodeType: ScopeNodeType;
+}
+
+/**
+ * Walk the DSL tree and collect every `x-*` key found on entities,
+ * grouped by extension key name.
+ */
+function collectXUsages(dsl: Dsl): Map<string, XUsage[]> {
+  const usages = new Map<string, XUsage[]>();
+
+  function record(key: string, path: string, nodeType: ScopeNodeType): void {
+    let list = usages.get(key);
+    if (!list) {
+      list = [];
+      usages.set(key, list);
+    }
+    list.push({ path, nodeType });
+  }
+
+  function walkObj(
+    obj: Record<string, unknown>,
+    path: string,
+    nodeType: ScopeNodeType,
+  ): void {
+    for (const key of Object.keys(obj)) {
+      if (key.startsWith("x-") && key !== "x-extensions" && key !== "x-extensions-strict") {
+        record(key, path ? `${path}.${key}` : key, nodeType);
+      }
+    }
+  }
+
+  walkObj(dsl as unknown as Record<string, unknown>, "", "root");
+
+  if (isRecord(dsl.system)) {
+    walkObj(dsl.system as unknown as Record<string, unknown>, "system", "system");
+  }
+
+  for (const [id, agent] of Object.entries(dsl.agents)) {
+    const agentObj = agent as unknown as Record<string, unknown>;
+    walkObj(agentObj, `agents.${id}`, "agent");
+    if (Array.isArray(agentObj["rules"])) {
+      for (let i = 0; i < agentObj["rules"].length; i++) {
+        const r = agentObj["rules"][i];
+        if (isRecord(r)) walkObj(r, `agents.${id}.rules[${i}]`, "rule");
+      }
+    }
+    if (Array.isArray(agentObj["escalation_criteria"])) {
+      for (let i = 0; i < agentObj["escalation_criteria"].length; i++) {
+        const e = agentObj["escalation_criteria"][i];
+        if (isRecord(e)) walkObj(e, `agents.${id}.escalation_criteria[${i}]`, "escalation_criterion");
+      }
+    }
+    if (Array.isArray(agentObj["prerequisites"])) {
+      for (let i = 0; i < agentObj["prerequisites"].length; i++) {
+        const p = agentObj["prerequisites"][i];
+        if (isRecord(p)) walkObj(p, `agents.${id}.prerequisites[${i}]`, "prerequisite");
+      }
+    }
+  }
+
+  for (const [id, task] of Object.entries(dsl.tasks)) {
+    const taskObj = task as unknown as Record<string, unknown>;
+    walkObj(taskObj, `tasks.${id}`, "task");
+    if (Array.isArray(taskObj["execution_steps"])) {
+      for (let i = 0; i < taskObj["execution_steps"].length; i++) {
+        const s = taskObj["execution_steps"][i];
+        if (isRecord(s)) walkObj(s, `tasks.${id}.execution_steps[${i}]`, "execution_step");
+      }
+    }
+  }
+
+  for (const [id, art] of Object.entries(dsl.artifacts)) {
+    walkObj(art as unknown as Record<string, unknown>, `artifacts.${id}`, "artifact");
+  }
+
+  for (const [id, tool] of Object.entries(dsl.tools)) {
+    const toolObj = tool as unknown as Record<string, unknown>;
+    walkObj(toolObj, `tools.${id}`, "tool");
+    if (Array.isArray(toolObj["commands"])) {
+      for (let i = 0; i < toolObj["commands"].length; i++) {
+        const c = toolObj["commands"][i];
+        if (isRecord(c)) walkObj(c, `tools.${id}.commands[${i}]`, "tool_command");
+      }
+    }
+  }
+
+  for (const [id, val] of Object.entries(dsl.validations)) {
+    walkObj(val as unknown as Record<string, unknown>, `validations.${id}`, "validation");
+  }
+
+  for (const [id, ht] of Object.entries(dsl.handoff_types)) {
+    walkObj(ht as unknown as Record<string, unknown>, `handoff_types.${id}`, "handoff_type");
+  }
+
+  for (const [id, wf] of Object.entries(dsl.workflow)) {
+    const wfObj = wf as unknown as Record<string, unknown>;
+    walkObj(wfObj, `workflow.${id}`, "workflow");
+    if (Array.isArray(wfObj["steps"])) {
+      for (let i = 0; i < wfObj["steps"].length; i++) {
+        const s = wfObj["steps"][i];
+        if (isRecord(s)) walkObj(s, `workflow.${id}.steps[${i}]`, "workflow_step");
+      }
+    }
+  }
+
+  for (const [id, pol] of Object.entries(dsl.policies)) {
+    walkObj(pol as unknown as Record<string, unknown>, `policies.${id}`, "policy");
+  }
+
+  for (const [id, gr] of Object.entries(dsl.guardrails)) {
+    walkObj(gr as unknown as Record<string, unknown>, `guardrails.${id}`, "guardrail");
+  }
+
+  for (const [id, gp] of Object.entries(dsl.guardrail_policies)) {
+    walkObj(gp as unknown as Record<string, unknown>, `guardrail_policies.${id}`, "guardrail_policy");
+  }
+
+  return usages;
+}
+
+export const extensionDeclaredButUnusedRule: LintRule = {
+  id: "extension-declared-unused",
+  description:
+    "Declared extension in `extensions` is never used on any entity",
+
+  run(dsl: Dsl): LintDiagnostic[] {
+    const diagnostics: LintDiagnostic[] = [];
+    const declaredKeys = Object.keys(dsl.extensions);
+    if (declaredKeys.length === 0) return diagnostics;
+
+    const usages = collectXUsages(dsl);
+
+    for (const key of declaredKeys) {
+      if (!usages.has(key)) {
+        diagnostics.push({
+          ruleId: "extension-declared-unused",
+          severity: "warning",
+          path: `extensions.${key}`,
+          message: `Extension "${key}" is declared but never used on any entity`,
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};
+
+export const extensionScopeMismatchRule: LintRule = {
+  id: "extension-scope-mismatch",
+  description:
+    "Extension used on a node type outside its declared scope",
+
+  run(dsl: Dsl): LintDiagnostic[] {
+    const diagnostics: LintDiagnostic[] = [];
+    const extensions = dsl.extensions;
+    if (Object.keys(extensions).length === 0) return diagnostics;
+
+    const usages = collectXUsages(dsl);
+
+    for (const [key, decl] of Object.entries(extensions)) {
+      const scope = decl.scope;
+      if (!scope || scope.length === 0) continue;
+      const scopeSet = new Set(scope);
+
+      const keyUsages = usages.get(key);
+      if (!keyUsages) continue;
+
+      for (const usage of keyUsages) {
+        if (!scopeSet.has(usage.nodeType)) {
+          diagnostics.push({
+            ruleId: "extension-scope-mismatch",
+            severity: "warning",
+            path: usage.path,
+            message: `Extension "${key}" is used on ${usage.nodeType} but declared scope is [${scope.join(", ")}]`,
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};
+
+export const extensionUndeclaredUsageRule: LintRule = {
+  id: "extension-undeclared-usage",
+  description:
+    "Entity uses x-* property that is not declared in extensions (when extensions section exists)",
+
+  run(dsl: Dsl): LintDiagnostic[] {
+    const diagnostics: LintDiagnostic[] = [];
+    const extensions = dsl.extensions;
+    if (Object.keys(extensions).length === 0) return diagnostics;
+
+    const declaredKeys = new Set(Object.keys(extensions));
+    const usages = collectXUsages(dsl);
+
+    for (const [key, keyUsages] of usages) {
+      if (declaredKeys.has(key)) continue;
+      for (const usage of keyUsages) {
+        diagnostics.push({
+          ruleId: "extension-undeclared-usage",
+          severity: "info",
+          path: usage.path,
+          message: `Extension "${key}" is used but not declared in extensions — consider adding a declaration`,
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/src/linter/rules/task-agent-binding.ts
+++ b/src/linter/rules/task-agent-binding.ts
@@ -19,6 +19,7 @@ export const taskAgentBindingRule: LintRule = {
 
     for (const [taskId, task] of Object.entries(dsl.tasks)) {
       for (const fromAgentId of task.allowed_from_agents) {
+        if (fromAgentId === task.target_agent) continue;
         const fromAgent = dsl.agents[fromAgentId];
         if (fromAgent && !fromAgent.can_invoke_agents.includes(task.target_agent)) {
           diagnostics.push({

--- a/src/loader/loader.ts
+++ b/src/loader/loader.ts
@@ -43,14 +43,19 @@ function deepClone(value: unknown): unknown {
 }
 
 /**
- * Resolve a JSON Pointer (RFC 6901) against the root document.
+ * Resolve a JSON Pointer (RFC 6901) against a root object.
  *
- * Expects `pointer` to start with `#/`. Segment escapes (`~0` → `~`, `~1` → `/`)
- * are handled per the specification.
+ * Expects `pointer` to start with `#/`. Segment escapes (`~0` → `~`,
+ * `~1` → `/`) are handled per the specification.
  *
- * @throws {DslLoadError} if a segment is not found or traverses a non-object.
+ * @returns `{ found: true, value }` if the pointer resolves, or
+ *          `{ found: false }` if any segment is missing.
+ * @throws {DslLoadError} if traversal hits a non-object.
  */
-function resolveJsonPointer(root: AnyRecord, pointer: string): unknown {
+function tryResolveJsonPointer(
+  root: AnyRecord,
+  pointer: string,
+): { found: true; value: unknown } | { found: false } {
   const path = pointer.slice(2);
   const segments = path.split("/").map((s) =>
     s.replace(/~1/g, "/").replace(/~0/g, "~"),
@@ -65,12 +70,24 @@ function resolveJsonPointer(root: AnyRecord, pointer: string): unknown {
     }
     current = (current as AnyRecord)[segment];
     if (current === undefined) {
-      throw new DslLoadError(
-        `Cannot resolve JSON Pointer "${pointer}": path segment "${segment}" not found`,
-      );
+      return { found: false };
     }
   }
-  return current;
+  return { found: true, value: current };
+}
+
+/**
+ * Strict variant — throws when the pointer target is missing.
+ * Used in Phase 2 (linking) where all sections are available.
+ */
+function resolveJsonPointer(root: AnyRecord, pointer: string): unknown {
+  const result = tryResolveJsonPointer(root, pointer);
+  if (!result.found) {
+    throw new DslLoadError(
+      `Cannot resolve JSON Pointer "${pointer}": target not found`,
+    );
+  }
+  return result.value;
 }
 
 function hasRefs(value: AnyRecord): value is AnyRecord & { $refs: string[] } {
@@ -125,11 +142,18 @@ function deepMergeRefs(
   return result;
 }
 
+// ===================================================================
+// Phase 1 — Assembly
+//
+// Loads external file $ref/$refs and resolves file-internal #/ pointers
+// against each file's own root.  Cross-section #/ pointers that can't
+// resolve within the file are preserved for Phase 2.
+// ===================================================================
+
 async function loadRefsSource(
   refPath: string,
   baseDir: string,
   resolving: Set<string>,
-  rootDoc: AnyRecord,
 ): Promise<AnyRecord> {
   const target = resolve(baseDir, refPath);
   const s = await fsStat(target).catch(() => null);
@@ -139,7 +163,7 @@ async function loadRefsSource(
       throw new DslLoadError(`Circular $refs detected: ${target}`, target);
     }
     resolving.add(target);
-    const result = await loadDirectoryAsMap(target, resolving, rootDoc);
+    const result = await loadDirectoryAsMap(target, resolving);
     resolving.delete(target);
     return result;
   }
@@ -161,11 +185,11 @@ async function loadRefsSource(
     );
   }
 
-  const resolved = (await resolveRefsDeep(
+  const resolved = (await assembleRefs(
     content,
     dirname(target),
     resolving,
-    rootDoc,
+    content as AnyRecord,
   )) as AnyRecord;
   resolving.delete(target);
   return resolved;
@@ -174,7 +198,6 @@ async function loadRefsSource(
 async function loadDirectoryAsMap(
   dirPath: string,
   resolving: Set<string>,
-  rootDoc: AnyRecord,
 ): Promise<AnyRecord> {
   let entries: string[];
   try {
@@ -210,11 +233,11 @@ async function loadDirectoryAsMap(
       );
     }
 
-    const resolved = (await resolveRefsDeep(
+    const resolved = (await assembleRefs(
       content,
       dirPath,
       resolving,
-      rootDoc,
+      content as AnyRecord,
     )) as AnyRecord;
 
     merged = deepMergeRefs(merged, resolved, filePath);
@@ -227,7 +250,6 @@ async function processRefs(
   obj: AnyRecord,
   baseDir: string,
   resolving: Set<string>,
-  rootDoc: AnyRecord,
 ): Promise<AnyRecord> {
   const refPaths = obj["$refs"] as string[];
   const inline: AnyRecord = {};
@@ -240,7 +262,7 @@ async function processRefs(
   let merged: AnyRecord = {};
 
   for (const refPath of refPaths) {
-    const loaded = await loadRefsSource(refPath, baseDir, resolving, rootDoc);
+    const loaded = await loadRefsSource(refPath, baseDir, resolving);
     merged = deepMergeRefs(merged, loaded, refPath);
   }
 
@@ -249,42 +271,56 @@ async function processRefs(
   return merged;
 }
 
-async function resolveRefsDeep(
+/**
+ * Phase 1 — Assembly.
+ *
+ * Recursively resolves external file `$ref` / `$refs` and builds the
+ * assembled document tree.
+ *
+ * `#/` pointers are resolved against `fileRoot` (the current file's
+ * own root).  If the target doesn't exist within the file, the `$ref`
+ * is preserved as-is — it likely references another section of the DSL
+ * and will be resolved in Phase 2 (linking).
+ */
+async function assembleRefs(
   data: unknown,
   baseDir: string,
   resolving: Set<string>,
-  rootDoc: AnyRecord,
+  fileRoot: AnyRecord,
 ): Promise<unknown> {
   if (typeof data !== "object" || data === null) return data;
 
   if (Array.isArray(data)) {
     return Promise.all(
-      data.map((item) => resolveRefsDeep(item, baseDir, resolving, rootDoc)),
+      data.map((item) => assembleRefs(item, baseDir, resolving, fileRoot)),
     );
   }
 
-  // $ref: string — replace this object entirely
   if (isRef(data)) {
     const refValue = data.$ref;
 
-    // JSON Pointer reference (#/...)
+    // In-document pointer — resolve against current file root.
+    // Preserve if not found (cross-section ref for Phase 2).
     if (refValue.startsWith("#/")) {
       if (resolving.has(refValue)) {
         throw new DslLoadError(`Circular $ref detected: ${refValue}`);
       }
+      const result = tryResolveJsonPointer(fileRoot, refValue);
+      if (!result.found) {
+        return data;
+      }
       resolving.add(refValue);
-      const target = resolveJsonPointer(rootDoc, refValue);
-      const resolved = await resolveRefsDeep(
-        deepClone(target),
+      const resolved = await assembleRefs(
+        deepClone(result.value),
         baseDir,
         resolving,
-        rootDoc,
+        fileRoot,
       );
       resolving.delete(refValue);
       return resolved;
     }
 
-    // File reference with optional JSON Pointer fragment (file.yaml#/path)
+    // External file reference (with optional #/fragment)
     const hashIdx = refValue.indexOf("#");
     const filePart = hashIdx >= 0 ? refValue.slice(0, hashIdx) : refValue;
     const fragment = hashIdx >= 0 ? refValue.slice(hashIdx) : null;
@@ -306,7 +342,7 @@ async function resolveRefsDeep(
         );
       }
       resolving.add(refTarget);
-      const result = await loadDirectoryAsMap(refTarget, resolving, rootDoc);
+      const result = await loadDirectoryAsMap(refTarget, resolving);
       resolving.delete(refTarget);
       return result;
     }
@@ -323,12 +359,13 @@ async function resolveRefsDeep(
     }
     resolving.add(refTarget);
     const content = await readYaml(refTarget);
-    const fileRoot = fragment ? content as AnyRecord : rootDoc;
-    let fileData = await resolveRefsDeep(
+    // Each file gets its own root scope for #/ pointer resolution.
+    const newFileRoot = isRecord(content) ? (content as AnyRecord) : fileRoot;
+    let fileData = await assembleRefs(
       content,
       dirname(refTarget),
       resolving,
-      fileRoot,
+      newFileRoot,
     );
     resolving.delete(refTarget);
 
@@ -347,18 +384,61 @@ async function resolveRefsDeep(
 
   let obj = data as AnyRecord;
 
-  // $refs: string[] — import files and deep-merge into this map
   if (hasRefs(obj)) {
-    obj = await processRefs(obj, baseDir, resolving, rootDoc);
+    obj = await processRefs(obj, baseDir, resolving);
   }
 
-  // Recurse into values
   const result: AnyRecord = {};
   for (const [key, value] of Object.entries(obj)) {
-    result[key] = await resolveRefsDeep(value, baseDir, resolving, rootDoc);
+    result[key] = await assembleRefs(value, baseDir, resolving, fileRoot);
   }
   return result;
 }
+
+// ===================================================================
+// Phase 2 — Linking
+//
+// Walks the assembled document and resolves all remaining #/ pointers
+// against the fully-expanded root.  No file I/O; pure pointer resolution.
+// Unresolvable pointers are errors — the document is fully assembled.
+// ===================================================================
+
+/**
+ * Phase 2 — Linking.
+ *
+ * Resolves every remaining `#/` pointer against the assembled document
+ * root.  Any pointer that can't be resolved is a genuine error — by
+ * this point the entire document has been assembled from all files.
+ */
+function linkDocPointers(data: unknown, rootDoc: AnyRecord): unknown {
+  if (typeof data !== "object" || data === null) return data;
+
+  if (Array.isArray(data)) {
+    return data.map((item) => linkDocPointers(item, rootDoc));
+  }
+
+  if (isRef(data)) {
+    const refValue = data.$ref;
+    if (refValue.startsWith("#/")) {
+      const target = resolveJsonPointer(rootDoc, refValue);
+      return linkDocPointers(deepClone(target), rootDoc);
+    }
+    // Non-#/ $ref should not remain after Phase 1 — preserve as-is
+    // (defensive; assembleRefs should have resolved all file refs).
+    return data;
+  }
+
+  const obj = data as AnyRecord;
+  const result: AnyRecord = {};
+  for (const [key, value] of Object.entries(obj)) {
+    result[key] = linkDocPointers(value, rootDoc);
+  }
+  return result;
+}
+
+// ===================================================================
+// Public API
+// ===================================================================
 
 function checkVersion(data: Record<string, unknown>, filePath: string): void {
   const version = data["version"];
@@ -391,13 +471,22 @@ export async function loadDsl(entryPath: string): Promise<LoadResult> {
   checkVersion(data, absPath);
 
   const baseDir = dirname(absPath);
-  const resolving = new Set<string>([absPath]);
-  const resolved = (await resolveRefsDeep(
+
+  // Phase 1 — Assembly: load all external files and resolve
+  // file-internal #/ pointers.  Cross-section #/ pointers are preserved.
+  const assembled = (await assembleRefs(
     data,
     baseDir,
-    resolving,
+    new Set<string>([absPath]),
     data,
   )) as Record<string, unknown>;
+
+  // Phase 2 — Linking: resolve remaining #/ pointers against the
+  // fully-assembled root.  Failure here is a genuine broken reference.
+  const resolved = linkDocPointers(
+    assembled,
+    assembled,
+  ) as Record<string, unknown>;
 
   return { data: resolved, filePath: absPath };
 }

--- a/src/schema/artifact.ts
+++ b/src/schema/artifact.ts
@@ -11,6 +11,7 @@ export const ArtifactSchema = z
     states: z.array(z.string()),
     required_validations: z.array(z.string()).default([]),
     visibility: z.string().optional(),
+    classification: z.string().optional(),
     guardrails: z.array(z.string()).optional(),
   })
   .passthrough();

--- a/src/schema/task.ts
+++ b/src/schema/task.ts
@@ -22,7 +22,7 @@ export const TaskSchema = z
   .object({
     description: z.string(),
     target_agent: z.string(),
-    allowed_from_agents: z.array(z.string()),
+    allowed_from_agents: z.array(z.string()).default([]),
     workflow: z.string(),
     input_artifacts: z.array(z.string()),
     invocation_handoff: z.string(),

--- a/src/schema/validation.ts
+++ b/src/schema/validation.ts
@@ -8,6 +8,7 @@ export const ValidationSchema = z
     executor: z.string(),
     blocking: z.boolean(),
     produces_evidence: z.string().optional(),
+    description: z.string().optional(),
   })
   .passthrough();
 export type Validation = z.infer<typeof ValidationSchema>;

--- a/test/auditor/workflow-gate.test.ts
+++ b/test/auditor/workflow-gate.test.ts
@@ -65,6 +65,7 @@ describe("workflow gate — LLM evaluation (dsl-audit)", () => {
         "audit-dsl-completeness": makeAuditResult({ miss_count: 0, critical_gaps: [] }),
         "audit-semantic-design": makeAuditResult({ audit_type: "semantic" }),
         "audit-generated-prompts": makeAuditResult({ audit_type: "prompt" }),
+        "audit-extension-consumption": makeAuditResult({ audit_type: "extensions" }),
       },
       gateApproval: true,
     });
@@ -115,6 +116,7 @@ describe("workflow gate — LLM evaluation (dsl-audit)", () => {
         "audit-dsl-completeness": makeAuditResult(),
         "audit-semantic-design": makeAuditResult({ audit_type: "semantic" }),
         "audit-generated-prompts": makeAuditResult({ audit_type: "prompt" }),
+        "audit-extension-consumption": makeAuditResult({ audit_type: "extensions" }),
       },
       gateApproval: false, // LLM would reject
     });

--- a/test/linter/extension-consumption.test.ts
+++ b/test/linter/extension-consumption.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect } from "vitest";
+import { DslSchema, type Dsl } from "../../src/schema/index.js";
+import {
+  extensionDeclaredButUnusedRule,
+  extensionScopeMismatchRule,
+  extensionUndeclaredUsageRule,
+} from "../../src/linter/rules/extension-consumption.js";
+
+function makeDsl(partial: Partial<Record<string, unknown>>): Dsl {
+  return DslSchema.parse({
+    version: 1,
+    system: { id: "s", name: "S", default_workflow_order: ["implement"] },
+    ...partial,
+  });
+}
+
+describe("extensionDeclaredButUnusedRule", () => {
+  it("warns when a declared extension is never used", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-meta": { type: "string", required: false },
+      },
+      agents: { a1: { role_name: "R", purpose: "P" } },
+    });
+    const diags = extensionDeclaredButUnusedRule.run(dsl);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].severity).toBe("warning");
+    expect(diags[0].path).toBe("extensions.x-meta");
+    expect(diags[0].message).toContain("never used");
+  });
+
+  it("no warning when declared extension is used on an agent", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-notes": { type: "string", required: false },
+      },
+      agents: {
+        a1: { role_name: "R", purpose: "P", "x-notes": "some note" },
+      },
+    });
+    const diags = extensionDeclaredButUnusedRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("no warning when declared extension is used on a task", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-task-info": { type: "string", required: false },
+      },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1",
+          allowed_from_agents: ["a1"], workflow: "implement",
+          input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          "x-task-info": "info",
+        },
+      },
+    });
+    const diags = extensionDeclaredButUnusedRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("no warning when declared extension is used on system", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-sys": { type: "object", required: false },
+      },
+      system: {
+        id: "s", name: "S", default_workflow_order: ["implement"],
+        "x-sys": { tier: "prod" },
+      },
+    });
+    const diags = extensionDeclaredButUnusedRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("warns for multiple declared-but-unused extensions", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-a": { type: "string", required: false },
+        "x-b": { type: "string", required: false },
+        "x-c": { type: "string", required: false },
+      },
+      agents: {
+        a1: { role_name: "R", purpose: "P", "x-a": "used" },
+      },
+    });
+    const diags = extensionDeclaredButUnusedRule.run(dsl);
+    expect(diags).toHaveLength(2);
+    const paths = diags.map((d) => d.path).sort();
+    expect(paths).toEqual(["extensions.x-b", "extensions.x-c"]);
+  });
+
+  it("returns empty when no extensions declared", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", "x-custom": "val" } },
+    });
+    const diags = extensionDeclaredButUnusedRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("detects usage on artifacts", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-owner-team": { type: "string", required: false },
+      },
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        art1: {
+          type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"],
+          consumers: ["a1"], states: ["draft"],
+          "x-owner-team": "platform",
+        },
+      },
+    });
+    const diags = extensionDeclaredButUnusedRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("detects usage on tools", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-rate-limit": { type: "string", required: false },
+      },
+      tools: {
+        t1: { kind: "cli", invokable_by: [], "x-rate-limit": "low" },
+      },
+    });
+    const diags = extensionDeclaredButUnusedRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("detects usage on workflows", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-wf-meta": { type: "object", required: false },
+      },
+      workflow: {
+        implement: {
+          steps: [], "x-wf-meta": { important: true },
+        },
+      },
+    });
+    const diags = extensionDeclaredButUnusedRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("detects usage on policies", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-policy-meta": { type: "object", required: false },
+      },
+      policies: {
+        p1: {
+          when: { artifact_type: "code" },
+          "x-policy-meta": { severity: "high" },
+        },
+      },
+    });
+    const diags = extensionDeclaredButUnusedRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("detects usage on validations", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-val-meta": { type: "object", required: false },
+      },
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      validations: {
+        v1: {
+          target_artifact: "art1", kind: "semantic",
+          executor_type: "agent", executor: "a1", blocking: true,
+          "x-val-meta": { depth: "full" },
+        },
+      },
+    });
+    const diags = extensionDeclaredButUnusedRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("detects usage on handoff_types", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-ht-meta": { type: "object", required: false },
+      },
+      handoff_types: {
+        h1: { version: 1, schema: {}, "x-ht-meta": { stable: true } },
+      },
+    });
+    const diags = extensionDeclaredButUnusedRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("detects usage on guardrails", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-gr-meta": { type: "object", required: false },
+      },
+      guardrails: {
+        g1: { description: "G", scope: {}, tags: [], "x-gr-meta": {} },
+      },
+    });
+    const diags = extensionDeclaredButUnusedRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+});
+
+describe("extensionScopeMismatchRule", () => {
+  it("warns when extension used outside declared scope", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-agent-only": { type: "string", required: false, scope: ["agent"] },
+      },
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1",
+          allowed_from_agents: ["a1"], workflow: "implement",
+          input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          "x-agent-only": "misplaced",
+        },
+      },
+    });
+    const diags = extensionScopeMismatchRule.run(dsl);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].severity).toBe("warning");
+    expect(diags[0].path).toBe("tasks.t1.x-agent-only");
+    expect(diags[0].message).toContain("task");
+    expect(diags[0].message).toContain("agent");
+  });
+
+  it("no warning when extension used within declared scope", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-agent-only": { type: "string", required: false, scope: ["agent"] },
+      },
+      agents: {
+        a1: { role_name: "R", purpose: "P", "x-agent-only": "correct" },
+      },
+    });
+    const diags = extensionScopeMismatchRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("no warning when extension has no declared scope", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-anywhere": { type: "string", required: false },
+      },
+      agents: {
+        a1: { role_name: "R", purpose: "P", "x-anywhere": "ok" },
+      },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1",
+          allowed_from_agents: ["a1"], workflow: "implement",
+          input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          "x-anywhere": "ok",
+        },
+      },
+    });
+    const diags = extensionScopeMismatchRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("no warning when extension has empty scope array", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-flex": { type: "string", required: false, scope: [] },
+      },
+      agents: {
+        a1: { role_name: "R", purpose: "P", "x-flex": "ok" },
+      },
+    });
+    const diags = extensionScopeMismatchRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("detects multiple scope mismatches", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-tool-only": { type: "string", required: false, scope: ["tool"] },
+      },
+      agents: {
+        a1: { role_name: "R", purpose: "P", "x-tool-only": "bad" },
+      },
+      tasks: {
+        t1: {
+          description: "d", target_agent: "a1",
+          allowed_from_agents: ["a1"], workflow: "implement",
+          input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          "x-tool-only": "bad",
+        },
+      },
+    });
+    const diags = extensionScopeMismatchRule.run(dsl);
+    expect(diags).toHaveLength(2);
+  });
+
+  it("returns empty when no extensions declared", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+    });
+    const diags = extensionScopeMismatchRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+});
+
+describe("extensionUndeclaredUsageRule", () => {
+  it("reports info when x-* used but not declared (with extensions section present)", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-declared": { type: "string", required: false },
+      },
+      agents: {
+        a1: { role_name: "R", purpose: "P", "x-declared": "ok", "x-undeclared": "hmm" },
+      },
+    });
+    const diags = extensionUndeclaredUsageRule.run(dsl);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].severity).toBe("info");
+    expect(diags[0].path).toBe("agents.a1.x-undeclared");
+    expect(diags[0].message).toContain("not declared");
+  });
+
+  it("returns empty when all x-* usages are declared", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-meta": { type: "string", required: false },
+      },
+      agents: {
+        a1: { role_name: "R", purpose: "P", "x-meta": "ok" },
+      },
+    });
+    const diags = extensionUndeclaredUsageRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("returns empty when extensions section is empty (no declarations to compare against)", () => {
+    const dsl = makeDsl({
+      agents: {
+        a1: { role_name: "R", purpose: "P", "x-custom": "val" },
+      },
+    });
+    const diags = extensionUndeclaredUsageRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+
+  it("reports multiple undeclared usages across entities", () => {
+    const dsl = makeDsl({
+      extensions: {
+        "x-known": { type: "string", required: false },
+      },
+      agents: {
+        a1: { role_name: "R", purpose: "P", "x-unknown-a": "a" },
+        a2: { role_name: "R2", purpose: "P2", "x-unknown-b": "b" },
+      },
+    });
+    const diags = extensionUndeclaredUsageRule.run(dsl);
+    expect(diags).toHaveLength(2);
+    const paths = diags.map((d) => d.path).sort();
+    expect(paths).toEqual(["agents.a1.x-unknown-a", "agents.a2.x-unknown-b"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add LLM-powered `audit` command with four audit types: render (19-dimension completeness), dsl (semantic design), prompt (fidelity), extensions (x-* consumption gaps)
- Fix critical `$ref` resolution bug: redesign loader into two-phase architecture (assembleRefs + linkDocPointers) to correctly handle cross-document JSON Pointer references
- Fix `task-agent-binding` lint rule to skip self-execution case (`fromAgent == targetAgent`), make `allowed_from_agents` optional
- Standardize DSL: migrate `x-description` → `description` on validations, `x-artifact-class` → `classification` on artifacts
- Improve `dsl-audit` workflow with per-task gates for immediate critical blocking
- Extend `dsl-audit-result` handoff schema (v4) with `completion_criteria_coverage`
- Add `anti_patterns` to `dsl-auditor` agent definition

## Test plan
- [x] All 737 tests pass
- [x] `agent-contracts validate dsl_base/agent-contracts.yaml` passes
- [x] `agent-contracts lint dsl_base/agent-contracts.yaml` reports no errors
- [x] LLM audit `audit dsl` returns 0 critical findings
- [x] TypeScript typecheck clean

Made with [Cursor](https://cursor.com)