### PR TITLE
chore: transfer repo ownership to foo-log-inc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @foo-ogawa
+* @foo-log-inc

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 foo-ogawa
+Copyright (c) 2026 foo-log-inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -711,7 +711,7 @@ artifacts:
 
 ## artifact-contracts integration
 
-agent-contracts integrates with [artifact-contracts](https://github.com/foo-ogawa/artifact-contracts) and [cli-contracts](https://github.com/foo-ogawa/cli-contracts) to provide a unified artifact governance model.
+agent-contracts integrates with [artifact-contracts](https://github.com/foo-log-inc/artifact-contracts) and [cli-contracts](https://github.com/foo-log-inc/cli-contracts) to provide a unified artifact governance model.
 
 ### Design principle
 
@@ -1106,7 +1106,7 @@ VarsSubstitutionError: Undefined variable "repo_url" in value "Repository: ${var
 
 For the full CLI reference with all commands, options, arguments, exit codes, and AI agent policies, see the [CLI Reference](docs/cli-reference.md).
 
-The CLI contract specification is defined in [`cli-contract.yaml`](cli-contract.yaml) using [CLI Contracts](https://github.com/foo-ogawa/cli-contracts). Commands that have side effects declare structured `effects` metadata, and the `--introspect` global option outputs the derived policy as JSON without executing the command.
+The CLI contract specification is defined in [`cli-contract.yaml`](cli-contract.yaml) using [CLI Contracts](https://github.com/foo-log-inc/cli-contracts). Commands that have side effects declare structured `effects` metadata, and the `--introspect` global option outputs the derived policy as JSON without executing the command.
 
 ### Installation
 
@@ -1149,7 +1149,7 @@ agent-contracts audit --introspect
 agent-contracts validate --introspect
 ````
 
-The output follows the [CLI Contracts](https://github.com/foo-ogawa/cli-contracts) `IntrospectionResult` shape:
+The output follows the [CLI Contracts](https://github.com/foo-log-inc/cli-contracts) `IntrospectionResult` shape:
 
 ````json
 {

--- a/cli-contract.yaml
+++ b/cli-contract.yaml
@@ -12,8 +12,8 @@ info:
   license:
     name: MIT
   contact:
-    name: foo-ogawa
-    url: https://github.com/foo-ogawa/agent-contracts
+    name: foo-log-inc
+    url: https://github.com/foo-log-inc/agent-contracts
 
 artifact_slots:
   dsl-definitions:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.30.3",
+  "version": "0.30.4",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",
@@ -49,15 +49,15 @@
     "typescript",
     "ai-development"
   ],
-  "author": "foo-ogawa",
+  "author": "foo-log-inc",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/foo-ogawa/agent-contracts.git"
+    "url": "git+https://github.com/foo-log-inc/agent-contracts.git"
   },
-  "homepage": "https://github.com/foo-ogawa/agent-contracts#readme",
+  "homepage": "https://github.com/foo-log-inc/agent-contracts#readme",
   "bugs": {
-    "url": "https://github.com/foo-ogawa/agent-contracts/issues"
+    "url": "https://github.com/foo-log-inc/agent-contracts/issues"
   },
   "dependencies": {
     "@stoplight/spectral-core": "^1.22.0",


### PR DESCRIPTION
## Summary
- Update all GitHub URLs and references from foo-ogawa to foo-log-inc
- Bump version to 0.30.4


Made with [Cursor](https://cursor.com)