### PR TITLE
feat: add model_class field to TaskSchema for per-task LLM selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ A **Task** defines a delegatable unit of work:
 * input artifacts
 * invocation/result handoffs
 * task-specific execution expectations
+* `model_class` — optional LLM capability requirement (`fast`, `standard`, `thinking`)
 
 ### Artifact
 
@@ -619,6 +620,7 @@ tasks:
     allowed_from_agents:
       - main-architect
     workflow: implement
+    model_class: standard            # optional: fast | standard | thinking
     input_artifacts:
       - spec-md
       - plan-md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/schemas/dsl.schema.json
+++ b/schemas/dsl.schema.json
@@ -541,6 +541,14 @@
             "items": {
               "type": "string"
             }
+          },
+          "model_class": {
+            "type": "string",
+            "enum": [
+              "fast",
+              "standard",
+              "thinking"
+            ]
           }
         },
         "required": [

--- a/src/renderer/context.ts
+++ b/src/renderer/context.ts
@@ -170,6 +170,7 @@ export interface DelegatableTaskView {
   invocation_payload_keys: string[];
   result_handoff: string;
   result_payload_keys: string[];
+  model_class?: string;
 }
 
 export interface PerAgentContext {
@@ -767,6 +768,7 @@ function buildDelegatableTasks(
         result_payload_keys: resultHandoff
           ? extractSchemaFieldNames(resultHandoff.schema)
           : [],
+        ...(t.model_class ? { model_class: t.model_class } : {}),
       };
     });
 }

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -103,8 +103,10 @@ export {
 } from "./team-interface.js";
 export {
   ExecutionStepSchema,
+  ModelClassSchema,
   TaskSchema,
   type ExecutionStep,
+  type ModelClass,
   type Task,
 } from "./task.js";
 export { CommandSchema, ToolSchema, type Command, type Tool } from "./tool.js";

--- a/src/schema/task.ts
+++ b/src/schema/task.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import { EscalationCriterionSchema, RuleSchema, SectionSchema } from "./agent.js";
 
+export const ModelClassSchema = z.enum(["fast", "standard", "thinking"]);
+export type ModelClass = z.infer<typeof ModelClassSchema>;
+
 export const ExecutionStepSchema = z
   .object({
     id: z.string(),
@@ -40,6 +43,7 @@ export const TaskSchema = z
     sections: z.array(SectionSchema).optional(),
     validations: z.array(z.string()).default([]),
     guardrails: z.array(z.string()).optional(),
+    model_class: ModelClassSchema.optional(),
   })
   .passthrough();
 export type Task = z.infer<typeof TaskSchema>;

--- a/test/context-builders.test.ts
+++ b/test/context-builders.test.ts
@@ -213,6 +213,23 @@ describe("buildPerAgentContext", () => {
     expect(ctx.delegatableTasks[0].id).toBe("delegated-work");
   });
 
+  it("propagates model_class to delegatableTasks", () => {
+    const dsl = createMinimalDsl();
+    dsl.tasks["implement-feature"].model_class = "thinking";
+    const ctx = buildPerAgentContext(dsl, { ...dsl.agents["reviewer"], id: "reviewer" });
+    const dt = ctx.delegatableTasks.find((t) => t.id === "implement-feature");
+    expect(dt).toBeDefined();
+    expect(dt!.model_class).toBe("thinking");
+  });
+
+  it("omits model_class from delegatableTasks when not set", () => {
+    const dsl = createMinimalDsl();
+    const ctx = buildPerAgentContext(dsl, { ...dsl.agents["reviewer"], id: "reviewer" });
+    const dt = ctx.delegatableTasks.find((t) => t.id === "implement-feature");
+    expect(dt).toBeDefined();
+    expect(dt!.model_class).toBeUndefined();
+  });
+
   it("has empty relatedValidations when agent runs no validations", () => {
     const dsl = createMinimalDsl();
     const ctx = buildPerAgentContext(dsl, { ...dsl.agents["dev"], id: "dev" });

--- a/test/schema/schema.test.ts
+++ b/test/schema/schema.test.ts
@@ -148,6 +148,24 @@ describe("schema normal cases", () => {
     expect(t.validations).toEqual(["v1", "v2"]);
   });
 
+  it("parses TaskSchema with model_class", () => {
+    for (const mc of ["fast", "standard", "thinking"] as const) {
+      const t = TaskSchema.parse({ ...minimalValidTask, model_class: mc });
+      expect(t.model_class).toBe(mc);
+    }
+  });
+
+  it("allows TaskSchema without model_class", () => {
+    const t = TaskSchema.parse(minimalValidTask);
+    expect(t.model_class).toBeUndefined();
+  });
+
+  it("rejects invalid model_class value", () => {
+    expect(() =>
+      TaskSchema.parse({ ...minimalValidTask, model_class: "ultra" }),
+    ).toThrow();
+  });
+
   it("parses ArtifactSchema", () => {
     const a = ArtifactSchema.parse(minimalValidArtifact);
     expect(a.required_validations).toEqual([]);


### PR DESCRIPTION
## Summary

- Add optional `model_class` enum field (`fast` | `standard` | `thinking`) to `TaskSchema` for declaring per-task LLM capability requirements
- Propagate `model_class` to `DelegatableTaskView` in the render context
- Regenerate `dsl.schema.json` with the new field

## Motivation

Enables DSL authors to express that different tasks require different LLM capability levels. Runtime systems (agent-contracts-runtime) can then route tasks to appropriate models/providers based on this declaration.

## Test plan

- [x] Schema validation: accepts valid model_class values, rejects invalid ones, allows omission
- [x] Context propagation: model_class appears in delegatableTasks when set, omitted when not set
- [x] All 880 existing tests pass
- [x] Build succeeds
- [x] JSON Schema regenerated

Closes #102

Made with [Cursor](https://cursor.com)