### PR TITLE
feat: support string array merge operators ($remove, $insert_after)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.22.7",
+  "version": "0.22.8",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/resolver/merger.ts
+++ b/src/resolver/merger.ts
@@ -20,10 +20,13 @@ function hasOperator(obj: AnyRecord): string | null {
   return null;
 }
 
-function findIndexById(arr: AnyArray, id: string): number {
-  return arr.findIndex(
-    (item) => isRecord(item) && (item as AnyRecord)["id"] === id,
-  );
+function findIndexByIdOrValue(arr: AnyArray, target: string): number {
+  return arr.findIndex((item) => {
+    if (typeof item === "string") {
+      return item === target;
+    }
+    return isRecord(item) && (item as AnyRecord)["id"] === target;
+  });
 }
 
 function applyArrayMergeOperator(
@@ -47,7 +50,7 @@ function applyArrayMergeOperator(
       const spec = operatorObj["$insert_after"] as AnyRecord;
       const target = spec["target"] as string;
       const items = spec["items"] as AnyArray;
-      const idx = findIndexById(baseArray, target);
+      const idx = findIndexByIdOrValue(baseArray, target);
       if (idx === -1) {
         throw new MergeError(
           `$insert_after target "${target}" not found in base at ${path}`,
@@ -61,8 +64,31 @@ function applyArrayMergeOperator(
       return operatorObj["$replace"] as AnyArray;
     }
     case "$remove": {
-      const removeList = operatorObj["$remove"] as AnyRecord[];
-      const idsToRemove = new Set(removeList.map((r) => r["id"] as string));
+      const removeList = operatorObj["$remove"] as unknown[];
+      if (removeList.length === 0) {
+        return baseArray;
+      }
+
+      if (typeof removeList[0] === "string") {
+        const valuesToRemove = new Set(removeList as string[]);
+        const result = baseArray.filter((item) => {
+          if (typeof item === "string" && valuesToRemove.has(item)) {
+            valuesToRemove.delete(item);
+            return false;
+          }
+          return true;
+        });
+        if (valuesToRemove.size > 0) {
+          throw new MergeError(
+            `$remove values not found in base at ${path}: ${[...valuesToRemove].join(", ")}`,
+          );
+        }
+        return result;
+      }
+
+      const idsToRemove = new Set(
+        (removeList as AnyRecord[]).map((r) => r["id"] as string),
+      );
       const result = baseArray.filter((item) => {
         if (isRecord(item) && typeof (item as AnyRecord)["id"] === "string") {
           const itemId = (item as AnyRecord)["id"] as string;

--- a/src/schema/merge-operators.ts
+++ b/src/schema/merge-operators.ts
@@ -22,7 +22,7 @@ export const ReplaceOperatorSchema = z.object({ $replace: z.any() });
 export type ReplaceOperator = z.infer<typeof ReplaceOperatorSchema>;
 
 export const RemoveOperatorSchema = z.object({
-  $remove: z.array(z.string()),
+  $remove: z.array(z.union([z.string(), z.object({ id: z.string() })])),
 });
 export type RemoveOperator = z.infer<typeof RemoveOperatorSchema>;
 
@@ -32,4 +32,4 @@ export type MergeableRecord<T> =
   | { $prepend: Record<string, unknown> }
   | { $insert_after: { after: string; entries: Record<string, unknown> } }
   | { $replace: unknown }
-  | { $remove: string[] };
+  | { $remove: (string | { id: string })[] };

--- a/test/resolver/resolver.test.ts
+++ b/test/resolver/resolver.test.ts
@@ -122,6 +122,25 @@ describe("mergeDsl", () => {
     expect(() => mergeDsl(base, project)).toThrow("not found");
   });
 
+  it("applies $insert_after on string arrays by value", () => {
+    const project = {
+      extends: "./base/",
+      agents: {
+        "agent-1": {
+          constraints: {
+            $insert_after: {
+              target: "c1",
+              items: ["c1.5"],
+            },
+          },
+        },
+      },
+    };
+    const result = mergeDsl(base, project);
+    const agents = result["agents"] as Record<string, Record<string, unknown>>;
+    expect(agents["agent-1"]["constraints"]).toEqual(["c1", "c1.5"]);
+  });
+
   it("applies $replace operator", () => {
     const project = {
       extends: "./base/",
@@ -161,6 +180,70 @@ describe("mergeDsl", () => {
     };
     expect(() => mergeDsl(base, project)).toThrow(MergeError);
     expect(() => mergeDsl(base, project)).toThrow("not found");
+  });
+
+  it("applies $remove on string arrays by value", () => {
+    const project = {
+      extends: "./base/",
+      agents: {
+        "agent-1": {
+          constraints: { $remove: ["c1"] },
+        },
+      },
+    };
+    const result = mergeDsl(base, project);
+    const agents = result["agents"] as Record<string, Record<string, unknown>>;
+    expect(agents["agent-1"]["constraints"]).toEqual([]);
+  });
+
+  it("applies $remove on string arrays preserving remaining items", () => {
+    const baseMulti = {
+      ...base,
+      agents: {
+        "agent-1": {
+          ...base.agents["agent-1"],
+          constraints: ["c1", "c2", "c3"],
+        },
+      },
+    };
+    const project = {
+      extends: "./base/",
+      agents: {
+        "agent-1": {
+          constraints: { $remove: ["c2"] },
+        },
+      },
+    };
+    const result = mergeDsl(baseMulti, project);
+    const agents = result["agents"] as Record<string, Record<string, unknown>>;
+    expect(agents["agent-1"]["constraints"]).toEqual(["c1", "c3"]);
+  });
+
+  it("throws on $remove with non-existent string value", () => {
+    const project = {
+      extends: "./base/",
+      agents: {
+        "agent-1": {
+          constraints: { $remove: ["nonexistent"] },
+        },
+      },
+    };
+    expect(() => mergeDsl(base, project)).toThrow(MergeError);
+    expect(() => mergeDsl(base, project)).toThrow("not found");
+  });
+
+  it("$remove with empty array is no-op", () => {
+    const project = {
+      extends: "./base/",
+      agents: {
+        "agent-1": {
+          constraints: { $remove: [] },
+        },
+      },
+    };
+    const result = mergeDsl(base, project);
+    const agents = result["agents"] as Record<string, Record<string, unknown>>;
+    expect(agents["agent-1"]["constraints"]).toEqual(["c1"]);
   });
 
   it("scalar fields are directly overwritten", () => {


### PR DESCRIPTION
## Summary

Fixes #66 — Extends merge operators to fully support string arrays.

Previously, `$remove` only worked with id-based object arrays and `$insert_after` only matched targets by `id` field. String arrays (like `constraints`, `can_read_artifacts`) required `$replace` for any modification.

Now:
- `$remove: ["value"]` removes matching string values from arrays
- `$insert_after: { target: "value", items: [...] }` finds string values as insertion targets

## Changes

- `src/resolver/merger.ts` — `$remove` dispatches by payload type (string vs object); `findIndexById` → `findIndexByIdOrValue`
- `src/schema/merge-operators.ts` — `RemoveOperatorSchema` updated to union type
- `test/resolver/resolver.test.ts` — 5 new test cases
- `package.json` — version bump to 0.22.8

## Test plan

- [x] `npm run build` passes
- [x] `npm run test:unit` — 744 tests pass
- [x] String array `$remove` (happy path + error)
- [x] String array `$insert_after` (value-based target)
- [x] Existing id-based operators unchanged
