### PR TITLE
feat: add state-dependent guardrail policy action

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ A **Guardrail Policy** defines enforcement strategy for guardrails:
 
 * rules — array of enforcement rules mapping guardrails to actions
 * Each rule specifies: severity (`critical`/`mandatory`/`warning`/`info`), action (`block`/`warn`/`shadow`/`info`), override permissions
+* `action` supports a conditional form for state-dependent enforcement: `{ default: "block", when: { maintenance: "shadow" } }`
+* Available states are declared system-wide via `system.states`
 
 ### Handoff Type
 
@@ -337,6 +339,7 @@ Design regressions become testable.
 * **Inheritance with merge operators via `extends`**
 * **Guardrail definitions** for cross-cutting process constraints
 * **Guardrail policies** with configurable enforcement (block/warn/shadow/info)
+* **State-dependent guardrail action** — `action` accepts a conditional form `{ default, when }` keyed by `system.states` for workspace-mode-aware enforcement
 * **Software bindings** (DI) for tool-specific guardrail implementation (Cursor, Git, GitHub)
 * **Guardrail generation** from DSL + policy + bindings via `generate guardrails`
 * **Navigation index** — compile-time artifact-centric model mapping artifacts to operations, agent permissions, relations, and action routes
@@ -374,6 +377,7 @@ system:
     - audit
     - release
     - reflect
+  states: []                       # optional — named workspace states for conditional guardrail action
 
 agents: {}
 tasks: {}
@@ -1536,6 +1540,12 @@ guardrail_policies:
       - guardrail: no-force-push
         severity: critical
         action: block
+      - guardrail: branch-lock
+        severity: critical
+        action:
+          default: block
+          when:
+            maintenance: shadow
       - guardrail: english-only-code
         severity: warning
         action: warn

--- a/docs/spec/guardrail-di.md
+++ b/docs/spec/guardrail-di.md
@@ -46,6 +46,7 @@ cursor outputs  git outputs   observability outputs
 | **DSL scope = entity references only** | No command strings or regex patterns in the DSL; those belong in bindings |
 | **Template duality** | Support both inline templates (short scripts) and external file references |
 | **Observability engine records only** | The observability engine never evaluates guardrails; it receives execution result events |
+| **State-dependent action** | `severity` is inherent to the guardrail and never changes; `action` can vary by workspace state declared in `system.states` |
 
 ### 1.3 Relationship to Existing Entities
 
@@ -202,10 +203,17 @@ const EscalationSchema = z.object({
   condition: z.string().optional(),
 }).passthrough();
 
