### PR TITLE
fix: reject multiple operators and fix orderedInsertAfter (fixes #70, #71)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.22.9",
+  "version": "0.23.0",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/resolver/merger.ts
+++ b/src/resolver/merger.ts
@@ -12,12 +12,18 @@ function isRecord(v: unknown): v is AnyRecord {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
-function hasOperator(obj: AnyRecord): string | null {
+function hasOperator(obj: AnyRecord, path?: string): string | null {
   const ops = ["$append", "$prepend", "$insert_after", "$replace", "$remove"];
+  const found: string[] = [];
   for (const op of ops) {
-    if (op in obj) return op;
+    if (op in obj) found.push(op);
   }
-  return null;
+  if (found.length > 1) {
+    throw new MergeError(
+      `Multiple merge operators in the same object at ${path ?? "unknown"}: ${found.join(", ")}`,
+    );
+  }
+  return found.length === 1 ? found[0] : null;
 }
 
 function findIndexByIdOrValue(arr: AnyArray, target: string): number {
@@ -34,7 +40,7 @@ function applyArrayMergeOperator(
   operatorObj: AnyRecord,
   path: string,
 ): AnyArray {
-  const op = hasOperator(operatorObj);
+  const op = hasOperator(operatorObj, path);
   if (!op) return baseArray;
 
   switch (op) {
@@ -116,9 +122,13 @@ function orderedInsertAfter(
   afterKey: string,
   entries: AnyRecord,
 ): AnyRecord {
+  const entryKeys = new Set(Object.keys(entries));
   const result: AnyRecord = {};
   let inserted = false;
   for (const key of Object.keys(base)) {
+    if (inserted && entryKeys.has(key)) {
+      continue;
+    }
     result[key] = base[key];
     if (key === afterKey) {
       for (const [ek, ev] of Object.entries(entries)) {
@@ -126,9 +136,6 @@ function orderedInsertAfter(
       }
       inserted = true;
     }
-  }
-  if (!inserted) {
-    return result;
   }
   return result;
 }
@@ -138,7 +145,7 @@ function applyMapMergeOperator(
   operatorObj: AnyRecord,
   path: string,
 ): AnyRecord {
-  const op = hasOperator(operatorObj);
+  const op = hasOperator(operatorObj, path);
   if (!op) return baseMap;
 
   switch (op) {
@@ -198,7 +205,7 @@ export function deepMergeEntities(
     const baseVal = result[key];
     const projVal = project[key];
 
-    if (isRecord(projVal) && hasOperator(projVal)) {
+    if (isRecord(projVal) && hasOperator(projVal, `${path}.${key}`)) {
       if (!hasExtends) {
         throw new MergeError(
           `Merge operator used without extends at ${path}.${key}`,
@@ -242,7 +249,7 @@ export function mergeEntityMaps(
   let result: AnyRecord;
 
   if (isRecord(projectMap) && !Array.isArray(projectMap)) {
-    const op = hasOperator(projectMap);
+    const op = hasOperator(projectMap, path);
     if (op) {
       if (!hasExtends) {
         throw new MergeError(

--- a/test/resolver/resolver.test.ts
+++ b/test/resolver/resolver.test.ts
@@ -282,6 +282,59 @@ describe("mergeDsl", () => {
     expect(agents["agent-1"]["constraints"]).toEqual(["c0", "c1"]);
   });
 
+  it("throws on multiple merge operators in same object", () => {
+    const project = {
+      extends: "./base/",
+      agents: {
+        $remove: ["agent-1"],
+        $append: { "agent-new": { role_name: "N", purpose: "P" } },
+      },
+    };
+    expect(() => mergeDsl(base, project)).toThrow(MergeError);
+    expect(() => mergeDsl(base, project)).toThrow(/Multiple merge operators/);
+  });
+
+  it("throws on multiple operators in nested property", () => {
+    const project = {
+      extends: "./base/",
+      agents: {
+        "agent-1": {
+          constraints: { $append: ["c2"], $prepend: ["c0"] },
+        },
+      },
+    };
+    expect(() => mergeDsl(base, project)).toThrow(MergeError);
+    expect(() => mergeDsl(base, project)).toThrow(/Multiple merge operators/);
+  });
+
+  it("map $insert_after with overlapping existing key after anchor", () => {
+    const baseWithThree = {
+      ...base,
+      agents: {
+        "agent-a": { role_name: "A", purpose: "PA" },
+        "agent-b": { role_name: "B", purpose: "PB" },
+        "agent-c": { role_name: "C", purpose: "PC" },
+      },
+    };
+    const project = {
+      extends: "./base/",
+      agents: {
+        $insert_after: {
+          after: "agent-a",
+          entries: { "agent-c": { role_name: "C-updated", purpose: "PC-new" } },
+        },
+      },
+    };
+    const result = mergeDsl(baseWithThree, project);
+    const agents = result["agents"] as Record<string, Record<string, unknown>>;
+    expect(agents["agent-c"]["role_name"]).toBe("C-updated");
+    const keys = Object.keys(agents);
+    expect(keys.filter((k) => k === "agent-c")).toHaveLength(1);
+    expect(keys[0]).toBe("agent-a");
+    expect(keys[1]).toBe("agent-c");
+    expect(keys[2]).toBe("agent-b");
+  });
+
   it("scalar fields are directly overwritten", () => {
     const project = {
       extends: "./base/",


### PR DESCRIPTION
## Summary

Fixes #70 and #71 — Two merge operator logic bugs.

### Bug 1: Multiple operators silently ignored (#70)

When multiple merge operators (`$remove`, `$append`, etc.) appeared in the same object, only the first one in detection order was applied. Others were silently dropped.

**Fix**: `hasOperator()` now detects all operator keys and throws `MergeError` if more than one is present. This makes the ambiguity explicit rather than silently losing operations.

### Bug 2: `orderedInsertAfter` overwrites inserted entries (#71)

When map `$insert_after` inserted an entry whose key already existed after the anchor in the base, the loop would overwrite the inserted value with the old base value.

**Fix**: After insertion, skip any base key that was already written as part of the inserted entries.

## Changes

- `src/resolver/merger.ts` — `hasOperator` validates single-operator constraint; `orderedInsertAfter` skips duplicate keys
- `test/resolver/resolver.test.ts` — 3 new tests
- `package.json` — version bump to 0.23.0

## Test plan

- [x] `npm run build` passes
- [x] `npm run test:unit` — 749 tests pass
- [x] Multiple operators in same object → MergeError
- [x] Multiple operators in nested property → MergeError
- [x] `$insert_after` with overlapping key retains inserted value and correct order
- [x] All existing tests pass
