### PR TITLE
feat: skip render when output path has unresolved entity variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/guardrail-generator/generator.ts
+++ b/src/guardrail-generator/generator.ts
@@ -20,6 +20,7 @@ import {
   getDslSection,
   filterIds,
   expandOutputPath,
+  hasUnresolvedPathVars,
 } from "../renderer/index.js";
 
 // Register the `json` template helper
@@ -443,10 +444,9 @@ export async function generateGuardrails(
           const rendered = compiled(mergedCtx);
 
           const entity = section[entityId] as Record<string, unknown> | undefined;
-          const resolvedOutput = resolveBindingRenderOutputPath(
-            expandOutputPath(renderTarget.output, context, entityId, entity),
-            paths,
-          );
+          const expandedOutput = expandOutputPath(renderTarget.output, context, entityId, entity);
+          if (hasUnresolvedPathVars(expandedOutput)) continue;
+          const resolvedOutput = resolveBindingRenderOutputPath(expandedOutput, paths);
           const outputPath = resolve(config.configDir, resolvedOutput);
 
           if (shouldSkipEmpty && rendered.trim().length === 0) {

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -5,6 +5,7 @@ export {
   getDslSection,
   filterIds,
   expandOutputPath,
+  hasUnresolvedPathVars,
   type RenderOptions,
 } from "./renderer.js";
 export {

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -356,6 +356,16 @@ export function expandOutputPath(
   );
 }
 
+import { CONTEXT_TYPES } from "../schema/context-type.js";
+
+const CONTEXT_TYPE_PATTERN = new RegExp(
+  `\\{(${CONTEXT_TYPES.join("|")})\\.[^}]+\\}`,
+);
+
+export function hasUnresolvedPathVars(path: string): boolean {
+  return CONTEXT_TYPE_PATTERN.test(path);
+}
+
 export function buildEntityContext(
   dsl: Dsl,
   context: ContextType,
@@ -437,6 +447,7 @@ export async function renderFromConfig(
         const output = compiled(ctx);
         const entity = section[entityId] as Record<string, unknown> | undefined;
         const outputPath = expandOutputPath(target.output, target.context, entityId, entity);
+        if (hasUnresolvedPathVars(outputPath)) continue;
         if (target.skip_empty && isEffectivelyEmpty(output)) {
           await removeIfExists(outputPath);
           continue;
@@ -505,6 +516,7 @@ export async function checkDriftFromConfig(
         const expected = compiled(ctx);
         const entity = section[entityId] as Record<string, unknown> | undefined;
         const outputPath = expandOutputPath(target.output, target.context, entityId, entity);
+        if (hasUnresolvedPathVars(outputPath)) continue;
         await checkExpectedVsExisting(expected, outputPath, target.skip_empty, diffs);
       }
     }

--- a/test/renderer/renderer.test.ts
+++ b/test/renderer/renderer.test.ts
@@ -4,7 +4,7 @@ import { parse as parseYaml } from "yaml";
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { DslSchema, type Dsl } from "../../src/schema/index.js";
 import { buildGlobalContext, buildPerAgentContext, buildWorkflowContext } from "../../src/renderer/context.js";
-import { renderFromConfig, checkDriftFromConfig, expandOutputPath } from "../../src/renderer/renderer.js";
+import { renderFromConfig, checkDriftFromConfig, expandOutputPath, hasUnresolvedPathVars } from "../../src/renderer/renderer.js";
 import { generateSequenceDiagram } from "../../src/renderer/sequence-diagram.js";
 import { generateOverviewFlowchart } from "../../src/renderer/overview-flowchart.js";
 import { artifactOwnershipRule } from "../../src/linter/rules/artifact-ownership.js";
@@ -1149,5 +1149,78 @@ describe("expandOutputPath", () => {
     const entity = { severity: "critical" };
     const result = expandOutputPath("guardrails/{guardrail.id}/{guardrail.severity}.md", "guardrail", "no-force-push", entity);
     expect(result).toBe("guardrails/no-force-push/critical.md");
+  });
+});
+
+describe("hasUnresolvedPathVars", () => {
+  it("returns false for fully resolved path", () => {
+    expect(hasUnresolvedPathVars("out/my-agent/file.md")).toBe(false);
+  });
+
+  it("returns true for path with unresolved variable", () => {
+    expect(hasUnresolvedPathVars("../{agent.x-claude-path}/CLAUDE.md")).toBe(true);
+  });
+
+  it("returns true for path with multiple unresolved variables", () => {
+    expect(hasUnresolvedPathVars("{agent.x-path}/{agent.name}/file.md")).toBe(true);
+  });
+
+  it("returns false for path with no braces", () => {
+    expect(hasUnresolvedPathVars("simple/path/file.md")).toBe(false);
+  });
+});
+
+describe("renderFromConfig - unresolved path skipping", () => {
+  it("skips rendering when output path has unresolved variables", async () => {
+    const templatePath = join(outputDir, "skip-unresolved.hbs");
+    mkdirSync(outputDir, { recursive: true });
+    writeFileSync(templatePath, "content for {{agent.id}}", "utf8");
+
+    const dsl = DslSchema.parse({
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: ["implement"] },
+      agents: {
+        "agent-with-path": { role_name: "Dev", purpose: "dev", "x-claude-path": "packages/app" },
+        "agent-without-path": { role_name: "Reviewer", purpose: "review" },
+      },
+    });
+
+    const targets: ResolvedRenderTarget[] = [
+      {
+        template: templatePath,
+        context: "agent",
+        output: join(outputDir, "{agent.x-claude-path}/CLAUDE.md"),
+      },
+    ];
+
+    const files = await renderFromConfig(dsl, targets);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toContain("packages/app/CLAUDE.md");
+  });
+
+  it("renders all agents when all paths resolve", async () => {
+    const templatePath = join(outputDir, "all-resolve.hbs");
+    mkdirSync(outputDir, { recursive: true });
+    writeFileSync(templatePath, "hi {{agent.id}}", "utf8");
+
+    const dsl = DslSchema.parse({
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: ["implement"] },
+      agents: {
+        "a1": { role_name: "Dev", purpose: "dev", "x-claude-path": "pkg/a" },
+        "a2": { role_name: "QA", purpose: "qa", "x-claude-path": "pkg/b" },
+      },
+    });
+
+    const targets: ResolvedRenderTarget[] = [
+      {
+        template: templatePath,
+        context: "agent",
+        output: join(outputDir, "{agent.x-claude-path}/out.md"),
+      },
+    ];
+
+    const files = await renderFromConfig(dsl, targets);
+    expect(files).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

- Skip rendering when `expandOutputPath` leaves unresolved `{context.field}` patterns (e.g. `{agent.x-claude-path}` undefined for an entity)
- Default behavior — no opt-in flag needed
- Only checks entity context patterns (agent, task, guardrail, etc.), not path-resolution vars like `{out}`
- Applied to all render call sites: renderer, drift checker, guardrail-generator

## Test plan

- [x] `hasUnresolvedPathVars` unit tests (resolved vs unresolved paths)
- [x] `renderFromConfig` integration test: agents with/without `x-claude-path` — only resolved agents generate files
- [x] All 771 tests pass including guardrail-generator tests (no regression on `{out}` path vars)

Closes #77

Made with [Cursor](https://cursor.com)