### PR TITLE
feat: artifact-contracts Phase 3-5 integration (v0.25.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/linter/index.ts
+++ b/src/linter/index.ts
@@ -6,6 +6,7 @@ export { toolExecutionRule } from "./rules/tool-execution.js";
 export { taskAgentBindingRule } from "./rules/task-agent-binding.js";
 export { mergeIntegrityRule } from "./rules/merge-integrity.js";
 export { artifactOwnershipRule } from "./rules/artifact-ownership.js";
+export { artifactOwnershipConsistencyRule } from "./rules/artifact-ownership-consistency.js";
 export { toolCommandsRule } from "./rules/tool-commands.js";
 export { guardrailPolicyCoverageRule } from "./rules/guardrail-policy-coverage.js";
 export { yamlReservedKeySafetyRule } from "./rules/yaml-reserved-key-safety.js";

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -17,6 +17,7 @@ import {
   guardrailOrphanedRule,
 } from "./rules/entity-guardrail-binding.js";
 import { validationExecutorNoContextRule } from "./rules/validation-executor-no-context.js";
+import { artifactOwnershipConsistencyRule } from "./rules/artifact-ownership-consistency.js";
 import {
   extensionDeclaredButUnusedRule,
   extensionScopeMismatchRule,
@@ -39,6 +40,7 @@ const builtinRules: LintRule[] = [
   entityNoGuardrailsRule,
   guardrailOrphanedRule,
   validationExecutorNoContextRule,
+  artifactOwnershipConsistencyRule,
   extensionDeclaredButUnusedRule,
   extensionScopeMismatchRule,
   extensionUndeclaredUsageRule,

--- a/src/linter/rules/artifact-ownership-consistency.ts
+++ b/src/linter/rules/artifact-ownership-consistency.ts
@@ -1,0 +1,40 @@
+import type { Dsl } from "../../schema/index.js";
+import type { LintRule, LintDiagnostic } from "../types.js";
+
+export const artifactOwnershipConsistencyRule: LintRule = {
+  id: "artifact-ownership-consistency",
+  description:
+    "Ensure own_artifacts entries are included in can_read_artifacts and check deprecated owner field consistency",
+
+  run(dsl: Dsl): LintDiagnostic[] {
+    const diagnostics: LintDiagnostic[] = [];
+
+    for (const [agentId, agent] of Object.entries(dsl.agents)) {
+      for (const artId of agent.own_artifacts) {
+        if (!agent.can_read_artifacts.includes(artId)) {
+          diagnostics.push({
+            ruleId: "artifact-ownership-consistency",
+            severity: "warning",
+            path: `agents.${agentId}.own_artifacts`,
+            message: `Agent "${agentId}" owns artifact "${artId}" but does not include it in can_read_artifacts`,
+          });
+        }
+      }
+    }
+
+    for (const [artId, art] of Object.entries(dsl.artifacts)) {
+      if (!art.owner) continue;
+      const ownerAgent = dsl.agents[art.owner];
+      if (ownerAgent && !ownerAgent.own_artifacts.includes(artId)) {
+        diagnostics.push({
+          ruleId: "artifact-ownership-consistency",
+          severity: "warning",
+          path: `artifacts.${artId}.owner`,
+          message: `Artifact "${artId}" has deprecated owner "${art.owner}" but agent does not list it in own_artifacts`,
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/src/linter/rules/tool-execution.ts
+++ b/src/linter/rules/tool-execution.ts
@@ -60,9 +60,9 @@ export const toolExecutionRule: LintRule = {
     }
 
     for (const [valId, val] of Object.entries(dsl.validations)) {
-      if (val.executor_type !== "tool") continue;
+      if (val.executor_type !== "tool" || !val.executor) continue;
       const hasExecutor = Object.values(dsl.agents).some((a) =>
-        a.can_execute_tools.includes(val.executor),
+        a.can_execute_tools.includes(val.executor!),
       );
       if (!hasExecutor) {
         diagnostics.push({

--- a/src/linter/rules/validation-executor-no-context.ts
+++ b/src/linter/rules/validation-executor-no-context.ts
@@ -15,6 +15,7 @@ export const validationExecutorNoContextRule: LintRule = {
     const diagnostics: LintDiagnostic[] = [];
 
     for (const [validationId, val] of Object.entries(dsl.validations)) {
+      if (!val.executor) continue;
       if (val.executor_type === "agent") {
         const agent = dsl.agents[val.executor];
         if (!agent) continue;

--- a/src/renderer/context.ts
+++ b/src/renderer/context.ts
@@ -69,7 +69,7 @@ export interface EntityValidationEntry {
   validation_id: string;
   kind: string;
   target_artifact: string;
-  executor_type: string;
+  executor_type?: string;
   blocking: boolean;
   produces_evidence?: string;
 }

--- a/src/renderer/overview-flowchart.ts
+++ b/src/renderer/overview-flowchart.ts
@@ -57,9 +57,9 @@ function collectPhaseOps(dsl: Dsl, wfId: string): PhaseOps {
     } else if (step.type === "validation") {
       const val = dsl.validations[step.validation];
       if (val) {
-        if (val.executor_type === "agent") {
+        if (val.executor_type === "agent" && val.executor) {
           addOp(agentOps, val.executor, "validate");
-        } else {
+        } else if (val.executor) {
           addOp(toolOps, val.executor, "verification");
         }
         addOp(artifactOps, val.target_artifact, "V");

--- a/src/renderer/sequence-diagram.ts
+++ b/src/renderer/sequence-diagram.ts
@@ -96,8 +96,8 @@ function collectReferencedIds(
     } else if (step.type === "validation") {
       const val = dsl.validations[step.validation];
       if (val) {
-        if (val.executor_type === "agent") addAgent(val.executor);
-        else tools.add(val.executor);
+        if (val.executor && val.executor_type === "agent") addAgent(val.executor);
+        else if (val.executor) tools.add(val.executor);
         artifacts.add(val.target_artifact);
       }
     }

--- a/src/schema/agent.ts
+++ b/src/schema/agent.ts
@@ -49,6 +49,7 @@ export const AgentSchema = z
   .object({
     role_name: z.string(),
     purpose: z.string(),
+    own_artifacts: z.array(z.string()).default([]),
     can_read_artifacts: z.array(z.string()).default([]),
     can_write_artifacts: z.array(z.string()).default([]),
     can_execute_tools: z.array(z.string()).default([]),

--- a/src/schema/task.ts
+++ b/src/schema/task.ts
@@ -11,6 +11,8 @@ export const ExecutionStepSchema = z
     uses_tool: z.string().optional(),
     produces_artifact: z.string().optional(),
     reads_artifact: z.string().optional(),
+    validates_artifact: z.string().optional(),
+    validation_kind: z.enum(["schema", "mechanical", "semantic", "approval", "provenance", "traceability", "fidelity"]).optional(),
     depends_on: z.array(z.string()).optional(),
     skip_condition: z.string().optional(),
     wait_for_approval: z.boolean().optional(),

--- a/src/schema/tool.ts
+++ b/src/schema/tool.ts
@@ -16,6 +16,8 @@ export const ToolSchema = z
     input_artifacts: z.array(z.string()).default([]),
     output_artifacts: z.array(z.string()).default([]),
     invokable_by: z.array(z.string()).default([]),
+    cli_contract: z.string().optional(),
+    artifact_bindings: z.record(z.string(), z.string()).default({}),
     side_effects: z.array(z.string()).default([]),
     commands: z.array(CommandSchema).default([]),
     guardrails: z.array(z.string()).optional(),

--- a/src/schema/validation.ts
+++ b/src/schema/validation.ts
@@ -4,8 +4,8 @@ export const ValidationSchema = z
   .object({
     target_artifact: z.string(),
     kind: z.enum(["schema", "mechanical", "semantic", "approval", "provenance", "traceability", "fidelity"]),
-    executor_type: z.enum(["tool", "agent"]),
-    executor: z.string(),
+    executor_type: z.enum(["tool", "agent"]).optional(),
+    executor: z.string().optional(),
     blocking: z.boolean(),
     produces_evidence: z.string().optional(),
     description: z.string().optional(),

--- a/src/validator/reference-resolver.ts
+++ b/src/validator/reference-resolver.ts
@@ -36,6 +36,9 @@ export function checkReferences(dsl: Dsl): ReferenceDiagnostic[] {
   }
 
   for (const [id, agent] of Object.entries(dsl.agents)) {
+    for (const ref of agent.own_artifacts) {
+      checkExists(ref, artifactIds, "artifacts", `agents.${id}.own_artifacts`);
+    }
     for (const ref of agent.can_read_artifacts) {
       checkExists(ref, artifactIds, "artifacts", `agents.${id}.can_read_artifacts`);
     }
@@ -93,7 +96,7 @@ export function checkReferences(dsl: Dsl): ReferenceDiagnostic[] {
     }
     for (const valId of art.required_validations) {
       const validation = dsl.validations[valId];
-      if (validation?.executor_type === "tool") {
+      if (validation?.executor_type === "tool" && validation.executor) {
         const tool = dsl.tools[validation.executor];
         if (tool && tool.invokable_by.length === 0) {
           diagnostics.push({
@@ -112,13 +115,16 @@ export function checkReferences(dsl: Dsl): ReferenceDiagnostic[] {
         checkExists(ref, agentIds, "agents", `tools.${id}.invokable_by`);
       }
     }
+    for (const ref of Object.values(tool.artifact_bindings)) {
+      checkExists(ref, artifactIds, "artifacts", `tools.${id}.artifact_bindings`);
+    }
   }
 
   for (const [id, val] of Object.entries(dsl.validations)) {
     checkExists(val.target_artifact, artifactIds, "artifacts", `validations.${id}.target_artifact`);
-    if (val.executor_type === "tool") {
+    if (val.executor_type === "tool" && val.executor) {
       checkExists(val.executor, toolIds, "tools", `validations.${id}.executor`);
-    } else if (val.executor_type === "agent") {
+    } else if (val.executor_type === "agent" && val.executor) {
       checkExists(val.executor, agentIds, "agents", `validations.${id}.executor`);
     }
   }


### PR DESCRIPTION
## Summary

- **Phase 3**: Add `own_artifacts` to AgentSchema (replaces deprecated artifact.owner), add `artifact_bindings` and `cli_contract` to ToolSchema, validator reference checks, ownership consistency lint rule
- **Phase 5**: Add `validates_artifact`/`validation_kind` to ExecutionStepSchema, make `executor`/`executor_type` optional in ValidationSchema

## Test plan

- [x] All 771 unit tests pass
- [x] Build succeeds
- [x] No breaking changes (all new fields have defaults or are optional)


Made with [Cursor](https://cursor.com)