### PR TITLE
chore: widen peerDep to accept agent-contracts-runtime ^0.32.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-contracts",
-  "version": "0.32.3",
+  "version": "0.32.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-contracts",
-      "version": "0.32.3",
+      "version": "0.32.5",
       "license": "MIT",
       "dependencies": {
         "@stoplight/spectral-core": "^1.22.0",
@@ -30,7 +30,7 @@
         "@google/genai": "^2.0.1",
         "@openai/agents": "^0.11.1",
         "@types/node": "^25.6.0",
-        "agent-contracts-runtime": "^0.31.0",
+        "agent-contracts-runtime": "^0.31.4",
         "eslint": "^10.2.0",
         "globals": "^17.5.0",
         "prettier": "^3.8.2",
@@ -44,7 +44,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "agent-contracts-runtime": "^0.31.0"
+        "agent-contracts-runtime": "^0.31.0 || ^0.32.0"
       },
       "peerDependenciesMeta": {
         "agent-contracts-runtime": {
@@ -2797,9 +2797,9 @@
       }
     },
     "node_modules/agent-contracts": {
-      "version": "0.30.4",
-      "resolved": "https://registry.npmjs.org/agent-contracts/-/agent-contracts-0.30.4.tgz",
-      "integrity": "sha512-Z6gMf8Er93JY9TgZh0o2RMrnRcMaesPDznbO4tUl+ISX10iBex/PSnIEe8Pkr3z+LjX/uon7BzBwsX7iPf6cOg==",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/agent-contracts/-/agent-contracts-0.32.4.tgz",
+      "integrity": "sha512-v2voRU1ef8kdw2BlDJOJpK/Dw/dZp3pHYPRtVxhRKPeWQ0fub7kCAGfXxhe0irNaocoSmRukq2Ly+B6c+NEaKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2807,7 +2807,7 @@
         "@stoplight/spectral-functions": "^1.9.0",
         "@stoplight/spectral-rulesets": "^1.22.1",
         "ajv": "^8.18.0",
-        "cli-contracts": "^0.30.0",
+        "cli-contracts": "^0.31.0",
         "commander": "^14.0.3",
         "handlebars": "^4.7.9",
         "minimatch": "^10.2.5",
@@ -2822,7 +2822,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "agent-contracts-runtime": "^0.30.0"
+        "agent-contracts-runtime": "^0.31.0"
       },
       "peerDependenciesMeta": {
         "agent-contracts-runtime": {
@@ -2831,13 +2831,13 @@
       }
     },
     "node_modules/agent-contracts-runtime": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/agent-contracts-runtime/-/agent-contracts-runtime-0.31.3.tgz",
-      "integrity": "sha512-KKbOp3gXQM1+jJREwz1DusyE04xDJ2CrWjSGPYdLT5eTwcymQ2ob5fp0qJbKRh7105G7dfIqlTsyvehTbSkGdA==",
+      "version": "0.31.4",
+      "resolved": "https://registry.npmjs.org/agent-contracts-runtime/-/agent-contracts-runtime-0.31.4.tgz",
+      "integrity": "sha512-wna+1SHiELElvV81dotqLk+U0wDP0nQZmdrkq4fJsUJRLkf7uFAh1w8ilpte8Hs4h7ql9Oxg+j/BOGnk/Xgq3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "agent-contracts": "^0.30.0",
+        "agent-contracts": "^0.32.0",
         "commander": "^12.1.0",
         "dotenv": "^17.4.2",
         "handlebars": "^4.7.9",
@@ -2872,47 +2872,6 @@
       }
     },
     "node_modules/agent-contracts-runtime/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/agent-contracts/node_modules/cli-contracts": {
-      "version": "0.30.4",
-      "resolved": "https://registry.npmjs.org/cli-contracts/-/cli-contracts-0.30.4.tgz",
-      "integrity": "sha512-x4kqnDNDQPiVvigJXXONpfrKnFpK/USKCSFMJ41ICndeqnRNb9Ue8kvtsxUZoni+jdy/0PpZ3G8cfsjR7dQtJQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.138",
-        "ajv": "^8.17.1",
-        "commander": "^12.1.0",
-        "glob": "^10.3.10",
-        "handlebars": "^4.7.8",
-        "js-yaml": "^4.1.0",
-        "yaml": "^2.8.2",
-        "zod": "^4.4.3"
-      },
-      "bin": {
-        "cli-contracts": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "agent-contracts-runtime": "^0.30.0"
-      },
-      "peerDependenciesMeta": {
-        "agent-contracts-runtime": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/agent-contracts/node_modules/cli-contracts/node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.32.4",
+  "version": "0.32.5",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",
@@ -78,7 +78,7 @@
     "@google/genai": "^2.0.1",
     "@openai/agents": "^0.11.1",
     "@types/node": "^25.6.0",
-    "agent-contracts-runtime": "^0.31.0",
+    "agent-contracts-runtime": "^0.31.4",
     "eslint": "^10.2.0",
     "globals": "^17.5.0",
     "prettier": "^3.8.2",
@@ -89,7 +89,7 @@
     "vitest": "^4.1.4"
   },
   "peerDependencies": {
-    "agent-contracts-runtime": "^0.31.0"
+    "agent-contracts-runtime": "^0.31.0 || ^0.32.0"
   },
   "peerDependenciesMeta": {
     "agent-contracts-runtime": {


### PR DESCRIPTION
## Summary
- Widen `peerDependencies.agent-contracts-runtime` from `^0.31.0` to `^0.31.0 || ^0.32.0`
- Bump version to 0.32.5

## Motivation
Allow downstream packages to install agent-contracts-runtime v0.32.x alongside agent-contracts without peer dependency conflicts.

Made with [Cursor](https://cursor.com)