### PR TITLE
fix: relax remaining deprecated field lint rules (v0.24.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/linter/rules/task-agent-binding.ts
+++ b/src/linter/rules/task-agent-binding.ts
@@ -86,10 +86,10 @@ export const taskAgentBindingRule: LintRule = {
             });
           }
           const tool = dsl.tools[step.uses_tool];
-          if (tool && !tool.invokable_by.includes(task.target_agent)) {
+          if (tool && tool.invokable_by.length > 0 && !tool.invokable_by.includes(task.target_agent)) {
             diagnostics.push({
               ruleId: "task-agent-binding",
-              severity: "error",
+              severity: "warning",
               path: `tasks.${taskId}.execution_steps`,
               message: `Task "${taskId}" step uses_tool "${step.uses_tool}" but tool's invokable_by does not include "${task.target_agent}"`,
             });

--- a/src/linter/rules/tool-execution.ts
+++ b/src/linter/rules/tool-execution.ts
@@ -17,10 +17,10 @@ export const toolExecutionRule: LintRule = {
     for (const [agentId, agent] of Object.entries(dsl.agents)) {
       for (const toolId of agent.can_execute_tools) {
         const invokableBy = toolInvokableBy.get(toolId);
-        if (invokableBy && !invokableBy.has(agentId)) {
+        if (invokableBy && invokableBy.size > 0 && !invokableBy.has(agentId)) {
           diagnostics.push({
             ruleId: "tool-execution",
-            severity: "error",
+            severity: "warning",
             path: `agents.${agentId}.can_execute_tools`,
             message: `Agent "${agentId}" has can_execute_tools "${toolId}" but tool's invokable_by does not include "${agentId}"`,
           });
@@ -29,12 +29,13 @@ export const toolExecutionRule: LintRule = {
     }
 
     for (const [toolId, tool] of Object.entries(dsl.tools)) {
+      if (tool.invokable_by.length === 0) continue;
       for (const agentId of tool.invokable_by) {
         const agent = dsl.agents[agentId];
         if (agent && !agent.can_execute_tools.includes(toolId)) {
           diagnostics.push({
             ruleId: "tool-execution",
-            severity: "error",
+            severity: "warning",
             path: `tools.${toolId}.invokable_by`,
             message: `Tool "${toolId}" has invokable_by "${agentId}" but agent's can_execute_tools does not include "${toolId}"`,
           });

--- a/src/linter/spectral/ruleset.ts
+++ b/src/linter/spectral/ruleset.ts
@@ -232,9 +232,9 @@ const ruleset: RulesetDefinition = {
     },
 
     "tool-invokable-by-ref": {
-      description: "Tool invokable_by must reference existing agents",
+      description: "(deprecated) Tool invokable_by must reference existing agents",
       message: "{{error}}",
-      severity: "error",
+      severity: "warn",
       given: "$.tools.*",
       then: {
         field: "invokable_by",
@@ -256,8 +256,8 @@ const ruleset: RulesetDefinition = {
     },
 
     "artifact-owner-exists": {
-      description: "Every artifact must have an owner",
-      severity: "error",
+      description: "(deprecated) Every artifact must have an owner",
+      severity: "warn",
       given: "$.artifacts.*",
       then: {
         field: "owner",

--- a/test/linter/linter.test.ts
+++ b/test/linter/linter.test.ts
@@ -132,11 +132,20 @@ describe("validationCoverageRule", () => {
 describe("toolExecutionRule", () => {
   it("detects can_execute_tools ↔ invokable_by mismatch (agent side)", () => {
     const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_execute_tools: ["t1"] }, a2: { role_name: "R2", purpose: "P2" } },
+      tools: { t1: { kind: "cli", invokable_by: ["a2"] } },
+    });
+    const diags = toolExecutionRule.run(dsl);
+    expect(diags.some((d) => d.message.includes("invokable_by does not include"))).toBe(true);
+  });
+
+  it("skips invokable_by check when invokable_by is empty (deprecated)", () => {
+    const dsl = makeDsl({
       agents: { a1: { role_name: "R", purpose: "P", can_execute_tools: ["t1"] } },
       tools: { t1: { kind: "cli", invokable_by: [] } },
     });
     const diags = toolExecutionRule.run(dsl);
-    expect(diags.some((d) => d.message.includes("invokable_by does not include"))).toBe(true);
+    expect(diags.some((d) => d.message.includes("invokable_by does not include"))).toBe(false);
   });
 
   it("detects invokable_by ↔ can_execute_tools mismatch (tool side)", () => {
@@ -289,6 +298,26 @@ describe("taskAgentBindingRule", () => {
 
   it("detects uses_tool bidirectional mismatch (tool invokable_by missing target)", () => {
     const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_execute_tools: ["t1"], can_return_handoffs: ["h", "r"] }, a2: { role_name: "R2", purpose: "P2" } },
+      tools: { t1: { kind: "cli", invokable_by: ["a2"] } },
+      tasks: {
+        task1: {
+          description: "d", target_agent: "a1", allowed_from_agents: ["a1"],
+          workflow: "implement", input_artifacts: [], invocation_handoff: "h", result_handoff: "r",
+          execution_steps: [{ id: "s1", action: "Act", uses_tool: "t1" }],
+        },
+      },
+      handoff_types: {
+        h: { version: 1, schema: {} },
+        r: { version: 1, schema: {} },
+      },
+    });
+    const diags = taskAgentBindingRule.run(dsl);
+    expect(diags.some((d) => d.message.includes("invokable_by does not include"))).toBe(true);
+  });
+
+  it("skips invokable_by check when invokable_by is empty (deprecated)", () => {
+    const dsl = makeDsl({
       agents: { a1: { role_name: "R", purpose: "P", can_execute_tools: ["t1"], can_return_handoffs: ["h", "r"] } },
       tools: { t1: { kind: "cli", invokable_by: [] } },
       tasks: {
@@ -304,7 +333,7 @@ describe("taskAgentBindingRule", () => {
       },
     });
     const diags = taskAgentBindingRule.run(dsl);
-    expect(diags.some((d) => d.message.includes("invokable_by does not include"))).toBe(true);
+    expect(diags.some((d) => d.message.includes("invokable_by does not include"))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Fix lint rules that were not relaxed in v0.24.0 despite the corresponding schema fields being deprecated
- `artifact-owner-exists`: `error` → `warn` (owner is now optional)
- `tool-invokable-by-ref`: `error` → `warn` (invokable_by is deprecated)
- `tool-execution` custom rule: skip bidirectional check when `invokable_by` is empty, severity `error` → `warning`
- `task-agent-binding` custom rule: skip `invokable_by` check when empty, severity `error` → `warning`

## Test plan

- [x] All 771 unit tests pass
- [x] Build succeeds
- [x] New tests verify deprecated-empty skip behavior


Made with [Cursor](https://cursor.com)