### PR TITLE
feat: add memory capability block to agent schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/schemas/dsl.schema.json
+++ b/schemas/dsl.schema.json
@@ -294,6 +294,21 @@
             "items": {
               "type": "string"
             }
+          },
+          "memory": {
+            "type": "object",
+            "properties": {
+              "resumable": {
+                "type": "boolean"
+              },
+              "ref_required": {
+                "type": "boolean"
+              },
+              "emits_memory_ref": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
           }
         },
         "required": [

--- a/src/linter/index.ts
+++ b/src/linter/index.ts
@@ -20,3 +20,4 @@ export { taskOutputValidationCompletenessRule } from "./rules/task-output-valida
 export { entityGuardrailUndefinedRule, entityNoGuardrailsRule, guardrailOrphanedRule } from "./rules/entity-guardrail-binding.js";
 export { validationExecutorNoContextRule } from "./rules/validation-executor-no-context.js";
 export { extensionDeclaredButUnusedRule, extensionScopeMismatchRule, extensionUndeclaredUsageRule } from "./rules/extension-consumption.js";
+export { memoryConsistencyRule } from "./rules/memory-consistency.js";

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -32,6 +32,7 @@ import { bindingCompletenessRule } from "./rules/binding-completeness.js";
 import { bindingDirectionMatchRule } from "./rules/binding-direction-match.js";
 import { slotDeclarationExistsRule } from "./rules/slot-declaration-exists.js";
 import { configPathConsistencyRule } from "./rules/config-path-consistency.js";
+import { memoryConsistencyRule } from "./rules/memory-consistency.js";
 
 const builtinRules: LintRule[] = [
   validationCoverageRule,
@@ -60,6 +61,7 @@ const builtinRules: LintRule[] = [
   bindingDirectionMatchRule,
   slotDeclarationExistsRule,
   configPathConsistencyRule,
+  memoryConsistencyRule,
 ];
 
 export function lint(

--- a/src/linter/rules/memory-consistency.ts
+++ b/src/linter/rules/memory-consistency.ts
@@ -1,0 +1,39 @@
+import type { Dsl } from "../../schema/index.js";
+import type { LintRule, LintDiagnostic } from "../types.js";
+
+export const memoryConsistencyRule: LintRule = {
+  id: "memory-consistency",
+  description:
+    "Validate memory capability declarations are internally consistent",
+
+  run(dsl: Dsl): LintDiagnostic[] {
+    const diagnostics: LintDiagnostic[] = [];
+
+    for (const [agentId, agent] of Object.entries(dsl.agents)) {
+      const memory = (agent as Record<string, unknown>).memory as
+        | { resumable?: boolean; ref_required?: boolean; emits_memory_ref?: boolean }
+        | undefined;
+      if (!memory) continue;
+
+      if (memory.resumable && !memory.emits_memory_ref) {
+        diagnostics.push({
+          ruleId: "memory-consistency",
+          severity: "warning",
+          path: `agents.${agentId}.memory`,
+          message: `Agent "${agentId}" declares memory.resumable but does not declare emits_memory_ref — resumed sessions will not produce a memory_ref for downstream continuation`,
+        });
+      }
+
+      if (memory.ref_required && !memory.resumable) {
+        diagnostics.push({
+          ruleId: "memory-consistency",
+          severity: "error",
+          path: `agents.${agentId}.memory`,
+          message: `Agent "${agentId}" declares memory.ref_required but resumable is not true — ref_required requires resumable capability`,
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/src/schema/agent.ts
+++ b/src/schema/agent.ts
@@ -45,6 +45,13 @@ export const PrerequisiteSchema = z
   .passthrough();
 export type Prerequisite = z.infer<typeof PrerequisiteSchema>;
 
+export const MemoryCapabilitySchema = z.object({
+  resumable: z.boolean().optional(),
+  ref_required: z.boolean().optional(),
+  emits_memory_ref: z.boolean().optional(),
+});
+export type MemoryCapability = z.infer<typeof MemoryCapabilitySchema>;
+
 export const AgentSchema = z
   .object({
     role_name: z.string(),
@@ -66,6 +73,7 @@ export const AgentSchema = z
     sections: z.array(SectionSchema).optional(),
     prerequisites: z.array(PrerequisiteSchema).optional(),
     guardrails: z.array(z.string()).optional(),
+    memory: MemoryCapabilitySchema.optional(),
   })
   .passthrough();
 export type Agent = z.infer<typeof AgentSchema>;

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,6 +1,8 @@
 export {
   AgentSchema,
   type Agent,
+  MemoryCapabilitySchema,
+  type MemoryCapability,
   EscalationCriterionSchema,
   type EscalationCriterion,
   PrerequisiteSchema,

--- a/test/linter/linter.test.ts
+++ b/test/linter/linter.test.ts
@@ -12,6 +12,7 @@ import { artifactRequiredValidationWiringRule } from "../../src/linter/rules/art
 import { taskOutputValidationCompletenessRule } from "../../src/linter/rules/task-output-validation-completeness.js";
 import { semanticValidationPhaseCoverageRule } from "../../src/linter/rules/semantic-validation-phase-coverage.js";
 import { deprecatedOwnershipFieldsRule } from "../../src/linter/rules/deprecated-ownership-fields.js";
+import { memoryConsistencyRule } from "../../src/linter/rules/memory-consistency.js";
 
 const fixturesDir = resolve(import.meta.dirname, "../fixtures");
 
@@ -742,6 +743,62 @@ describe("deprecatedOwnershipFieldsRule", () => {
       },
     });
     const diags = deprecatedOwnershipFieldsRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+});
+
+describe("memoryConsistencyRule", () => {
+  it("warns when resumable is true but emits_memory_ref is not declared", () => {
+    const dsl = makeDsl({
+      agents: {
+        "test-agent": {
+          role_name: "Test",
+          purpose: "Test",
+          memory: { resumable: true },
+        },
+      },
+    });
+    const diags = memoryConsistencyRule.run(dsl);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].ruleId).toBe("memory-consistency");
+    expect(diags[0].severity).toBe("warning");
+    expect(diags[0].path).toBe("agents.test-agent.memory");
+    expect(diags[0].message).toContain("emits_memory_ref");
+  });
+
+  it("errors when ref_required is true but resumable is not true", () => {
+    const dsl = makeDsl({
+      agents: {
+        "test-agent": {
+          role_name: "Test",
+          purpose: "Test",
+          memory: { ref_required: true },
+        },
+      },
+    });
+    const diags = memoryConsistencyRule.run(dsl);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].ruleId).toBe("memory-consistency");
+    expect(diags[0].severity).toBe("error");
+    expect(diags[0].path).toBe("agents.test-agent.memory");
+    expect(diags[0].message).toContain("ref_required");
+  });
+
+  it("passes when memory config is consistent", () => {
+    const dsl = makeDsl({
+      agents: {
+        "test-agent": {
+          role_name: "Test",
+          purpose: "Test",
+          memory: {
+            resumable: true,
+            ref_required: true,
+            emits_memory_ref: true,
+          },
+        },
+      },
+    });
+    const diags = memoryConsistencyRule.run(dsl);
     expect(diags).toHaveLength(0);
   });
 });

--- a/test/schema/schema.test.ts
+++ b/test/schema/schema.test.ts
@@ -276,6 +276,48 @@ describe("boundary values", () => {
   });
 });
 
+describe("memory capability", () => {
+  it("parses agent with memory block", () => {
+    const result = AgentSchema.safeParse({
+      role_name: "test",
+      purpose: "test",
+      memory: {
+        resumable: true,
+        ref_required: false,
+        emits_memory_ref: true,
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.memory).toEqual({
+        resumable: true,
+        ref_required: false,
+        emits_memory_ref: true,
+      });
+    }
+  });
+
+  it("allows agent without memory block", () => {
+    const result = AgentSchema.safeParse({
+      role_name: "test",
+      purpose: "test",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.memory).toBeUndefined();
+    }
+  });
+
+  it("allows partial memory block", () => {
+    const result = AgentSchema.safeParse({
+      role_name: "test",
+      purpose: "test",
+      memory: { resumable: true },
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
 describe("schema default values", () => {
   it("defaults all AgentSchema permission arrays to [] when omitted", () => {
     const a = AgentSchema.parse(minimalValidAgent);


### PR DESCRIPTION
## Summary
- Add `MemoryCapabilitySchema` to `AgentSchema` with `resumable`, `ref_required`, `emits_memory_ref` fields
- Add `memory-consistency` lint rule (warning: resumable without emits_memory_ref; error: ref_required without resumable)
- Regenerate JSON Schema

## Test plan
- [x] Schema parse tests (3 cases: full, absent, partial)
- [x] Lint rule tests (3 cases: warning, error, clean)
- [x] All 886 existing tests pass
- [x] `npm run typecheck` passes

Closes #101

Made with [Cursor](https://cursor.com)