### PR TITLE
feat: handoff payload render helpers (v0.30.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1476,6 +1476,10 @@ Templates can use these built-in helpers:
 | `notEmpty` | `{{#if (notEmpty obj)}}` | True when object has at least one key |
 | `inc` | `{{inc @index}}` | Increment number by 1 (for 1-based indexing) |
 | `yamlBlock` | `{{{yamlBlock obj}}}` | Render value as YAML-formatted text |
+| `jsonBlock` | `{{{jsonBlock obj}}}` | Render value as pretty-printed JSON |
+| `yamlFrontmatter` | `{{{yamlFrontmatter obj}}}` | Render value as YAML frontmatter (`---` delimiters) |
+| `handoffPayload` | `(handoffPayload handoffType)` | Resolve handoff payload (`example` or schema skeleton) |
+| `handoffEnvelope` | `(handoffEnvelope handoffType id=@key)` | Build `{ type, version, payload }` envelope object |
 | `lookupPayloadFields` | `{{#each (lookupPayloadFields schema)}}` | Extract schema field info (name, type, required, enum); resolves `allOf` internally |
 | `join` | `{{join arr ", "}}` | Join array elements with separator |
 | `contains` | `{{#if (contains arr "x")}}` | True when array includes value |

--- a/dsl_base/agents/dsl-designer.yaml
+++ b/dsl_base/agents/dsl-designer.yaml
@@ -395,6 +395,10 @@ dsl-designer:
         | `notEmpty` | `{{#if (notEmpty obj)}}` | Check if object is non-empty |
         | `inc` | `{{inc @index}}` | 1-based index |
         | `yamlBlock` | `{{{yamlBlock obj}}}` | Render as YAML |
+        | `jsonBlock` | `{{{jsonBlock obj}}}` | Render as pretty JSON |
+        | `yamlFrontmatter` | `{{{yamlFrontmatter obj}}}` | Render as YAML frontmatter |
+        | `handoffPayload` | `(handoffPayload handoffType)` | Resolve handoff payload object |
+        | `handoffEnvelope` | `(handoffEnvelope handoffType id=@key)` | Build handoff envelope object |
         | `lookupPayloadFields` | `{{#each (lookupPayloadFields schema)}}` | Extract schema fields (resolves allOf) |
         | `join` | `{{join arr ", "}}` | Join array |
         | `contains` | `{{#if (contains arr "x")}}` | Array inclusion check |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-contracts",
-  "version": "0.30.1",
+  "version": "0.30.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-contracts",
-      "version": "0.30.1",
+      "version": "0.30.3",
       "license": "MIT",
       "dependencies": {
         "@stoplight/spectral-core": "^1.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/sample/templates/agent-prompt.md.hbs
+++ b/sample/templates/agent-prompt.md.hbs
@@ -32,6 +32,11 @@
     inc                  - {{inc @index}} — 1-based index (0 → 1, 1 → 2, ...)
     eq                   - {{#if (eq a b)}} — strict equality
     yamlBlock            - {{{yamlBlock obj}}} — render object as YAML text
+    jsonBlock            - {{{jsonBlock obj}}} — render object as pretty JSON
+    yamlFrontmatter      - {{{yamlFrontmatter obj}}} — render object as YAML frontmatter (--- delimiters)
+    handoffPayload       - (handoffPayload handoffType) — resolve example or schema skeleton payload
+    handoffEnvelope      - (handoffEnvelope handoffType) — { type, version, payload } envelope object
+                           Use id=@key when iterating relatedHandoffTypes without id field
     lookupPayloadFields  - {{#each (lookupPayloadFields schema)}} — extract field info
     join                 - {{join arr ", "}} — join array elements with separator
     contains             - {{#if (contains arr "x")}} — true when array includes value

--- a/sample/templates/overview.md.hbs
+++ b/sample/templates/overview.md.hbs
@@ -20,6 +20,10 @@
     inc                  - {{inc @index}} — 1-based index (0 → 1, 1 → 2, ...)
     eq                   - {{#if (eq a b)}} — strict equality
     yamlBlock            - {{{yamlBlock obj}}} — render object as YAML text
+    jsonBlock            - {{{jsonBlock obj}}} — render object as pretty JSON
+    yamlFrontmatter      - {{{yamlFrontmatter obj}}} — YAML frontmatter with --- delimiters
+    handoffPayload       - (handoffPayload handoffType) — example or schema skeleton payload
+    handoffEnvelope      - (handoffEnvelope handoffType id=@key) — { type, version, payload }
     lookupPayloadFields  - {{#each (lookupPayloadFields schema)}} — extract field info
     join                 - {{join arr ", "}} — join array elements with separator
     contains             - {{#if (contains arr "x")}} — true when array includes value

--- a/src/renderer/handoff-payload.ts
+++ b/src/renderer/handoff-payload.ts
@@ -1,0 +1,121 @@
+import { resolveAllOf } from "../schema/index.js";
+
+type AnyRecord = Record<string, unknown>;
+
+export interface HandoffTypeLike {
+  id?: string;
+  version?: number;
+  schema?: AnyRecord;
+  example?: AnyRecord;
+}
+
+/**
+ * Resolve the payload object for a handoff type.
+ * Uses `example` when defined; otherwise generates a skeleton from `schema`.
+ */
+export function resolveHandoffPayload(
+  handoffType: HandoffTypeLike | null | undefined,
+): AnyRecord {
+  if (!handoffType) return {};
+  if (
+    handoffType.example &&
+    typeof handoffType.example === "object" &&
+    !Array.isArray(handoffType.example)
+  ) {
+    return handoffType.example;
+  }
+  if (handoffType.schema && typeof handoffType.schema === "object") {
+    return exampleFromSchema(handoffType.schema);
+  }
+  return {};
+}
+
+/**
+ * Build a handoff envelope `{ type, version, payload }` suitable for
+ * runtime invocation files and documentation.
+ */
+export function buildHandoffEnvelope(
+  handoffType: HandoffTypeLike | null | undefined,
+  idOverride?: string,
+): AnyRecord {
+  if (!handoffType) return {};
+  const type = idOverride ?? handoffType.id;
+  return {
+    ...(type ? { type } : {}),
+    ...(handoffType.version !== undefined ? { version: handoffType.version } : {}),
+    payload: resolveHandoffPayload(handoffType),
+  };
+}
+
+function exampleFromSchema(schema: AnyRecord): AnyRecord {
+  const effective = resolveAllOf(schema);
+  if (
+    effective["$ref"] &&
+    !effective["properties"] &&
+    !effective["type"]
+  ) {
+    return {};
+  }
+  return exampleFromJsonSchema(effective);
+}
+
+function exampleFromJsonSchema(schema: AnyRecord): AnyRecord {
+  const type = schema["type"];
+  if (type === "object" || schema["properties"]) {
+    return exampleFromObjectSchema(schema);
+  }
+  return {};
+}
+
+function exampleFromObjectSchema(schema: AnyRecord): AnyRecord {
+  const props = schema["properties"] as AnyRecord | undefined;
+  if (!props) return {};
+
+  const required = new Set(
+    (schema["required"] as string[] | undefined) ?? [],
+  );
+  const result: AnyRecord = {};
+
+  for (const [key, propSchema] of Object.entries(props)) {
+    if (!required.has(key)) continue;
+    result[key] = exampleFromPropertySchema(
+      propSchema as AnyRecord,
+      key,
+    );
+  }
+
+  return result;
+}
+
+function exampleFromPropertySchema(
+  schema: AnyRecord,
+  propName: string,
+): unknown {
+  const effective = resolveAllOf(schema);
+
+  if (effective["example"] !== undefined) return effective["example"];
+  if (effective["const"] !== undefined) return effective["const"];
+
+  const enumVals = effective["enum"] as unknown[] | undefined;
+  if (enumVals && enumVals.length > 0) return enumVals[0];
+
+  const type = effective["type"];
+  if (type === "string" || (!type && effective["format"])) {
+    return `<${propName}>`;
+  }
+  if (type === "integer") return 0;
+  if (type === "number") return 0;
+  if (type === "boolean") return false;
+  if (type === "array") {
+    const items = effective["items"] as AnyRecord | undefined;
+    if (items && typeof items === "object") {
+      return [exampleFromPropertySchema(items, "item")];
+    }
+    return [];
+  }
+  if (type === "object" || effective["properties"]) {
+    return exampleFromObjectSchema(effective);
+  }
+
+  return null;
+}

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -41,3 +41,13 @@ export {
   resolveEffectiveGuardrails,
   resolveEntityValidations,
 } from "./context.js";
+export {
+  toYamlString,
+  toJsonString,
+  toYamlFrontmatter,
+} from "./serialization.js";
+export {
+  resolveHandoffPayload,
+  buildHandoffEnvelope,
+  type HandoffTypeLike,
+} from "./handoff-payload.js";

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -21,6 +21,11 @@ import {
 import { generateSequenceDiagram } from "./sequence-diagram.js";
 import { generateOverviewFlowchart } from "./overview-flowchart.js";
 import { buildNavigationIndex } from "../navigation-index/index.js";
+import { toYamlString, toJsonString, toYamlFrontmatter } from "./serialization.js";
+import {
+  resolveHandoffPayload,
+  buildHandoffEnvelope,
+} from "./handoff-payload.js";
 
 Handlebars.registerHelper("eq", (a: unknown, b: unknown) => a === b);
 
@@ -61,76 +66,36 @@ Handlebars.registerHelper(
   },
 );
 
-function toYamlLines(obj: unknown, indent: number): string[] {
-  const pad = "  ".repeat(indent);
-  if (obj === null || obj === undefined) return [`${pad}null`];
-  if (typeof obj === "boolean" || typeof obj === "number")
-    return [`${pad}${obj}`];
-  if (typeof obj === "string") {
-    if (obj.includes("\n")) {
-      const lines = [`${pad}|`];
-      for (const line of obj.split("\n")) {
-        lines.push(line === "" ? "" : `${pad}  ${line}`);
-      }
-      return lines;
-    }
-    return [`${pad}${JSON.stringify(obj)}`];
-  }
-  if (Array.isArray(obj)) {
-    const lines: string[] = [];
-    for (const item of obj) {
-      if (typeof item === "object" && item !== null && !Array.isArray(item)) {
-        const entries = Object.entries(item as Record<string, unknown>);
-        if (entries.length > 0) {
-          const [firstKey, firstVal] = entries[0];
-          const firstValLines = toYamlLines(firstVal, 0);
-          if (firstValLines.length === 1 && !firstValLines[0].includes("\n")) {
-            lines.push(`${pad}- ${firstKey}: ${firstValLines[0].trim()}`);
-          } else {
-            lines.push(`${pad}- ${firstKey}:`);
-            lines.push(...toYamlLines(firstVal, indent + 2));
-          }
-          for (let i = 1; i < entries.length; i++) {
-            const [k, v] = entries[i];
-            const vLines = toYamlLines(v, indent + 2);
-            if (vLines.length === 1) {
-              lines.push(`${pad}  ${k}: ${vLines[0].trim()}`);
-            } else {
-              lines.push(`${pad}  ${k}:`);
-              lines.push(...vLines);
-            }
-          }
-        } else {
-          lines.push(`${pad}- {}`);
-        }
-      } else {
-        const valLines = toYamlLines(item, 0);
-        lines.push(`${pad}- ${valLines[0].trim()}`);
-      }
-    }
-    return lines;
-  }
-  if (typeof obj === "object") {
-    const lines: string[] = [];
-    for (const [key, value] of Object.entries(
-      obj as Record<string, unknown>,
-    )) {
-      const valLines = toYamlLines(value, indent + 1);
-      if (valLines.length === 1 && !valLines[0].includes("|")) {
-        lines.push(`${pad}${key}: ${valLines[0].trim()}`);
-      } else {
-        lines.push(`${pad}${key}:`);
-        lines.push(...valLines);
-      }
-    }
-    return lines;
-  }
-  return [`${pad}${String(obj)}`];
-}
-
 Handlebars.registerHelper("yamlBlock", (obj: unknown): string => {
-  return toYamlLines(obj, 0).join("\n");
+  return toYamlString(obj);
 });
+
+Handlebars.registerHelper("jsonBlock", (obj: unknown): string => {
+  return toJsonString(obj);
+});
+
+Handlebars.registerHelper("yamlFrontmatter", (obj: unknown): string => {
+  return toYamlFrontmatter(obj);
+});
+
+Handlebars.registerHelper(
+  "handoffPayload",
+  (handoffType: Record<string, unknown> | null | undefined) => {
+    return resolveHandoffPayload(handoffType ?? undefined);
+  },
+);
+
+Handlebars.registerHelper(
+  "handoffEnvelope",
+  (
+    handoffType: Record<string, unknown> | null | undefined,
+    options?: { hash?: { id?: string } },
+  ) => {
+    const idOverride =
+      typeof options?.hash?.id === "string" ? options.hash.id : undefined;
+    return buildHandoffEnvelope(handoffType ?? undefined, idOverride);
+  },
+);
 
 Handlebars.registerHelper(
   "join",

--- a/src/renderer/serialization.ts
+++ b/src/renderer/serialization.ts
@@ -1,0 +1,83 @@
+function toYamlLines(obj: unknown, indent: number): string[] {
+  const pad = "  ".repeat(indent);
+  if (obj === null || obj === undefined) return [`${pad}null`];
+  if (typeof obj === "boolean" || typeof obj === "number")
+    return [`${pad}${obj}`];
+  if (typeof obj === "string") {
+    if (obj.includes("\n")) {
+      const lines = [`${pad}|`];
+      for (const line of obj.split("\n")) {
+        lines.push(line === "" ? "" : `${pad}  ${line}`);
+      }
+      return lines;
+    }
+    return [`${pad}${JSON.stringify(obj)}`];
+  }
+  if (Array.isArray(obj)) {
+    const lines: string[] = [];
+    for (const item of obj) {
+      if (typeof item === "object" && item !== null && !Array.isArray(item)) {
+        const entries = Object.entries(item as Record<string, unknown>);
+        if (entries.length > 0) {
+          const [firstKey, firstVal] = entries[0];
+          const firstValLines = toYamlLines(firstVal, 0);
+          if (firstValLines.length === 1 && !firstValLines[0].includes("\n")) {
+            lines.push(`${pad}- ${firstKey}: ${firstValLines[0].trim()}`);
+          } else {
+            lines.push(`${pad}- ${firstKey}:`);
+            lines.push(...toYamlLines(firstVal, indent + 2));
+          }
+          for (let i = 1; i < entries.length; i++) {
+            const [k, v] = entries[i];
+            const vLines = toYamlLines(v, indent + 2);
+            if (vLines.length === 1) {
+              lines.push(`${pad}  ${k}: ${vLines[0].trim()}`);
+            } else {
+              lines.push(`${pad}  ${k}:`);
+              lines.push(...vLines);
+            }
+          }
+        } else {
+          lines.push(`${pad}- {}`);
+        }
+      } else {
+        const valLines = toYamlLines(item, 0);
+        lines.push(`${pad}- ${valLines[0].trim()}`);
+      }
+    }
+    return lines;
+  }
+  if (typeof obj === "object") {
+    const lines: string[] = [];
+    for (const [key, value] of Object.entries(
+      obj as Record<string, unknown>,
+    )) {
+      const valLines = toYamlLines(value, indent + 1);
+      if (valLines.length === 1 && !valLines[0].includes("|")) {
+        lines.push(`${pad}${key}: ${valLines[0].trim()}`);
+      } else {
+        lines.push(`${pad}${key}:`);
+        lines.push(...valLines);
+      }
+    }
+    return lines;
+  }
+  return [`${pad}${String(obj)}`];
+}
+
+/** Render any value as YAML text (no surrounding ``` fences or frontmatter delimiters). */
+export function toYamlString(obj: unknown): string {
+  return toYamlLines(obj, 0).join("\n");
+}
+
+/** Render any value as pretty-printed JSON text. */
+export function toJsonString(obj: unknown, indent = 2): string {
+  return JSON.stringify(obj, null, indent);
+}
+
+/** Render any value as YAML frontmatter (`---` delimiters included). */
+export function toYamlFrontmatter(obj: unknown): string {
+  const body = toYamlString(obj);
+  if (!body) return "---\n---\n";
+  return `---\n${body}\n---\n`;
+}

--- a/test/renderer.test.ts
+++ b/test/renderer.test.ts
@@ -316,6 +316,90 @@ describe("Handlebars helpers", () => {
     expect(content).toBe("MANY");
   });
 
+  it("jsonBlock helper renders pretty JSON", async () => {
+    const tplPath = join(TEMP_DIR, "tpl", "json.hbs");
+    await writeFile(tplPath, "{{{jsonBlock agent}}}");
+    const outPattern = join(TEMP_DIR, "out", "{agent.id}.md");
+
+    const targets: ResolvedRenderTarget[] = [
+      { template: tplPath, context: "agent", output: outPattern },
+    ];
+    await renderFromConfig(createMinimalDsl(), targets);
+    const content = await readFile(join(TEMP_DIR, "out", "dev.md"), "utf8");
+    expect(content).toContain('"role_name": "Developer"');
+  });
+
+  it("yamlFrontmatter helper wraps YAML with delimiters", async () => {
+    const tplPath = join(TEMP_DIR, "tpl", "fm.hbs");
+    await writeFile(
+      tplPath,
+      "{{{yamlFrontmatter (handoffEnvelope handoff_type)}}}",
+    );
+    const outPattern = join(TEMP_DIR, "out", "{handoff_type.id}.md");
+
+    const dsl: Dsl = {
+      ...createMinimalDsl(),
+      handoff_types: {
+        "task-request": {
+          version: 1,
+          example: { task_id: "specify-feature" },
+          schema: { type: "object", properties: {} },
+        },
+      },
+    };
+    const targets: ResolvedRenderTarget[] = [
+      { template: tplPath, context: "handoff_type", output: outPattern },
+    ];
+    await renderFromConfig(dsl, targets);
+    const content = await readFile(
+      join(TEMP_DIR, "out", "task-request.md"),
+      "utf8",
+    );
+    expect(content).toMatch(/^---\n/);
+    expect(content).toContain('type: "task-request"');
+    expect(content).toMatch(/---\n$/);
+  });
+
+  it("handoffPayload and handoffEnvelope helpers render payload examples", async () => {
+    const tplPath = join(TEMP_DIR, "tpl", "handoff.hbs");
+    await writeFile(
+      tplPath,
+      [
+        "PAYLOAD:",
+        "{{{yamlBlock (handoffPayload handoff_type)}}}",
+        "ENVELOPE:",
+        "{{{jsonBlock (handoffEnvelope handoff_type)}}}",
+      ].join("\n"),
+    );
+    const outPattern = join(TEMP_DIR, "out", "{handoff_type.id}.md");
+
+    const dsl: Dsl = {
+      ...createMinimalDsl(),
+      handoff_types: {
+        "task-request": {
+          version: 1,
+          schema: {
+            type: "object",
+            required: ["task_id"],
+            properties: { task_id: { type: "string" } },
+          },
+          example: { task_id: "specify-feature" },
+        },
+      },
+    };
+    const targets: ResolvedRenderTarget[] = [
+      { template: tplPath, context: "handoff_type", output: outPattern },
+    ];
+    await renderFromConfig(dsl, targets);
+    const content = await readFile(
+      join(TEMP_DIR, "out", "task-request.md"),
+      "utf8",
+    );
+    expect(content).toContain('task_id: "specify-feature"');
+    expect(content).toContain('"type": "task-request"');
+    expect(content).toContain('"payload"');
+  });
+
   it("groupBy helper groups array elements by key", async () => {
     const tplPath = join(TEMP_DIR, "tpl", "group.hbs");
     const tplContent = [

--- a/test/renderer/serialization-handoff.test.ts
+++ b/test/renderer/serialization-handoff.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  toYamlString,
+  toJsonString,
+  toYamlFrontmatter,
+} from "../../src/renderer/serialization.js";
+import {
+  resolveHandoffPayload,
+  buildHandoffEnvelope,
+} from "../../src/renderer/handoff-payload.js";
+
+describe("serialization", () => {
+  it("toYamlString renders nested objects", () => {
+    expect(toYamlString({ task_id: "specify", nested: { a: 1 } })).toBe(
+      'task_id: "specify"\nnested: a: 1',
+    );
+  });
+
+  it("toJsonString pretty-prints JSON", () => {
+    expect(toJsonString({ a: 1, b: ["x"] })).toBe(
+      '{\n  "a": 1,\n  "b": [\n    "x"\n  ]\n}',
+    );
+  });
+
+  it("toYamlFrontmatter wraps content with delimiters", () => {
+    expect(toYamlFrontmatter({ type: "task-delegation", version: 1 })).toBe(
+      '---\ntype: "task-delegation"\nversion: 1\n---\n',
+    );
+  });
+
+  it("toYamlFrontmatter handles empty object", () => {
+    expect(toYamlFrontmatter({})).toBe("---\n---\n");
+  });
+});
+
+describe("handoff payload resolution", () => {
+  it("prefers example over schema skeleton", () => {
+    const payload = resolveHandoffPayload({
+      schema: {
+        type: "object",
+        required: ["task_id"],
+        properties: { task_id: { type: "string" } },
+      },
+      example: { task_id: "from-example" },
+    });
+    expect(payload).toEqual({ task_id: "from-example" });
+  });
+
+  it("generates skeleton from schema required fields", () => {
+    const payload = resolveHandoffPayload({
+      schema: {
+        type: "object",
+        required: ["task_id", "validation_result"],
+        properties: {
+          task_id: { type: "string" },
+          validation_result: { type: "string", enum: ["pass", "fail"] },
+          notes: { type: "string" },
+        },
+      },
+    });
+    expect(payload).toEqual({
+      task_id: "<task_id>",
+      validation_result: "pass",
+    });
+  });
+
+  it("resolves allOf composed schemas", () => {
+    const payload = resolveHandoffPayload({
+      schema: {
+        allOf: [
+          {
+            type: "object",
+            required: ["from_agent"],
+            properties: { from_agent: { type: "string" } },
+          },
+          {
+            type: "object",
+            required: ["objective"],
+            properties: { objective: { type: "string" } },
+          },
+        ],
+      },
+    });
+    expect(payload).toEqual({
+      from_agent: "<from_agent>",
+      objective: "<objective>",
+    });
+  });
+
+  it("buildHandoffEnvelope wraps payload with type and version", () => {
+    const envelope = buildHandoffEnvelope(
+      {
+        id: "dsl-task-request",
+        version: 1,
+        schema: {
+          type: "object",
+          required: ["task_id"],
+          properties: { task_id: { type: "string" } },
+        },
+      },
+    );
+    expect(envelope).toEqual({
+      type: "dsl-task-request",
+      version: 1,
+      payload: { task_id: "<task_id>" },
+    });
+  });
+
+  it("buildHandoffEnvelope accepts id override for record iteration", () => {
+    const envelope = buildHandoffEnvelope(
+      {
+        version: 2,
+        example: { ok: true },
+      },
+      "custom-id",
+    );
+    expect(envelope).toEqual({
+      type: "custom-id",
+      version: 2,
+      payload: { ok: true },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add generic Handlebars helpers `jsonBlock`, `yamlFrontmatter` (alongside existing `yamlBlock`) for formatting any context object
- Add handoff-specific helpers `handoffPayload` and `handoffEnvelope` to resolve example payloads or generate schema skeletons for documentation and invocation files
- Extract serialization and handoff payload logic into dedicated modules with unit tests
- Bump version to 0.30.3

## Test plan
- [x] `npm run build`
- [x] `npm test` (856 tests pass)

Made with [Cursor](https://cursor.com)