### PR TITLE
chore: unify publish CI (node 22, test:ci)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
@@ -26,7 +26,7 @@ jobs:
         run: npm run build
 
       - name: Run tests
-        run: npm run test:unit
+        run: npm run test:ci
 
       - name: Publish to npm
         run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "generate:cli": "cli-contracts generate typescript",
     "generate:docs": "cli-contracts docs",
     "version": "node -e \"const fs=require('fs');const f='cli-contract.yaml';fs.writeFileSync(f,fs.readFileSync(f,'utf8').replace(/^  version: .*/m,'  version: '+process.env.npm_package_version))\" && git add cli-contract.yaml",
-    "prepublishOnly": "npm run clean && npm run build"
+    "prepublishOnly": "npm run clean && npm run build",
+    "test:ci": "vitest run"
   },
   "keywords": [
     "agent",


### PR DESCRIPTION
## Summary
- node-version → 22
- Add `test:ci` script for CI-safe test execution
- Align publish.yml test step to `npm run test:ci`
- Standardize `npm ci --legacy-peer-deps`

Made with [Cursor](https://cursor.com)