### PR TITLE
fix: make resolveAllOf recursive for nested allOf and property schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/schema/json-schema-utils.ts
+++ b/src/schema/json-schema-utils.ts
@@ -1,15 +1,18 @@
 type AnyRecord = Record<string, unknown>;
 
 /**
- * Shallow-merge an array of JSON Schema subschemas from an `allOf`.
- * Merges `properties`, `required`, and top-level scalars (`type`, `description`, etc.).
- * Handles one level of nesting only (sufficient for handoff schema composition).
+ * Recursively merge `allOf` arrays in a JSON Schema.
+ *
+ * Each `allOf` sub-schema is itself resolved first (handling nested
+ * `allOf`), then `properties`, `required`, and top-level scalars are
+ * merged. After merging, nested property schemas that contain their
+ * own `allOf` are also resolved so the output is fully flattened.
  */
 export function resolveAllOf(
   schema: AnyRecord,
 ): AnyRecord {
   const allOf = schema["allOf"];
-  if (!Array.isArray(allOf)) return schema;
+  if (!Array.isArray(allOf)) return resolveNestedProperties(schema);
 
   let mergedProperties: AnyRecord = {};
   let mergedRequired: string[] = [];
@@ -17,7 +20,7 @@ export function resolveAllOf(
 
   for (const sub of allOf) {
     if (typeof sub !== "object" || sub === null || Array.isArray(sub)) continue;
-    const subSchema = sub as AnyRecord;
+    const subSchema = resolveAllOf(sub as AnyRecord);
 
     if (
       subSchema["properties"] &&
@@ -56,10 +59,29 @@ export function resolveAllOf(
 
   const result: AnyRecord = { ...mergedTop };
   if (Object.keys(mergedProperties).length > 0) {
-    result["properties"] = mergedProperties;
+    result["properties"] = resolvePropertySchemas(mergedProperties);
   }
   if (mergedRequired.length > 0) {
     result["required"] = [...new Set(mergedRequired)];
+  }
+  return result;
+}
+
+function resolveNestedProperties(schema: AnyRecord): AnyRecord {
+  const props = schema["properties"];
+  if (!props || typeof props !== "object") return schema;
+  return { ...schema, properties: resolvePropertySchemas(props as AnyRecord) };
+}
+
+function resolvePropertySchemas(properties: AnyRecord): AnyRecord {
+  const result: AnyRecord = {};
+  for (const [key, value] of Object.entries(properties)) {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      const propSchema = value as AnyRecord;
+      result[key] = propSchema["allOf"] ? resolveAllOf(propSchema) : propSchema;
+    } else {
+      result[key] = value;
+    }
   }
   return result;
 }


### PR DESCRIPTION
## Summary
- `resolveAllOf` only flattened the top-level `allOf` array — sub-schemas within `allOf` that themselves contained `allOf` were not resolved, and property schemas with their own `allOf` compositions were left unmerged
- This caused `extractSchemaFieldNames` and `lookupPayloadFields` to miss fields defined via nested schema composition
- Now resolves `allOf` recursively: each sub-schema is resolved before merging, and merged property schemas are also resolved if they contain `allOf`

## Test plan
- [x] All 737 existing tests pass
- [x] TypeScript compiles without errors

Made with [Cursor](https://cursor.com)