### PR TITLE
fix: resolve extends chain recursively (fixes #64)

### DIFF
--- a/src/resolver/resolve.ts
+++ b/src/resolver/resolve.ts
@@ -1,12 +1,49 @@
 import { dirname, resolve as resolvePath } from "node:path";
 import { loadDsl } from "../loader/index.js";
-import { resolveBase } from "./base-resolver.js";
+import { resolveBase, BaseResolveError } from "./base-resolver.js";
 import { mergeDsl } from "./merger.js";
 
 export interface ResolveResult {
   data: Record<string, unknown>;
   projectPath: string;
-  basePath?: string;
+  basePaths: string[];
+}
+
+interface ResolvedChain {
+  data: Record<string, unknown>;
+  basePaths: string[];
+}
+
+async function resolveExtendsChain(
+  data: Record<string, unknown>,
+  filePath: string,
+  seen: Set<string>,
+): Promise<ResolvedChain> {
+  const extendsValue = data["extends"];
+  if (typeof extendsValue !== "string") {
+    return { data, basePaths: [] };
+  }
+
+  const projectDir = dirname(filePath);
+  const baseResult = await resolveBase(extendsValue, projectDir);
+  const basePath = baseResult.filePath;
+
+  if (seen.has(basePath)) {
+    throw new BaseResolveError(
+      `Circular extends detected: ${basePath}`,
+    );
+  }
+  seen.add(basePath);
+
+  const { data: resolvedBase, basePaths: ancestorPaths } =
+    await resolveExtendsChain(baseResult.data, basePath, seen);
+
+  const merged = mergeDsl(resolvedBase, data);
+
+  return {
+    data: merged,
+    basePaths: [...ancestorPaths, basePath],
+  };
 }
 
 export async function resolve(
@@ -14,23 +51,15 @@ export async function resolve(
 ): Promise<ResolveResult> {
   const absPath = resolvePath(projectDirOrFile);
   const projectResult = await loadDsl(absPath);
-  const projectData = projectResult.data;
-
-  const extendsValue = projectData["extends"];
-  if (typeof extendsValue !== "string") {
-    return {
-      data: projectData,
-      projectPath: projectResult.filePath,
-    };
-  }
-
-  const projectDir = dirname(projectResult.filePath);
-  const baseResult = await resolveBase(extendsValue, projectDir);
-  const merged = mergeDsl(baseResult.data, projectData);
+  const { data, basePaths } = await resolveExtendsChain(
+    projectResult.data,
+    projectResult.filePath,
+    new Set(),
+  );
 
   return {
-    data: merged,
+    data,
     projectPath: projectResult.filePath,
-    basePath: baseResult.filePath,
+    basePaths,
   };
 }

--- a/test/fixtures/chained-extends/child/agent-contracts.yaml
+++ b/test/fixtures/chained-extends/child/agent-contracts.yaml
@@ -1,0 +1,6 @@
+extends: ../parent
+version: 1
+guardrails:
+  no-squash:
+    description: "Squash is forbidden"
+    scope: merge

--- a/test/fixtures/chained-extends/grandparent/agent-contracts.yaml
+++ b/test/fixtures/chained-extends/grandparent/agent-contracts.yaml
@@ -1,0 +1,5 @@
+version: 1
+guardrails:
+  no-force-push:
+    description: "Force push is forbidden"
+    scope: all

--- a/test/fixtures/chained-extends/parent/agent-contracts.yaml
+++ b/test/fixtures/chained-extends/parent/agent-contracts.yaml
@@ -1,0 +1,8 @@
+extends: ../grandparent
+version: 1
+guardrails:
+  no-force-push:
+    scope: commit
+  no-rebase:
+    description: "Rebase is forbidden"
+    scope: all

--- a/test/fixtures/circular-extends/a/agent-contracts.yaml
+++ b/test/fixtures/circular-extends/a/agent-contracts.yaml
@@ -1,0 +1,2 @@
+extends: ../b
+version: 1

--- a/test/fixtures/circular-extends/b/agent-contracts.yaml
+++ b/test/fixtures/circular-extends/b/agent-contracts.yaml
@@ -1,0 +1,2 @@
+extends: ../a
+version: 1

--- a/test/resolver/resolver.test.ts
+++ b/test/resolver/resolver.test.ts
@@ -1,6 +1,7 @@
 import { resolve as resolvePath, join } from "node:path";
 import { describe, it, expect } from "vitest";
 import { mergeDsl, MergeError } from "../../src/resolver/merger.js";
+import { BaseResolveError } from "../../src/resolver/base-resolver.js";
 import { resolve } from "../../src/resolver/resolve.js";
 
 const fixturesDir = resolvePath(import.meta.dirname, "../fixtures");
@@ -250,7 +251,7 @@ describe("resolve() pipeline", () => {
       join(fixturesDir, "minimal/agent-contracts.yaml"),
     );
     expect(result.data["version"]).toBe(1);
-    expect(result.basePath).toBeUndefined();
+    expect(result.basePaths).toEqual([]);
   });
 
   it("resolves project with local base extends", async () => {
@@ -258,7 +259,7 @@ describe("resolve() pipeline", () => {
       join(fixturesDir, "base-resolve/project/agent-contracts.yaml"),
     );
 
-    expect(result.basePath).toBeDefined();
+    expect(result.basePaths.length).toBeGreaterThan(0);
 
     const agents = result.data["agents"] as Record<string, Record<string, unknown>>;
     const impl = agents["implementer"];
@@ -276,5 +277,48 @@ describe("resolve() pipeline", () => {
 
     const arts = result.data["artifacts"] as Record<string, Record<string, unknown>>;
     expect(arts["codebase"]["description"]).toBe("TypeScript monorepo");
+  });
+
+  it("resolves 3-level chained extends with merged guardrails", async () => {
+    const childPath = join(
+      fixturesDir,
+      "chained-extends/child/agent-contracts.yaml",
+    );
+    const parentPath = join(
+      fixturesDir,
+      "chained-extends/parent/agent-contracts.yaml",
+    );
+    const grandparentPath = join(
+      fixturesDir,
+      "chained-extends/grandparent/agent-contracts.yaml",
+    );
+
+    const result = await resolve(childPath);
+
+    const guardrails = result.data["guardrails"] as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(guardrails["no-force-push"]["description"]).toBe(
+      "Force push is forbidden",
+    );
+    expect(guardrails["no-force-push"]["scope"]).toBe("commit");
+    expect(guardrails["no-rebase"]["description"]).toBe("Rebase is forbidden");
+    expect(guardrails["no-squash"]["description"]).toBe("Squash is forbidden");
+
+    expect(result.basePaths).toEqual([grandparentPath, parentPath]);
+  });
+
+  it("throws BaseResolveError on circular extends", async () => {
+    await expect(
+      resolve(
+        join(fixturesDir, "circular-extends/a/agent-contracts.yaml"),
+      ),
+    ).rejects.toThrow(BaseResolveError);
+    await expect(
+      resolve(
+        join(fixturesDir, "circular-extends/a/agent-contracts.yaml"),
+      ),
+    ).rejects.toThrow(/Circular/);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #64 — Multi-level `extends` chain does not resolve recursively.

- **Root cause**: `resolve()` loaded only the immediate parent via `resolveBase()` without recursively resolving the parent's own `extends`. Intermediate merge results were lost.
- **Fix**: Extract a recursive `resolveExtendsChain()` helper (same pattern as the working `binding-loader.ts`) that resolves the full ancestry before merging.
- **Bonus**: Added circular `extends` detection (previously missing for DSL, but already present for bindings).

## Changes

- `src/resolver/resolve.ts` — Recursive chain resolution + circular detection
- `test/resolver/resolver.test.ts` — 3-level chained extends test + circular error test
- `test/fixtures/chained-extends/` — Grandparent → parent → child fixture
- `test/fixtures/circular-extends/` — A ↔ B cycle fixture

## Breaking change

`ResolveResult.basePath?: string` → `ResolveResult.basePaths: string[]`

This is a minor breaking change to the public API type. Consumers checking `result.basePath` need to switch to `result.basePaths[0]` or iterate the array.

## Test plan

- [x] `npm run build` passes
- [x] `npm run test:unit` — 739 tests pass (34 files)
- [x] 3-level extends: grandparent `description` present in final output
- [x] Override: parent's `scope: commit` overrides grandparent's `scope: all`
- [x] Circular: throws `BaseResolveError` with "Circular" message
- [x] Single-level extends: existing tests still pass
