### PR TITLE
fix: map merge operator no longer ignores sibling overrides (fixes #68)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.22.8",
+  "version": "0.22.9",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/resolver/merger.ts
+++ b/src/resolver/merger.ts
@@ -231,12 +231,16 @@ export function deepMergeEntities(
   return result;
 }
 
+const OPERATOR_KEYS = new Set(["$append", "$prepend", "$insert_after", "$replace", "$remove"]);
+
 export function mergeEntityMaps(
   baseMap: AnyRecord,
   projectMap: AnyRecord,
   path: string,
   hasExtends: boolean,
 ): AnyRecord {
+  let result: AnyRecord;
+
   if (isRecord(projectMap) && !Array.isArray(projectMap)) {
     const op = hasOperator(projectMap);
     if (op) {
@@ -245,13 +249,16 @@ export function mergeEntityMaps(
           `Merge operator used without extends at ${path}`,
         );
       }
-      return applyMapMergeOperator(baseMap, projectMap, path);
+      result = applyMapMergeOperator(baseMap, projectMap, path);
+    } else {
+      result = { ...baseMap };
     }
+  } else {
+    result = { ...baseMap };
   }
 
-  const result = { ...baseMap };
-
   for (const [key, projVal] of Object.entries(projectMap)) {
+    if (OPERATOR_KEYS.has(key)) continue;
     const baseVal = result[key];
     if (baseVal !== undefined && isRecord(baseVal) && isRecord(projVal)) {
       result[key] = deepMergeEntities(

--- a/test/resolver/resolver.test.ts
+++ b/test/resolver/resolver.test.ts
@@ -246,6 +246,42 @@ describe("mergeDsl", () => {
     expect(agents["agent-1"]["constraints"]).toEqual(["c1"]);
   });
 
+  it("map $remove with sibling property overrides", () => {
+    const baseWithTwo = {
+      ...base,
+      agents: {
+        "agent-1": base.agents["agent-1"],
+        "agent-2": { role_name: "R2", purpose: "P2", constraints: ["x"] },
+      },
+    };
+    const project = {
+      extends: "./base/",
+      agents: {
+        $remove: ["agent-2"],
+        "agent-1": { constraints: { $append: ["c2"] } },
+      },
+    };
+    const result = mergeDsl(baseWithTwo, project);
+    const agents = result["agents"] as Record<string, Record<string, unknown>>;
+    expect(agents["agent-2"]).toBeUndefined();
+    expect(agents["agent-1"]["constraints"]).toEqual(["c1", "c2"]);
+  });
+
+  it("map $append with sibling property overrides", () => {
+    const project = {
+      extends: "./base/",
+      agents: {
+        $append: { "agent-new": { role_name: "New", purpose: "New" } },
+        "agent-1": { constraints: { $prepend: ["c0"] } },
+      },
+    };
+    const result = mergeDsl(base, project);
+    const agents = result["agents"] as Record<string, Record<string, unknown>>;
+    expect(agents["agent-new"]).toBeDefined();
+    expect(agents["agent-new"]["role_name"]).toBe("New");
+    expect(agents["agent-1"]["constraints"]).toEqual(["c0", "c1"]);
+  });
+
   it("scalar fields are directly overwritten", () => {
     const project = {
       extends: "./base/",


### PR DESCRIPTION
## Summary

Fixes #68 — Map merge operator (`$remove`, `$append`, etc.) no longer silently ignores sibling property overrides.

**Root cause**: `mergeEntityMaps()` returned immediately after applying the operator, skipping the normal deep-merge loop for remaining non-operator keys.

**Fix**: Apply the operator first to get the modified base, then iterate non-operator keys through the standard merge logic.

## Changes

- `src/resolver/merger.ts` — Restructure `mergeEntityMaps` to continue processing after operator application
- `test/resolver/resolver.test.ts` — 2 new tests: `$remove` + override, `$append` + override
- `package.json` — version bump to 0.22.9

## Test plan

- [x] `npm run build` passes
- [x] `npm run test:unit` — 746 tests pass
- [x] `$remove` + sibling property override works together
- [x] `$append` + sibling property override works together
- [x] All existing operator-only tests still pass