+const ActionEnum = z.enum(["block", "warn", "shadow", "info"]);
+const ConditionalActionSchema = z.object({
+  default: ActionEnum,
+  when: z.record(z.string(), ActionEnum),
+});
+const ActionSchema = z.union([ActionEnum, ConditionalActionSchema]);
+
 const GuardrailPolicyRuleSchema = z.object({
   guardrail: z.string(),
   severity: z.enum(["critical", "mandatory", "warning", "info"]),
-  action: z.enum(["block", "warn", "shadow", "info"]),
+  action: ActionSchema,
   allow_override: z.boolean().default(false),
   override_requires: z.array(z.string()).optional(),
   escalation: EscalationSchema.optional(),
@@ -232,7 +240,7 @@ const GuardrailPolicySchema = z.object({
 |-------|----------|-------------|
 | `guardrail` | yes | ID reference to a `guardrails` entry |
 | `severity` | yes | `critical` / `mandatory` / `warning` / `info` |
-| `action` | yes | `block` (fail) / `warn` (display warning) / `shadow` (record only) / `info` (display info) |
+| `action` | yes | Enforcement action. Accepts a simple string (`"block"`, `"warn"`, `"shadow"`, `"info"`) or an object `{ default, when }` for state-dependent behavior. When a string, the action always applies. When an object, `default` applies normally and `when` maps state names (from `system.states`) to override actions. |
 | `allow_override` | no | Whether the action can be overridden (default: `false`) |
 | `override_requires` | no | What is required to override (e.g., `["rationale"]`) |
 | `escalation` | no | Escalation target and trigger condition |
@@ -286,6 +294,28 @@ guardrail_policies:
         allow_override: true
 ```
 
+#### 2.2.1 Conditional Action
+
+Policy rules support state-dependent action via the conditional form:
+
+```yaml
+- guardrail: branch-lock
+  severity: critical
+  action:
+    default: block
+    when:
+      maintenance: shadow
+```
+
+**Semantics:**
+
+- `action: "block"` (string) — always applies this action. Backward compatible.
+- `action: { default, when }` (object) — applies `default` normally; when the workspace is in a named state (from `system.states`), applies the override from `when`.
+- `severity` is NOT state-dependent. The importance of a guardrail does not change by workspace mode.
+- At runtime, exactly one action is resolved: the `when` entry matching the current state, or `default` if no match.
+
+**State resolution** is the responsibility of the guardrail runtime (binding scripts), not agent-contracts. The runtime reads the current workspace state (e.g., from a state file managed by the orchestrator) and resolves the effective action.
+
 ### 2.3 Updated DslSchema
 
 ```typescript
@@ -316,6 +346,22 @@ export const DslSchema = z
     extensions_strict: z.boolean().default(false),
   })
   .passthrough();
+```
+
+#### SystemSchema — `system.states`
+
+The `system` section uses `SystemSchema`. The `states` field declares named workspace states referenced by conditional policy actions (`action.when`).
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `states` | no | Array of named workspace states (e.g., `["idle", "work", "maintenance"]`). States referenced in `action.when` must be declared here. Defaults to `[]`. |
+
+```yaml
+system:
+  id: my-project
+  name: My Project
+  default_workflow_order: [implement]
+  states: [idle, work, maintenance]
 ```
 
 ---
@@ -825,6 +871,8 @@ binding.guardrail_impl.{key} → guardrails
 | `binding-template-missing` | error | A binding output specifies neither `template` nor `inline_template` |
 | `binding-path-unresolved` | error | A binding target uses `{name}` but config has no matching `paths` entry |
 | `validation-executor-no-context` | warning | A validation executor (agent/tool) exists in the DSL but the validation is not listed in the executor's prompt context |
+| `guardrail-policy-action-state-undefined` | error | A state key in `action.when` is not listed in `system.states` |
+| `system-states-unused` | info | A state in `system.states` is not referenced by any `action.when` in any policy |
 
 ### 7.2 Existing Rule Interactions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.30.4",
+  "version": "0.31.0",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/sample/templates/agent-prompt.md.hbs
+++ b/sample/templates/agent-prompt.md.hbs
@@ -141,10 +141,8 @@
 {{#if relatedGuardrails.length}}
 ## Guardrails
 
-| ID | Description | Severity | Action |
-|----|-------------|----------|--------|
 {{#each relatedGuardrails}}
-| {{this.guardrail_id}} | {{this.description}} | {{this.severity}} | {{this.action}} |
+- **{{this.guardrail_id}}** [{{this.severity}}]: {{this.description}} — {{#if this.action.default}}{{this.action.default}} ({{#each this.action.when}}{{@key}}: {{this}}{{#unless @last}}, {{/unless}}{{/each}}){{else}}{{this.action}}{{/if}}
 {{/each}}
 {{/if}}
 

--- a/schemas/dsl.schema.json
+++ b/schemas/dsl.schema.json
@@ -62,12 +62,20 @@
               "type": "string"
             }
           }
+        },
+        "states": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [
         "id",
         "name",
-        "default_workflow_order"
+        "default_workflow_order",
+        "states"
       ],
       "additionalProperties": {}
     },
@@ -1462,12 +1470,50 @@
                   ]
                 },
                 "action": {
-                  "type": "string",
-                  "enum": [
-                    "block",
-                    "warn",
-                    "shadow",
-                    "info"
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "block",
+                        "warn",
+                        "shadow",
+                        "info"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "default": {
+                          "type": "string",
+                          "enum": [
+                            "block",
+                            "warn",
+                            "shadow",
+                            "info"
+                          ]
+                        },
+                        "when": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "additionalProperties": {
+                            "type": "string",
+                            "enum": [
+                              "block",
+                              "warn",
+                              "shadow",
+                              "info"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "default",
+                        "when"
+                      ],
+                      "additionalProperties": false
+                    }
                   ]
                 },
                 "allow_override": {

--- a/src/linter/index.ts
+++ b/src/linter/index.ts
@@ -10,6 +10,10 @@ export { artifactOwnershipConsistencyRule } from "./rules/artifact-ownership-con
 export { deprecatedOwnershipFieldsRule } from "./rules/deprecated-ownership-fields.js";
 export { toolCommandsRule } from "./rules/tool-commands.js";
 export { guardrailPolicyCoverageRule } from "./rules/guardrail-policy-coverage.js";
+export {
+  guardrailPolicyActionStateUndefinedRule,
+  systemStatesUnusedRule,
+} from "./rules/guardrail-policy-action-state.js";
 export { yamlReservedKeySafetyRule } from "./rules/yaml-reserved-key-safety.js";
 export { artifactRequiredValidationWiringRule } from "./rules/artifact-required-validation-wiring.js";
 export { taskOutputValidationCompletenessRule } from "./rules/task-output-validation-completeness.js";

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -7,6 +7,10 @@ import { mergeIntegrityRule } from "./rules/merge-integrity.js";
 import { artifactOwnershipRule } from "./rules/artifact-ownership.js";
 import { toolCommandsRule } from "./rules/tool-commands.js";
 import { guardrailPolicyCoverageRule } from "./rules/guardrail-policy-coverage.js";
+import {
+  guardrailPolicyActionStateUndefinedRule,
+  systemStatesUnusedRule,
+} from "./rules/guardrail-policy-action-state.js";
 import { yamlReservedKeySafetyRule } from "./rules/yaml-reserved-key-safety.js";
 import { artifactRequiredValidationWiringRule } from "./rules/artifact-required-validation-wiring.js";
 import { taskOutputValidationCompletenessRule } from "./rules/task-output-validation-completeness.js";
@@ -37,6 +41,8 @@ const builtinRules: LintRule[] = [
   artifactOwnershipRule,
   toolCommandsRule,
   guardrailPolicyCoverageRule,
+  guardrailPolicyActionStateUndefinedRule,
+  systemStatesUnusedRule,
   yamlReservedKeySafetyRule,
   artifactRequiredValidationWiringRule,
   taskOutputValidationCompletenessRule,

--- a/src/linter/rules/guardrail-policy-action-state.ts
+++ b/src/linter/rules/guardrail-policy-action-state.ts
@@ -1,0 +1,78 @@
+import type { Action, ConditionalAction, Dsl } from "../../schema/index.js";
+import type { LintRule, LintDiagnostic } from "../types.js";
+
+function isConditionalAction(action: Action): action is ConditionalAction {
+  return typeof action === "object" && action !== null && "default" in action;
+}
+
+function collectReferencedWhenStates(dsl: Dsl): Set<string> {
+  const referenced = new Set<string>();
+  for (const policy of Object.values(dsl.guardrail_policies)) {
+    for (const rule of policy.rules) {
+      if (isConditionalAction(rule.action)) {
+        for (const state of Object.keys(rule.action.when)) {
+          referenced.add(state);
+        }
+      }
+    }
+  }
+  return referenced;
+}
+
+export const guardrailPolicyActionStateUndefinedRule: LintRule = {
+  id: "guardrail-policy-action-state-undefined",
+  description:
+    "Policy rule action.when keys must reference states declared in system.states",
+
+  run(dsl: Dsl): LintDiagnostic[] {
+    const diagnostics: LintDiagnostic[] = [];
+    const systemStates = new Set(dsl.system.states ?? []);
+
+    for (const [policyId, policy] of Object.entries(dsl.guardrail_policies)) {
+      for (let ruleIndex = 0; ruleIndex < policy.rules.length; ruleIndex++) {
+        const rule = policy.rules[ruleIndex];
+        if (!isConditionalAction(rule.action)) continue;
+
+        for (const state of Object.keys(rule.action.when)) {
+          if (!systemStates.has(state)) {
+            diagnostics.push({
+              ruleId: "guardrail-policy-action-state-undefined",
+              severity: "error",
+              path: `guardrail_policies.${policyId}.rules[${ruleIndex}].action.when.${state}`,
+              message: `Policy rule references state "${state}" in action.when, but it is not declared in system.states`,
+            });
+          }
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};
+
+export const systemStatesUnusedRule: LintRule = {
+  id: "system-states-unused",
+  description:
+    "Each state in system.states should be referenced by at least one policy rule action.when",
+
+  run(dsl: Dsl): LintDiagnostic[] {
+    const diagnostics: LintDiagnostic[] = [];
+    const states = dsl.system.states ?? [];
+    if (states.length === 0) return diagnostics;
+
+    const referenced = collectReferencedWhenStates(dsl);
+
+    for (const state of states) {
+      if (!referenced.has(state)) {
+        diagnostics.push({
+          ruleId: "system-states-unused",
+          severity: "info",
+          path: `system.states`,
+          message: `State "${state}" is declared in system.states but not referenced by any policy rule action.when`,
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/src/renderer/context.ts
+++ b/src/renderer/context.ts
@@ -10,6 +10,7 @@ import type {
   Policy,
   Guardrail,
   GuardrailPolicy,
+  Action,
   System,
   SoftwareBinding,
 } from "../schema/index.js";
@@ -35,7 +36,7 @@ export interface GuardrailEnforcementEntry {
   guardrail_id: string;
   description: string;
   severity: string;
-  action: string;
+  action: Action;
   scoped_agents: string[];
   scoped_tasks: string[];
   scoped_workflows: string[];
@@ -62,7 +63,7 @@ export interface EntityGuardrailEntry {
   tags: string[];
   source: "entity" | "scope" | "both";
   severity?: string;
-  action?: string;
+  action?: Action;
 }
 
 export interface EntityValidationEntry {
@@ -288,7 +289,7 @@ export function resolveEffectiveGuardrails(
 
   const allIds = new Set([...entitySide, ...scopeSide]);
 
-  const activePolicyRules = new Map<string, { severity: string; action: string }>();
+  const activePolicyRules = new Map<string, { severity: string; action: Action }>();
   for (const policy of Object.values(dsl.guardrail_policies)) {
     for (const rule of policy.rules) {
       if (!activePolicyRules.has(rule.guardrail)) {

--- a/src/schema/guardrail.ts
+++ b/src/schema/guardrail.ts
@@ -32,11 +32,23 @@ export type GuardrailPolicyRuleEscalation = z.infer<
   typeof GuardrailPolicyRuleEscalationSchema
 >;
 
+export const ActionEnum = z.enum(["block", "warn", "shadow", "info"]);
+export type ActionValue = z.infer<typeof ActionEnum>;
+
+export const ConditionalActionSchema = z.object({
+  default: ActionEnum,
+  when: z.record(z.string(), ActionEnum),
+});
+export type ConditionalAction = z.infer<typeof ConditionalActionSchema>;
+
+export const ActionSchema = z.union([ActionEnum, ConditionalActionSchema]);
+export type Action = z.infer<typeof ActionSchema>;
+
 export const GuardrailPolicyRuleSchema = z
   .object({
     guardrail: z.string(),
     severity: z.enum(["critical", "mandatory", "warning", "info"]),
-    action: z.enum(["block", "warn", "shadow", "info"]),
+    action: ActionSchema,
     allow_override: z.boolean().default(false),
     override_requires: z.array(z.string()).optional(),
     escalation: GuardrailPolicyRuleEscalationSchema.optional(),

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -44,11 +44,17 @@ export {
 } from "./dsl.js";
 export { HandoffTypeSchema, type HandoffType } from "./handoff-type.js";
 export {
+  ActionEnum,
+  ActionSchema,
+  ConditionalActionSchema,
   GuardrailPolicyRuleEscalationSchema,
   GuardrailPolicyRuleSchema,
   GuardrailPolicySchema,
   GuardrailScopeSchema,
   GuardrailSchema,
+  type Action,
+  type ActionValue,
+  type ConditionalAction,
   type Guardrail,
   type GuardrailPolicy,
   type GuardrailPolicyRule,

--- a/src/schema/system.ts
+++ b/src/schema/system.ts
@@ -19,6 +19,7 @@ export const SystemSchema = z
     default_workflow_order: z.array(z.string()),
     sections: z.array(SectionSchema).optional(),
     context_loading: ContextLoadingSchema,
+    states: z.array(z.string()).default([]),
   })
   .passthrough();
 export type System = z.infer<typeof SystemSchema>;

--- a/test/entity-guardrail-binding.test.ts
+++ b/test/entity-guardrail-binding.test.ts
@@ -161,6 +161,24 @@ describe("resolveEffectiveGuardrails", () => {
     expect(result[0].tags).toEqual(["safety"]);
   });
 
+  it("passes through conditional policy action", () => {
+    const conditionalAction = {
+      default: "block",
+      when: { maintenance: "shadow" },
+    };
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", guardrails: ["g1"] } },
+      guardrails: { g1: { description: "d", scope: {} } },
+      guardrail_policies: {
+        default: {
+          rules: [{ guardrail: "g1", severity: "critical", action: conditionalAction }],
+        },
+      },
+    });
+    const result = resolveEffectiveGuardrails(dsl, "agents", "a1");
+    expect(result[0].action).toEqual(conditionalAction);
+  });
+
   it("skips entity references to non-existent guardrails", () => {
     const dsl = makeDsl({
       agents: { a1: { role_name: "R", purpose: "P", guardrails: ["nonexistent"] } },

--- a/test/linter/guardrail-policy-action-state.test.ts
+++ b/test/linter/guardrail-policy-action-state.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest";
+import { DslSchema, type Dsl } from "../../src/schema/index.js";
+import {
+  guardrailPolicyActionStateUndefinedRule,
+  systemStatesUnusedRule,
+} from "../../src/linter/rules/guardrail-policy-action-state.js";
+
+function makeDsl(partial: Partial<Record<string, unknown>>): Dsl {
+  return DslSchema.parse({
+    version: 1,
+    system: { id: "s", name: "S", default_workflow_order: ["implement"] },
+    ...partial,
+  });
+}
+
+describe("guardrailPolicyActionStateUndefinedRule", () => {
+  it("returns no diagnostics when all when keys are in system.states", () => {
+    const dsl = makeDsl({
+      system: {
+        id: "s",
+        name: "S",
+        default_workflow_order: ["implement"],
+        states: ["idle", "maintenance"],
+      },
+      guardrails: { g1: { description: "d", scope: {} } },
+      guardrail_policies: {
+        p1: {
+          rules: [
+            {
+              guardrail: "g1",
+              severity: "critical",
+              action: { default: "block", when: { maintenance: "shadow" } },
+            },
+          ],
+        },
+      },
+    });
+    expect(guardrailPolicyActionStateUndefinedRule.run(dsl)).toHaveLength(0);
+  });
+
+  it("returns error when a when key is not in system.states", () => {
+    const dsl = makeDsl({
+      system: {
+        id: "s",
+        name: "S",
+        default_workflow_order: ["implement"],
+        states: ["idle"],
+      },
+      guardrails: { g1: { description: "d", scope: {} } },
+      guardrail_policies: {
+        p1: {
+          rules: [
+            {
+              guardrail: "g1",
+              severity: "critical",
+              action: { default: "block", when: { maintenance: "shadow" } },
+            },
+          ],
+        },
+      },
+    });
+    const diags = guardrailPolicyActionStateUndefinedRule.run(dsl);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].severity).toBe("error");
+    expect(diags[0].ruleId).toBe("guardrail-policy-action-state-undefined");
+    expect(diags[0].message).toContain("maintenance");
+  });
+
+  it("returns no diagnostics when action is a simple string", () => {
+    const dsl = makeDsl({
+      system: {
+        id: "s",
+        name: "S",
+        default_workflow_order: ["implement"],
+        states: ["idle"],
+      },
+      guardrails: { g1: { description: "d", scope: {} } },
+      guardrail_policies: {
+        p1: {
+          rules: [{ guardrail: "g1", severity: "critical", action: "block" }],
+        },
+      },
+    });
+    expect(guardrailPolicyActionStateUndefinedRule.run(dsl)).toHaveLength(0);
+  });
+
+  it("returns no diagnostics when system.states is empty and no when is used", () => {
+    const dsl = makeDsl({
+      guardrails: { g1: { description: "d", scope: {} } },
+      guardrail_policies: {
+        p1: {
+          rules: [{ guardrail: "g1", severity: "critical", action: "block" }],
+        },
+      },
+    });
+    expect(guardrailPolicyActionStateUndefinedRule.run(dsl)).toHaveLength(0);
+  });
+
+  it("returns error when system.states is empty but action.when references a state", () => {
+    const dsl = makeDsl({
+      guardrails: { g1: { description: "d", scope: {} } },
+      guardrail_policies: {
+        p1: {
+          rules: [
+            {
+              guardrail: "g1",
+              severity: "critical",
+              action: { default: "block", when: { maintenance: "shadow" } },
+            },
+          ],
+        },
+      },
+    });
+    const diags = guardrailPolicyActionStateUndefinedRule.run(dsl);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].severity).toBe("error");
+    expect(diags[0].message).toContain("maintenance");
+  });
+});
+
+describe("systemStatesUnusedRule", () => {
+  it("returns no diagnostics when all states are referenced", () => {
+    const dsl = makeDsl({
+      system: {
+        id: "s",
+        name: "S",
+        default_workflow_order: ["implement"],
+        states: ["idle", "maintenance"],
+      },
+      guardrails: { g1: { description: "d", scope: {} } },
+      guardrail_policies: {
+        p1: {
+          rules: [
+            {
+              guardrail: "g1",
+              severity: "critical",
+              action: {
+                default: "block",
+                when: { idle: "warn", maintenance: "shadow" },
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(systemStatesUnusedRule.run(dsl)).toHaveLength(0);
+  });
+
+  it("returns info when a state is declared but never used in any policy when", () => {
+    const dsl = makeDsl({
+      system: {
+        id: "s",
+        name: "S",
+        default_workflow_order: ["implement"],
+        states: ["idle", "orphan"],
+      },
+      guardrails: { g1: { description: "d", scope: {} } },
+      guardrail_policies: {
+        p1: {
+          rules: [
+            {
+              guardrail: "g1",
+              severity: "critical",
+              action: { default: "block", when: { idle: "warn" } },
+            },
+          ],
+        },
+      },
+    });
+    const diags = systemStatesUnusedRule.run(dsl);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].severity).toBe("info");
+    expect(diags[0].ruleId).toBe("system-states-unused");
+    expect(diags[0].message).toContain("orphan");
+  });
+
+  it("returns no diagnostics when system.states is empty", () => {
+    const dsl = makeDsl({
+      guardrails: { g1: { description: "d", scope: {} } },
+      guardrail_policies: {
+        p1: {
+          rules: [
+            {
+              guardrail: "g1",
+              severity: "critical",
+              action: { default: "block", when: { maintenance: "shadow" } },
+            },
+          ],
+        },
+      },
+    });
+    expect(systemStatesUnusedRule.run(dsl)).toHaveLength(0);
+  });
+
+  it("returns info for all states when all policy rules use simple string action", () => {
+    const dsl = makeDsl({
+      system: {
+        id: "s",
+        name: "S",
+        default_workflow_order: ["implement"],
+        states: ["idle", "maintenance"],
+      },
+      guardrails: { g1: { description: "d", scope: {} } },
+      guardrail_policies: {
+        p1: {
+          rules: [{ guardrail: "g1", severity: "critical", action: "block" }],
+        },
+      },
+    });
+    const diags = systemStatesUnusedRule.run(dsl);
+    expect(diags).toHaveLength(2);
+    expect(diags.every(d => d.severity === "info")).toBe(true);
+  });
+});

--- a/test/schema/guardrail.test.ts
+++ b/test/schema/guardrail.test.ts
@@ -177,6 +177,72 @@ describe("GuardrailPolicySchema", () => {
     expect(r.success).toBe(false);
   });
 
+  it("parses string action (backward compat)", () => {
+    const r = GuardrailPolicyRuleSchema.parse({
+      guardrail: "g",
+      severity: "critical",
+      action: "block",
+    });
+    expect(r.action).toBe("block");
+  });
+
+  it("parses conditional action object", () => {
+    const r = GuardrailPolicyRuleSchema.parse({
+      guardrail: "g",
+      severity: "critical",
+      action: { default: "block", when: { maintenance: "shadow" } },
+    });
+    expect(r.action).toEqual({
+      default: "block",
+      when: { maintenance: "shadow" },
+    });
+  });
+
+  it("rejects invalid default in conditional action", () => {
+    const r = GuardrailPolicyRuleSchema.safeParse({
+      guardrail: "g",
+      severity: "critical",
+      action: { default: "invalid" },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects invalid when values in conditional action", () => {
+    const r = GuardrailPolicyRuleSchema.safeParse({
+      guardrail: "g",
+      severity: "critical",
+      action: { default: "block", when: { maintenance: "invalid" } },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts empty when in conditional action", () => {
+    const r = GuardrailPolicyRuleSchema.parse({
+      guardrail: "g",
+      severity: "critical",
+      action: { default: "block", when: {} },
+    });
+    expect(r.action).toEqual({ default: "block", when: {} });
+  });
+
+  it("rejects conditional action missing when field", () => {
+    const r = GuardrailPolicyRuleSchema.safeParse({
+      guardrail: "g",
+      severity: "critical",
+      action: { default: "block" },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects conditional action missing default field", () => {
+    const r = GuardrailPolicyRuleSchema.safeParse({
+      guardrail: "g",
+      severity: "critical",
+      action: { when: { maintenance: "shadow" } },
+    });
+    expect(r.success).toBe(false);
+  });
+
   it("rejects missing guardrail in rule", () => {
     const r = GuardrailPolicyRuleSchema.safeParse({
       severity: "critical",

--- a/test/schema/schema.test.ts
+++ b/test/schema/schema.test.ts
@@ -116,6 +116,19 @@ describe("schema normal cases", () => {
     expect(() => SystemSchema.parse(minimalValidSystem)).not.toThrow();
   });
 
+  it("parses system.states array", () => {
+    const s = SystemSchema.parse({
+      ...minimalValidSystem,
+      states: ["idle", "work", "maintenance"],
+    });
+    expect(s.states).toEqual(["idle", "work", "maintenance"]);
+  });
+
+  it("defaults system.states to [] when omitted", () => {
+    const s = SystemSchema.parse(minimalValidSystem);
+    expect(s.states).toEqual([]);
+  });
+
   it("parses AgentSchema", () => {
     const a = AgentSchema.parse(minimalValidAgent);
     expect(a.can_read_artifacts).toEqual([]);


### PR DESCRIPTION
## Summary

- Add `system.states` field for declaring workspace state vocabulary
- Extend `action` on guardrail policy rules to accept conditional form `{ default, when }` for state-dependent enforcement
- Add lint rules: `guardrail-policy-action-state-undefined` (error) and `system-states-unused` (info)
- Update renderer, templates, JSON Schema, docs, and README

## Test plan

- [x] Schema: both string and `{ default, when }` forms validated
- [x] Schema: backward compatibility — existing `action: "block"` unchanged
- [x] Lint: undefined state references detected as errors
- [x] Lint: unused declared states flagged as info
- [x] Renderer: conditional action flows through `resolveEffectiveGuardrails`
- [x] Build passes, 875 unit tests pass

Closes #87
