### PR TITLE
chore: add .npmrc for supply chain hardening

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+allow-git=none

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,7 +1,7 @@
 ARG NODE_VERSION=22
 FROM node:${NODE_VERSION}-alpine
 WORKDIR /app
-COPY package.json package-lock.json ./
+COPY package.json package-lock.json .npmrc ./
 RUN npm ci
 COPY . .
 RUN npm run build


### PR DESCRIPTION
## Summary
- `.npmrc` を追加: `ignore-scripts=true` で postinstall スクリプト攻撃を防止、`allow-git=none` で git 依存解決を防止
- `Dockerfile.test` を更新: `.npmrc` を COPY

## Test plan
- [ ] CI パス確認

Made with [Cursor](https://cursor.com)