### PR TITLE
feat: support arbitrary entity field expansion in render output paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/auditor/context-builder.ts
+++ b/src/auditor/context-builder.ts
@@ -45,7 +45,8 @@ async function loadRenderedFiles(
     const section = getDslSection(dsl, target.context);
     const ids = filterIds(Object.keys(section), target.include, target.exclude);
     for (const entityId of ids) {
-      const outputPath = expandOutputPath(target.output, target.context, entityId);
+      const entity = section[entityId] as Record<string, unknown> | undefined;
+      const outputPath = expandOutputPath(target.output, target.context, entityId, entity);
       try {
         const content = await readFile(outputPath, "utf8");
         entries.push({ agent_id: entityId, path: outputPath, content });

--- a/src/guardrail-generator/generator.ts
+++ b/src/guardrail-generator/generator.ts
@@ -442,8 +442,9 @@ export async function generateGuardrails(
           const mergedCtx = { ...entityCtx, vars, paths, binding, resolved_checks: checkResult.resolved };
           const rendered = compiled(mergedCtx);
 
+          const entity = section[entityId] as Record<string, unknown> | undefined;
           const resolvedOutput = resolveBindingRenderOutputPath(
-            expandOutputPath(renderTarget.output, context, entityId),
+            expandOutputPath(renderTarget.output, context, entityId, entity),
             paths,
           );
           const outputPath = resolve(config.configDir, resolvedOutput);

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -339,8 +339,21 @@ export function filterIds(
   return allIds;
 }
 
-export function expandOutputPath(pattern: string, context: ContextType, entityId: string): string {
-  return pattern.replace(new RegExp(`\\{${context}\\.id\\}`, "g"), entityId);
+export function expandOutputPath(
+  pattern: string,
+  context: ContextType,
+  entityId: string,
+  entity?: Record<string, unknown>,
+): string {
+  return pattern.replace(
+    new RegExp(`\\{${context}\\.([^}]+)\\}`, "g"),
+    (_match, field: string) => {
+      if (field === "id") return entityId;
+      if (entity === undefined) return _match;
+      const value = entity[field];
+      return typeof value === "string" ? value : _match;
+    },
+  );
 }
 
 export function buildEntityContext(
@@ -422,7 +435,8 @@ export async function renderFromConfig(
       for (const entityId of ids) {
         const ctx = buildEntityContext(dsl, target.context, entityId);
         const output = compiled(ctx);
-        const outputPath = expandOutputPath(target.output, target.context, entityId);
+        const entity = section[entityId] as Record<string, unknown> | undefined;
+        const outputPath = expandOutputPath(target.output, target.context, entityId, entity);
         if (target.skip_empty && isEffectivelyEmpty(output)) {
           await removeIfExists(outputPath);
           continue;
@@ -489,7 +503,8 @@ export async function checkDriftFromConfig(
       for (const entityId of ids) {
         const ctx = buildEntityContext(dsl, target.context, entityId);
         const expected = compiled(ctx);
-        const outputPath = expandOutputPath(target.output, target.context, entityId);
+        const entity = section[entityId] as Record<string, unknown> | undefined;
+        const outputPath = expandOutputPath(target.output, target.context, entityId, entity);
         await checkExpectedVsExisting(expected, outputPath, target.skip_empty, diffs);
       }
     }

--- a/test/renderer/renderer.test.ts
+++ b/test/renderer/renderer.test.ts
@@ -4,7 +4,7 @@ import { parse as parseYaml } from "yaml";
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { DslSchema, type Dsl } from "../../src/schema/index.js";
 import { buildGlobalContext, buildPerAgentContext, buildWorkflowContext } from "../../src/renderer/context.js";
-import { renderFromConfig, checkDriftFromConfig } from "../../src/renderer/renderer.js";
+import { renderFromConfig, checkDriftFromConfig, expandOutputPath } from "../../src/renderer/renderer.js";
 import { generateSequenceDiagram } from "../../src/renderer/sequence-diagram.js";
 import { generateOverviewFlowchart } from "../../src/renderer/overview-flowchart.js";
 import { artifactOwnershipRule } from "../../src/linter/rules/artifact-ownership.js";
@@ -1095,5 +1095,59 @@ describe("guardrailCoverageMatrix helper", () => {
     expect(files).toHaveLength(1);
     const content = readFileSync(outputPath, "utf8");
     expect(content).toBe("STARTEND");
+  });
+});
+
+describe("expandOutputPath", () => {
+  it("expands {context.id} without entity", () => {
+    const result = expandOutputPath("out/{agent.id}/file.md", "agent", "my-agent");
+    expect(result).toBe("out/my-agent/file.md");
+  });
+
+  it("expands {context.id} with entity", () => {
+    const entity = { role_name: "architect", "x-claude-path": "backend" };
+    const result = expandOutputPath("out/{agent.id}/file.md", "agent", "my-agent", entity);
+    expect(result).toBe("out/my-agent/file.md");
+  });
+
+  it("expands standard fields from entity", () => {
+    const entity = { role_name: "architect", "x-claude-path": "backend" };
+    const result = expandOutputPath("{agent.role_name}/file.md", "agent", "my-agent", entity);
+    expect(result).toBe("architect/file.md");
+  });
+
+  it("expands x-* extension fields from entity", () => {
+    const entity = { role_name: "architect", "x-claude-path": "packages/backend" };
+    const result = expandOutputPath("../{agent.x-claude-path}/CLAUDE.md", "agent", "my-agent", entity);
+    expect(result).toBe("../packages/backend/CLAUDE.md");
+  });
+
+  it("leaves pattern unresolved when field is undefined", () => {
+    const entity = { role_name: "architect" };
+    const result = expandOutputPath("../{agent.x-claude-path}/CLAUDE.md", "agent", "my-agent", entity);
+    expect(result).toBe("../{agent.x-claude-path}/CLAUDE.md");
+  });
+
+  it("leaves pattern unresolved when entity is undefined", () => {
+    const result = expandOutputPath("../{agent.x-claude-path}/CLAUDE.md", "agent", "my-agent");
+    expect(result).toBe("../{agent.x-claude-path}/CLAUDE.md");
+  });
+
+  it("leaves pattern unresolved when field value is not a string", () => {
+    const entity = { "x-path": 123 };
+    const result = expandOutputPath("../{agent.x-path}/CLAUDE.md", "agent", "my-agent", entity);
+    expect(result).toBe("../{agent.x-path}/CLAUDE.md");
+  });
+
+  it("expands multiple different fields in one pattern", () => {
+    const entity = { "x-claude-path": "frontend", role_name: "dev" };
+    const result = expandOutputPath("{agent.x-claude-path}/{agent.role_name}/{agent.id}.md", "agent", "ui-agent", entity);
+    expect(result).toBe("frontend/dev/ui-agent.md");
+  });
+
+  it("works with guardrail context", () => {
+    const entity = { severity: "critical" };
+    const result = expandOutputPath("guardrails/{guardrail.id}/{guardrail.severity}.md", "guardrail", "no-force-push", entity);
+    expect(result).toBe("guardrails/no-force-push/critical.md");
   });
 });


### PR DESCRIPTION
## Summary

- Extend `expandOutputPath` to resolve `{context.<field>}` patterns from entity properties (not just `{context.id}`)
- Enables `{agent.x-claude-path}`, `{agent.role_name}`, etc. in render output paths
- All call sites updated: renderer, drift checker, auditor, guardrail-generator
- Undefined fields leave the pattern unresolved (no crash)

## Test plan

- [x] Unit tests for `expandOutputPath`: id, standard fields, x-* fields, undefined fields, non-string values, multiple fields, different contexts
- [x] All 765 existing tests pass
- [x] Build succeeds

Closes #75

Made with [Cursor](https://cursor.com)