### PR TITLE
refactor: unify merge operator handling with mergeSection (fixes #73)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/config/binding-merger.ts
+++ b/src/config/binding-merger.ts
@@ -1,13 +1,13 @@
-import { mergeEntityMaps, deepMergeEntities } from "../resolver/index.js";
+import { mergeSection, type SectionMode } from "../resolver/index.js";
 
 type AnyRecord = Record<string, unknown>;
 
-function isRecord(v: unknown): v is AnyRecord {
-  return typeof v === "object" && v !== null && !Array.isArray(v);
-}
-
-const BINDING_MAP_MERGE_SECTIONS = ["guardrail_impl", "outputs"];
-const BINDING_ARRAY_MERGE_SECTIONS = ["renders"];
+const BINDING_SECTIONS: Record<string, SectionMode> = {
+  guardrail_impl: "map",
+  outputs: "map",
+  renders: "array",
+  reporting: "object",
+};
 
 export function mergeBinding(
   base: AnyRecord,
@@ -16,45 +16,14 @@ export function mergeBinding(
   const hasExtends = typeof project["extends"] === "string";
   const result: AnyRecord = { ...base, ...project };
 
-  for (const section of BINDING_MAP_MERGE_SECTIONS) {
-    const baseVal = base[section];
-    const projVal = project[section];
-
-    if (projVal === undefined) {
-      continue;
-    }
-
-    const baseMap = isRecord(baseVal) ? baseVal : {};
-    result[section] = mergeEntityMaps(
-      baseMap,
-      projVal as AnyRecord,
+  for (const [section, mode] of Object.entries(BINDING_SECTIONS)) {
+    if (project[section] === undefined) continue;
+    result[section] = mergeSection(
+      base[section],
+      project[section],
       section,
       hasExtends,
-    );
-  }
-
-  for (const section of BINDING_ARRAY_MERGE_SECTIONS) {
-    const baseVal = base[section];
-    const projVal = project[section];
-
-    if (projVal === undefined) continue;
-
-    const baseArr = Array.isArray(baseVal) ? baseVal : [];
-    const projArr = Array.isArray(projVal) ? projVal : [];
-    result[section] = [...baseArr, ...projArr];
-  }
-
-  // reporting: deep merge when both sides are objects, otherwise project wins
-  if (
-    project["reporting"] !== undefined &&
-    isRecord(base["reporting"]) &&
-    isRecord(project["reporting"])
-  ) {
-    result["reporting"] = deepMergeEntities(
-      base["reporting"] as AnyRecord,
-      project["reporting"] as AnyRecord,
-      "reporting",
-      hasExtends,
+      mode,
     );
   }
 

--- a/src/resolver/index.ts
+++ b/src/resolver/index.ts
@@ -1,9 +1,13 @@
 export { resolveBase, resolveLocalBase, BaseResolveError } from "./base-resolver.js";
 export {
   mergeDsl,
+  mergeSection,
   mergeEntityMaps,
   deepMergeEntities,
+  applyArrayMergeOperator,
+  hasOperator,
   MergeError,
+  type SectionMode,
 } from "./merger.js";
 export { resolve, type ResolveResult } from "./resolve.js";
 export { substituteVars, VarsSubstitutionError } from "./substitute-vars.js";

--- a/src/resolver/merger.ts
+++ b/src/resolver/merger.ts
@@ -12,7 +12,7 @@ function isRecord(v: unknown): v is AnyRecord {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
-function hasOperator(obj: AnyRecord, path?: string): string | null {
+export function hasOperator(obj: AnyRecord, path?: string): string | null {
   const ops = ["$append", "$prepend", "$insert_after", "$replace", "$remove"];
   const found: string[] = [];
   for (const op of ops) {
@@ -35,7 +35,7 @@ function findIndexByIdOrValue(arr: AnyArray, target: string): number {
   });
 }
 
-function applyArrayMergeOperator(
+export function applyArrayMergeOperator(
   baseArray: AnyArray,
   operatorObj: AnyRecord,
   path: string,
@@ -216,7 +216,12 @@ export function deepMergeEntities(
       } else if (isRecord(baseVal)) {
         result[key] = applyMapMergeOperator(baseVal, projVal, `${path}.${key}`);
       } else {
-        result[key] = applyArrayMergeOperator([], projVal, `${path}.${key}`);
+        const op = hasOperator(projVal, `${path}.${key}`);
+        if (op === "$replace") {
+          result[key] = projVal["$replace"];
+        } else {
+          result[key] = applyArrayMergeOperator([], projVal, `${path}.${key}`);
+        }
       }
     } else if (
       isRecord(projVal) &&
@@ -239,6 +244,49 @@ export function deepMergeEntities(
 }
 
 const OPERATOR_KEYS = new Set(["$append", "$prepend", "$insert_after", "$replace", "$remove"]);
+
+export type SectionMode = "map" | "array" | "object";
+
+export function mergeSection(
+  base: unknown,
+  project: unknown,
+  path: string,
+  hasExtends: boolean,
+  mode: SectionMode,
+): unknown {
+  switch (mode) {
+    case "map": {
+      const baseMap = isRecord(base) ? (base as AnyRecord) : {};
+      return mergeEntityMaps(baseMap, project as AnyRecord, path, hasExtends);
+    }
+    case "array": {
+      const baseArr = Array.isArray(base) ? (base as AnyArray) : [];
+      if (isRecord(project) && hasOperator(project as AnyRecord, path)) {
+        if (!hasExtends) {
+          throw new MergeError(
+            `Merge operator used without extends at ${path}`,
+          );
+        }
+        return applyArrayMergeOperator(baseArr, project as AnyRecord, path);
+      }
+      const projArr = Array.isArray(project) ? (project as AnyArray) : [];
+      return [...baseArr, ...projArr];
+    }
+    case "object": {
+      const baseObj = isRecord(base) ? (base as AnyRecord) : {};
+      const projObj = isRecord(project) ? (project as AnyRecord) : {};
+      if (hasOperator(projObj, path)) {
+        if (!hasExtends) {
+          throw new MergeError(
+            `Merge operator used without extends at ${path}`,
+          );
+        }
+        return applyMapMergeOperator(baseObj, projObj, path);
+      }
+      return deepMergeEntities(baseObj, projObj, path, hasExtends);
+    }
+  }
+}
 
 export function mergeEntityMaps(
   baseMap: AnyRecord,
@@ -267,9 +315,10 @@ export function mergeEntityMaps(
   for (const [key, projVal] of Object.entries(projectMap)) {
     if (OPERATOR_KEYS.has(key)) continue;
     const baseVal = result[key];
-    if (baseVal !== undefined && isRecord(baseVal) && isRecord(projVal)) {
+    if (isRecord(projVal) && !Array.isArray(projVal)) {
+      const baseObj = isRecord(baseVal) ? baseVal : {};
       result[key] = deepMergeEntities(
-        baseVal,
+        baseObj,
         projVal as AnyRecord,
         `${path}.${key}`,
         hasExtends,
@@ -282,21 +331,22 @@ export function mergeEntityMaps(
   return result;
 }
 
-const MERGE_SECTIONS = [
-  "agents",
-  "tasks",
-  "artifacts",
-  "tools",
-  "validations",
-  "handoff_types",
-  "imports",
-  "workflow",
-  "policies",
-  "guardrails",
-  "guardrail_policies",
-  "components",
-  "extensions",
-];
+const DSL_SECTIONS: Record<string, SectionMode> = {
+  agents: "map",
+  tasks: "map",
+  artifacts: "map",
+  tools: "map",
+  validations: "map",
+  handoff_types: "map",
+  imports: "map",
+  workflow: "map",
+  policies: "map",
+  guardrails: "map",
+  guardrail_policies: "map",
+  components: "map",
+  extensions: "map",
+  system: "object",
+};
 
 export function mergeDsl(
   base: AnyRecord,
@@ -305,29 +355,14 @@ export function mergeDsl(
   const hasExtends = typeof project["extends"] === "string";
   const result: AnyRecord = { ...base, ...project };
 
-  if (project["system"] && base["system"]) {
-    result["system"] = deepMergeEntities(
-      base["system"] as AnyRecord,
-      project["system"] as AnyRecord,
-      "system",
-      hasExtends,
-    );
-  }
-
-  for (const section of MERGE_SECTIONS) {
-    const baseVal = base[section];
-    const projVal = project[section];
-
-    if (projVal === undefined) {
-      continue;
-    }
-
-    const baseMap = isRecord(baseVal) ? baseVal : {};
-    result[section] = mergeEntityMaps(
-      baseMap,
-      projVal as AnyRecord,
+  for (const [section, mode] of Object.entries(DSL_SECTIONS)) {
+    if (project[section] === undefined) continue;
+    result[section] = mergeSection(
+      base[section],
+      project[section],
       section,
       hasExtends,
+      mode,
     );
   }
 

--- a/test/config/binding-merger.test.ts
+++ b/test/config/binding-merger.test.ts
@@ -248,4 +248,126 @@ describe("mergeBinding", () => {
     const renders = result["renders"] as unknown[];
     expect(renders).toHaveLength(1);
   });
+
+  it("applies $replace operator on renders", () => {
+    const base = {
+      software: "cursor",
+      version: 1,
+      renders: [
+        { context: "system", output: "base.md", inline_template: "base-tpl" },
+      ],
+    };
+    const project = {
+      extends: "./base.yaml",
+      software: "cursor",
+      version: 1,
+      renders: {
+        $replace: [
+          { context: "agent", output: "child.md", inline_template: "child-tpl" },
+        ],
+      },
+    };
+    const result = mergeBinding(base, project);
+    const renders = result["renders"] as unknown[];
+    expect(renders).toHaveLength(1);
+    expect(renders[0]).toEqual(
+      expect.objectContaining({ context: "agent", output: "child.md" }),
+    );
+  });
+
+  it("applies $append operator on renders", () => {
+    const base = {
+      software: "cursor",
+      version: 1,
+      renders: [
+        { context: "system", output: "base.md", inline_template: "base-tpl" },
+      ],
+    };
+    const project = {
+      extends: "./base.yaml",
+      software: "cursor",
+      version: 1,
+      renders: {
+        $append: [
+          { context: "agent", output: "added.md", inline_template: "added" },
+        ],
+      },
+    };
+    const result = mergeBinding(base, project);
+    const renders = result["renders"] as unknown[];
+    expect(renders).toHaveLength(2);
+    expect(renders[0]).toEqual(expect.objectContaining({ context: "system" }));
+    expect(renders[1]).toEqual(expect.objectContaining({ context: "agent" }));
+  });
+
+  it("applies $remove operator on renders by id", () => {
+    const base = {
+      software: "cursor",
+      version: 1,
+      renders: [
+        { id: "r1", context: "system", output: "sys.md", inline_template: "s" },
+        { id: "r2", context: "agent", output: "agent.md", inline_template: "a" },
+      ],
+    };
+    const project = {
+      extends: "./base.yaml",
+      software: "cursor",
+      version: 1,
+      renders: {
+        $remove: [{ id: "r1" }],
+      },
+    };
+    const result = mergeBinding(base, project);
+    const renders = result["renders"] as unknown[];
+    expect(renders).toHaveLength(1);
+    expect(renders[0]).toEqual(expect.objectContaining({ id: "r2" }));
+  });
+
+  it("applies $prepend operator on renders", () => {
+    const base = {
+      software: "cursor",
+      version: 1,
+      renders: [
+        { context: "system", output: "base.md", inline_template: "base-tpl" },
+      ],
+    };
+    const project = {
+      extends: "./base.yaml",
+      software: "cursor",
+      version: 1,
+      renders: {
+        $prepend: [
+          { context: "agent", output: "first.md", inline_template: "first" },
+        ],
+      },
+    };
+    const result = mergeBinding(base, project);
+    const renders = result["renders"] as unknown[];
+    expect(renders).toHaveLength(2);
+    expect(renders[0]).toEqual(expect.objectContaining({ context: "agent" }));
+    expect(renders[1]).toEqual(expect.objectContaining({ context: "system" }));
+  });
+
+  it("applies $replace on reporting section (object mode)", () => {
+    const base = {
+      software: "cursor",
+      version: 1,
+      reporting: {
+        commands: { lint: "npm run lint" },
+        fail_open: true,
+      },
+    };
+    const project = {
+      extends: "./base.yaml",
+      software: "cursor",
+      version: 1,
+      reporting: {
+        $replace: { commands: { test: "npm test" }, fail_open: false },
+      },
+    };
+    const result = mergeBinding(base, project);
+    const reporting = result["reporting"] as Record<string, unknown>;
+    expect(reporting["commands"]).toEqual({ test: "npm test" });
+    expect(reporting["fail_open"]).toBe(false);
+  });
 });

--- a/test/resolver/resolver.test.ts
+++ b/test/resolver/resolver.test.ts
@@ -379,6 +379,40 @@ describe("mergeDsl", () => {
     expect(() => mergeDsl(base, project)).toThrow("without extends");
   });
 
+  it("applies $replace on system section (object mode)", () => {
+    const project = {
+      extends: "./base/",
+      system: {
+        $replace: { id: "new", name: "New System", default_workflow_order: ["b"] },
+      },
+    };
+    const result = mergeDsl(base, project);
+    const sys = result["system"] as Record<string, unknown>;
+    expect(sys["id"]).toBe("new");
+    expect(sys["name"]).toBe("New System");
+    expect(sys["default_workflow_order"]).toEqual(["b"]);
+  });
+
+  it("applies nested operator on new entity key", () => {
+    const project = {
+      extends: "./base/",
+      agents: {
+        "agent-1": {
+          constraints: { $append: ["c2"] },
+        },
+        "agent-new": {
+          role_name: "New",
+          purpose: "New purpose",
+          constraints: { $replace: ["only-new"] },
+        },
+      },
+    };
+    const result = mergeDsl(base, project);
+    const agents = result["agents"] as Record<string, Record<string, unknown>>;
+    expect(agents["agent-1"]["constraints"]).toEqual(["c1", "c2"]);
+    expect(agents["agent-new"]["constraints"]).toEqual(["only-new"]);
+  });
+
   it("project > base priority (2-layer model)", () => {
     const project = {
       extends: "./base/",


### PR DESCRIPTION
## Summary

Fixes #73 — Unify merge operator handling across DSL and binding mergers.

**Problem**: Three separate merge paths (entity maps, singleton objects, arrays) had inconsistent operator support. `system` and `reporting` section-level operators were broken, new entity keys with nested operators were unresolved.

**Solution**: Introduce `mergeSection(base, project, path, hasExtends, mode)` — a single entry point that dispatches based on section type (`"map"` / `"array"` / `"object"`). Both `mergeDsl` and `mergeBinding` now use a declarative sections record + shared loop.

## Changes

- `src/resolver/merger.ts` — Add `mergeSection` + `SectionMode`; replace `MERGE_SECTIONS` array with `DSL_SECTIONS` record; fix `mergeEntityMaps` sibling loop to always `deepMergeEntities` for records; fix `deepMergeEntities` `$replace` on missing base
- `src/config/binding-merger.ts` — Rewrite to use `BINDING_SECTIONS` + `mergeSection` (from ~80 lines to ~30 lines)
- `src/resolver/index.ts` — Export `mergeSection`, `SectionMode`
- `test/resolver/resolver.test.ts` — Add `system $replace`, new entity key + operator tests
- `test/config/binding-merger.test.ts` — Add `reporting $replace`, `renders $prepend` tests

## Test plan

- [x] `npm run build` passes
- [x] `npm run test:unit` — 756 tests pass
- [x] `system: { $replace: {...} }` replaces correctly
- [x] `reporting: { $replace: {...} }` replaces correctly
- [x] New entity key with nested `$replace` resolves
- [x] `renders: { $prepend: [...] }` works
- [x] All existing tests unchanged
