### PR TITLE
feat: deprecate bidirectional cross-references (v0.24.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.23.3",
+  "version": "0.24.0",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/linter/rules/artifact-ownership.ts
+++ b/src/linter/rules/artifact-ownership.ts
@@ -16,7 +16,7 @@ export const artifactOwnershipRule: LintRule = {
       for (const step of task.execution_steps) {
         if (step.produces_artifact) {
           const artifact = dsl.artifacts[step.produces_artifact];
-          if (artifact) {
+          if (artifact && (artifact.producers.length > 0 || artifact.editors.length > 0)) {
             const canWrite =
               artifact.producers.includes(agentId) ||
               artifact.editors.includes(agentId);
@@ -33,7 +33,7 @@ export const artifactOwnershipRule: LintRule = {
 
         if (step.reads_artifact) {
           const artifact = dsl.artifacts[step.reads_artifact];
-          if (artifact) {
+          if (artifact && (artifact.consumers.length > 0 || artifact.producers.length > 0 || artifact.editors.length > 0)) {
             const canRead =
               artifact.consumers.includes(agentId) ||
               artifact.producers.includes(agentId) ||

--- a/src/linter/spectral/ruleset.ts
+++ b/src/linter/spectral/ruleset.ts
@@ -24,9 +24,9 @@ const ruleset: RulesetDefinition = {
     },
 
     "artifact-producers-ref": {
-      description: "Artifact producers must reference existing agents",
+      description: "(deprecated) Artifact producers must reference existing agents",
       message: "{{error}}",
-      severity: "error",
+      severity: "warn",
       given: "$.artifacts.*",
       then: {
         field: "producers",
@@ -36,9 +36,9 @@ const ruleset: RulesetDefinition = {
     },
 
     "artifact-editors-ref": {
-      description: "Artifact editors must reference existing agents",
+      description: "(deprecated) Artifact editors must reference existing agents",
       message: "{{error}}",
-      severity: "error",
+      severity: "warn",
       given: "$.artifacts.*",
       then: {
         field: "editors",
@@ -48,9 +48,9 @@ const ruleset: RulesetDefinition = {
     },
 
     "artifact-consumers-ref": {
-      description: "Artifact consumers must reference existing agents",
+      description: "(deprecated) Artifact consumers must reference existing agents",
       message: "{{error}}",
-      severity: "error",
+      severity: "warn",
       given: "$.artifacts.*",
       then: {
         field: "consumers",
@@ -246,9 +246,9 @@ const ruleset: RulesetDefinition = {
     // ========== 15.2.2 Artifact responsibility integrity ==========
 
     "artifact-editors-not-empty": {
-      description: "Artifact editors must not be empty (15.2.2)",
+      description: "(deprecated) Artifact editors must not be empty (15.2.2)",
       message: "{{error}}",
-      severity: "error",
+      severity: "info",
       given: "$.artifacts.*.editors",
       then: {
         function: editorsNotEmpty,

--- a/src/schema/artifact.ts
+++ b/src/schema/artifact.ts
@@ -4,15 +4,20 @@ export const ArtifactSchema = z
   .object({
     type: z.string(),
     description: z.string().optional(),
-    owner: z.string(),
-    producers: z.array(z.string()),
-    editors: z.array(z.string()),
-    consumers: z.array(z.string()),
-    states: z.array(z.string()),
+    owner: z.string().optional(),
+    producers: z.array(z.string()).default([]),
+    editors: z.array(z.string()).default([]),
+    consumers: z.array(z.string()).default([]),
+    states: z.array(z.string()).default([]),
     required_validations: z.array(z.string()).default([]),
     visibility: z.string().optional(),
     classification: z.string().optional(),
     guardrails: z.array(z.string()).optional(),
+    authority: z.enum(["canonical", "derived", "generated", "control"]).optional(),
+    path_patterns: z.array(z.string()).optional(),
+    exclude_patterns: z.array(z.string()).optional(),
+    manual_edit: z.enum(["allowed", "discouraged", "forbidden"]).optional(),
+    change_control: z.enum(["none", "approval-required", "regeneration-required"]).optional(),
   })
   .passthrough();
 export type Artifact = z.infer<typeof ArtifactSchema>;

--- a/src/schema/tool.ts
+++ b/src/schema/tool.ts
@@ -15,7 +15,7 @@ export const ToolSchema = z
     description: z.string().optional(),
     input_artifacts: z.array(z.string()).default([]),
     output_artifacts: z.array(z.string()).default([]),
-    invokable_by: z.array(z.string()),
+    invokable_by: z.array(z.string()).default([]),
     side_effects: z.array(z.string()).default([]),
     commands: z.array(CommandSchema).default([]),
     guardrails: z.array(z.string()).optional(),

--- a/src/scorer/scorer.ts
+++ b/src/scorer/scorer.ts
@@ -199,76 +199,6 @@ function schemaCompleteness(dsl: Dsl): DimensionResult {
   };
 }
 
-function crossReferenceBidirectionality(dsl: Dsl): DimensionResult {
-  let totalChecks = 0;
-  let passedChecks = 0;
-  const issues: string[] = [];
-
-  for (const [agentId, agent] of Object.entries(dsl.agents)) {
-    for (const toolId of agent.can_execute_tools) {
-      totalChecks++;
-      const tool = dsl.tools[toolId];
-      if (tool && tool.invokable_by.includes(agentId)) {
-        passedChecks++;
-      } else {
-        issues.push(`agent ${agentId} → tool ${toolId}`);
-      }
-    }
-
-    for (const artId of agent.can_write_artifacts) {
-      totalChecks++;
-      const art = dsl.artifacts[artId];
-      if (
-        art &&
-        (art.producers.includes(agentId) || art.editors.includes(agentId))
-      ) {
-        passedChecks++;
-      } else {
-        issues.push(`agent ${agentId} → artifact ${artId} (write)`);
-      }
-    }
-
-    for (const artId of agent.can_read_artifacts) {
-      totalChecks++;
-      const art = dsl.artifacts[artId];
-      if (
-        art &&
-        (art.consumers.includes(agentId) ||
-          art.producers.includes(agentId) ||
-          art.editors.includes(agentId))
-      ) {
-        passedChecks++;
-      } else {
-        issues.push(`agent ${agentId} → artifact ${artId} (read)`);
-      }
-    }
-  }
-
-  for (const [toolId, tool] of Object.entries(dsl.tools)) {
-    for (const agentId of tool.invokable_by) {
-      totalChecks++;
-      const agent = dsl.agents[agentId];
-      if (agent && agent.can_execute_tools.includes(toolId)) {
-        passedChecks++;
-      } else {
-        issues.push(`tool ${toolId} → agent ${agentId}`);
-      }
-    }
-  }
-
-  return {
-    id: "cross-reference-bidirectionality",
-    label: "Cross-reference bidirectionality",
-    score: passedChecks,
-    total: totalChecks,
-    percent: pct(passedChecks, totalChecks),
-    weight: 2,
-    recommendations:
-      issues.length > 0
-        ? [`${issues.length} unreciprocated cross-references: ${issues.slice(0, 5).join(", ")}${issues.length > 5 ? `, ... (${issues.length - 5} more)` : ""}`]
-        : [],
-  };
-}
 
 function entityGuardrailCoverage(dsl: Dsl): DimensionResult {
   const entitySections: Array<{ name: string; entities: Record<string, { guardrails?: string[] }> }> = [
@@ -376,7 +306,6 @@ export function score(dsl: Dsl): ScoreResult {
     guardrailPolicyCoverage(dsl),
     workflowValidationIntegration(dsl),
     schemaCompleteness(dsl),
-    crossReferenceBidirectionality(dsl),
     guardrailScopeResolution(dsl),
     entityGuardrailCoverage(dsl),
   ];

--- a/src/validator/reference-resolver.ts
+++ b/src/validator/reference-resolver.ts
@@ -57,15 +57,23 @@ export function checkReferences(dsl: Dsl): ReferenceDiagnostic[] {
   }
 
   for (const [id, art] of Object.entries(dsl.artifacts)) {
-    checkExists(art.owner, agentIds, "agents", `artifacts.${id}.owner`);
-    for (const ref of art.producers) {
-      checkExists(ref, agentIds, "agents", `artifacts.${id}.producers`);
+    if (art.owner) {
+      checkExists(art.owner, agentIds, "agents", `artifacts.${id}.owner`);
     }
-    for (const ref of art.editors) {
-      checkExists(ref, agentIds, "agents", `artifacts.${id}.editors`);
+    if (art.producers.length > 0) {
+      for (const ref of art.producers) {
+        checkExists(ref, agentIds, "agents", `artifacts.${id}.producers`);
+      }
     }
-    for (const ref of art.consumers) {
-      checkExists(ref, agentIds, "agents", `artifacts.${id}.consumers`);
+    if (art.editors.length > 0) {
+      for (const ref of art.editors) {
+        checkExists(ref, agentIds, "agents", `artifacts.${id}.editors`);
+      }
+    }
+    if (art.consumers.length > 0) {
+      for (const ref of art.consumers) {
+        checkExists(ref, agentIds, "agents", `artifacts.${id}.consumers`);
+      }
     }
     for (const ref of art.required_validations) {
       checkExists(ref, validationIds, "validations", `artifacts.${id}.required_validations`);
@@ -73,13 +81,15 @@ export function checkReferences(dsl: Dsl): ReferenceDiagnostic[] {
   }
 
   for (const [id, art] of Object.entries(dsl.artifacts)) {
-    const ownerAgent = dsl.agents[art.owner];
-    if (ownerAgent && !ownerAgent.can_read_artifacts.includes(id)) {
-      diagnostics.push({
-        path: `artifacts.${id}.owner`,
-        message: `Agent "${art.owner}" owns artifact "${id}" but cannot read it (missing from can_read_artifacts)`,
-        code: "artifact-owner-no-read",
-      });
+    if (art.owner) {
+      const ownerAgent = dsl.agents[art.owner];
+      if (ownerAgent && !ownerAgent.can_read_artifacts.includes(id)) {
+        diagnostics.push({
+          path: `artifacts.${id}.owner`,
+          message: `Agent "${art.owner}" owns artifact "${id}" but cannot read it (missing from can_read_artifacts)`,
+          code: "artifact-owner-no-read",
+        });
+      }
     }
     for (const valId of art.required_validations) {
       const validation = dsl.validations[valId];
@@ -97,8 +107,10 @@ export function checkReferences(dsl: Dsl): ReferenceDiagnostic[] {
   }
 
   for (const [id, tool] of Object.entries(dsl.tools)) {
-    for (const ref of tool.invokable_by) {
-      checkExists(ref, agentIds, "agents", `tools.${id}.invokable_by`);
+    if (tool.invokable_by.length > 0) {
+      for (const ref of tool.invokable_by) {
+        checkExists(ref, agentIds, "agents", `tools.${id}.invokable_by`);
+      }
     }
   }
 

--- a/test/scorer/scorer.test.ts
+++ b/test/scorer/scorer.test.ts
@@ -33,10 +33,10 @@ describe("score()", () => {
     expect(result.overall).toBeLessThanOrEqual(100);
   });
 
-  it("returns 8 dimensions", () => {
+  it("returns 7 dimensions", () => {
     const dsl = makeDsl({});
     const result = score(dsl);
-    expect(result.dimensions).toHaveLength(8);
+    expect(result.dimensions).toHaveLength(7);
   });
 
   it("returns 100 for an empty DSL (no entities = nothing to check)", () => {
@@ -253,28 +253,6 @@ describe("schema-completeness", () => {
   });
 });
 
-describe("cross-reference-bidirectionality", () => {
-  it("scores 100% when all refs are reciprocated", () => {
-    const dsl = makeDsl({
-      agents: { a1: { role_name: "R", purpose: "P", can_execute_tools: ["t1"], can_write_artifacts: ["art1"] } },
-      tools: { t1: { kind: "cli", invokable_by: ["a1"] } },
-      artifacts: { art1: { type: "code", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] } },
-    });
-    const d = dim(score(dsl), "cross-reference-bidirectionality");
-    expect(d.percent).toBe(100);
-    expect(d.recommendations).toHaveLength(0);
-  });
-
-  it("detects unreciprocated agent→tool reference", () => {
-    const dsl = makeDsl({
-      agents: { a1: { role_name: "R", purpose: "P", can_execute_tools: ["t1"] } },
-      tools: { t1: { kind: "cli", invokable_by: [] } },
-    });
-    const d = dim(score(dsl), "cross-reference-bidirectionality");
-    expect(d.percent).toBeLessThan(100);
-    expect(d.recommendations[0]).toContain("agent a1");
-  });
-});
 
 describe("guardrail-scope-resolution", () => {
   it("scores 100% when all scope entries resolve", () => {
@@ -341,7 +319,7 @@ describe("score on full fixture", () => {
     const result = score(dsl);
     expect(result.overall).toBeGreaterThanOrEqual(0);
     expect(result.overall).toBeLessThanOrEqual(100);
-    expect(result.dimensions).toHaveLength(8);
+    expect(result.dimensions).toHaveLength(7);
     for (const d of result.dimensions) {
       expect(d.percent).toBeGreaterThanOrEqual(0);
       expect(d.percent).toBeLessThanOrEqual(100);


### PR DESCRIPTION
## Summary

- Deprecate artifact `producers`/`consumers`/`editors` (default to `[]`) and `owner` (optional) — aligning with artifact-contracts design
- Deprecate tool `invokable_by` (default to `[]`)
- Add optional artifact-contracts fields (`authority`, `path_patterns`, `exclude_patterns`, `manual_edit`, `change_control`)
- Remove `crossReferenceBidirectionality` scorer dimension (8→7 dimensions)
- Add guards in reference-resolver for deprecated fields (skip validation when empty)
- Relax spectral lint rules for deprecated fields (`error`→`warn`/`info`)
- Skip `artifact-ownership` lint checks when deprecated fields are all empty

## Test plan

- [x] All 769 unit tests pass
- [x] Build succeeds
- [x] Scorer now returns 7 dimensions
- [x] Artifacts/tools without deprecated fields parse without errors


Made with [Cursor](https://cursor.com)