### PR TITLE
docs(spec): artifact binding (v2) + $clone variant spec

### DIFF
--- a/docs/spec/artifact-binding-spec.md
+++ b/docs/spec/artifact-binding-spec.md
@@ -1,0 +1,550 @@
+# Abstract Artifact Binding — agent-contracts ↔ artifact-contracts 接続仕様
+
+> **Status**: Proposal (v2)
+> **Updated**: 2026-06-05
+> **目的**: 「汎用 agent-contracts DSL の artifact 定義をデフォルト値とし、artifact-contracts.yaml
+> の具象データで上書きして binding で結合する」を、**既存のガードレイル binding と同じ流れ**で実現する具体仕様。
+> **v2 変更点**: `$clone` の導入に伴い全面改訂。fanout モデルを廃止し、resolve 時
+> variant 生成 + LLM 委譲モデルに移行。binding モデルを簡略化（単一の `artifact_binding`）。
+> agent-contracts 中の artifact は既に抽象化されており、実体は config レベルで
+> artifact-contracts と binding により解決する。
+> **関連**: `artifact-contracts/traceability-proposal.md`, `SoftwareBinding` / guardrail-generator,
+> `docs/spec/instantiate-variant-slots-spec.md`
+
+---
+
+## 1. 参照モデル — ガードレイル binding の実装分析（検証済み）
+
+agent-contracts の実装を読むと、ガードレイルは **4 つの関心事**に分離されている。これが
+artifact にも適用すべきテンプレート。
+
+### 1.1 抽象宣言（DSL・汎用）— `src/schema/guardrail.ts`
+
+```ts
+GuardrailSchema = {
+  description: string;
+  scope: { agents?, tasks?, tools?, artifacts?, workflows? };  // ← すべて「ID 配列」= 抽象参照
+  rationale?, tags, exemptions?
+}
+```
+
+ガードレイル定義は **intent と抽象 scope（artifact ID 等）だけ**を持ち、具象パスや正規表現を
+持たない。
+
+### 1.2 ポリシー（DSL・汎用）— `GuardrailPolicySchema`
+
+```ts
+GuardrailPolicyRule = { guardrail: string; severity; action; allow_override; ... }
+```
+
+「どの guardrail を どの severity/action で強制するか」の決定。これも抽象。
+
+### 1.3 具象 binding（プロジェクト固有）— `src/schema/binding.ts` `SoftwareBinding`
+
+```ts
+SoftwareBinding = {
+  software: string; version: 1; extends?: string;
+  guardrail_impl?: Record<guardrailId, { checks: Check[] }>;  // ← 抽象 guardrail の具象実装
+  outputs?: Record<name, BindingOutput>;                       // target に "{var}" テンプレート
+  renders?, reporting?
+}
+Check = { matcher?: command_regex | content_regex | file_glob; script?; message? }
+```
+
+抽象 guardrail ID に対して、**具体的な matcher（正規表現・glob）や script** を与えるのは
+binding 側。
+
+### 1.4 解決（合成）— `src/guardrail-generator/resolve-checks.ts` / `resolve-paths.ts`
+
+```ts
+resolveChecks(dsl, binding, policy):
+  for (guardrailId, impl) of binding.guardrail_impl:
+    guardrail = dsl.guardrails[guardrailId]     // 抽象 intent + scope
+    policyRule = policy.rules.find(guardrail==id) // 強制決定
+    → ResolvedCheck { guardrail_id, guardrail, policy_rule, check }  // 合成
+
+resolveBindingTargetPath(target, config.paths, software):
+  target.replace("{var}", config.paths[var])    // 具象パスは config.paths から注入
+```
+
+`SoftwareBinding` は `extends`（パッケージ / 相対パス）で合成可能（`binding-loader.ts`）。
+
+### 1.5 抽出される原則
+
+```text
+DSL        : intent + 抽象 ID 参照（具象を持たない）
+Policy     : 強制決定（severity / action）
+Binding    : 抽象 ID → 具象実装（matcher / path / template）
+config.paths: 具象パス変数の注入点
+Resolver   : DSL × Binding × Policy を ID 一致で合成
+```
+
+**ID 一致で合成する**のが鍵。`guardrail_impl` のキーは DSL の guardrail ID。
+
+---
+
+## 2. 現状の非対称（これが問題）
+
+agent / tool / guardrail は **既に artifact を抽象 ID で参照している**:
+
+| 参照元 | フィールド | 値 | 所在 |
+|--------|-----------|----|----|
+| Agent | `own_artifacts` / `can_read_artifacts` / `can_write_artifacts` | artifact ID 配列 | `schema/agent.ts` |
+| Tool | `input_artifacts` / `output_artifacts` / `artifact_bindings` | artifact ID（と slot→ID） | `schema/tool.ts` |
+| Guardrail | `scope.artifacts` | artifact ID 配列 | `schema/guardrail.ts` |
+
+**ところが artifact の定義そのものが具象を含んでいる** — `schema/artifact.ts`:
+
+```ts
+ArtifactSchema = {
+  type; authority?; required_validations; guardrails?; producers; consumers; editors;
+  path_patterns?: string[];      // ← 具象（プロジェクト固有）
+  exclude_patterns?: string[];   // ← 具象
+}
+```
+
+ガードレイルは具象（matcher/path）が **binding 側**にあるのに、artifact は具象（path_patterns）が
+**DSL 側**にある。この**非対称**が「どこまでが汎用 agent-contracts DSL か」を不透明にしている。
+
+---
+
+## 3. 提案① — DSL 側の整理
+
+### 3.1 既存 `artifacts:` はデフォルト値として維持
+
+agent-contracts DSL の `artifacts:` セクションは**そのまま使う**。既存の `path_patterns` 等の
+フィールドも後方互換のため残す。ただし、artifact-contracts.yaml が binding された場合は
+**DSL の値はデフォルト値程度の意味**しか持たず、artifact-contracts.yaml の値で上書きされる。
+
+```yaml
+# agent-contracts DSL（汎用。path_patterns はデフォルト値）
+artifacts:
+  openapi-spec:
+    type: api-contract
+    authority: canonical
+    path_patterns: ["specs/**/*.yaml"]     # デフォルト値。binding で上書き可
+    required_validations: [openapi-lint]
+    guardrails: [no-manual-edit]
+```
+
+原則としては、**artifact-contracts.yaml で全て定義して上書きすることが望ましい**。
+agent-contracts DSL 中の具象値（path_patterns 等）はデフォルト値に過ぎない。
+
+### 3.2 agent-contracts 中の artifact は既に抽象化されている
+
+agent-contracts DSL の artifact 定義は **抽象 ID** である。agent / task / guardrail は
+この ID を参照する:
+
+- `agent.can_write_artifacts: [openapi-spec]` — agent が書ける artifact
+- `task.input_artifacts: [openapi-spec]` — task が必要とする artifact
+- `guardrail.scope.artifacts: [openapi-spec]` — guardrail が適用される artifact
+
+これらの ID 参照は変更不要。**実体（path_patterns 等の具象データ）は config レベルで
+artifact-contracts.yaml と binding により解決する**。
+
+### 3.3 variant と artifact の関係
+
+variant agent には `can_read/write_artifacts` で **具体的な artifact ID を直接指定**する。
+LLM は `purpose` + `can_read/write_artifacts` を見て委譲先を判断する。
+
+```yaml
+agents:
+  implementer.api_contract:
+    $clone:
+      from: implementer
+      merge:
+        purpose: "Implementer for API contract changes"
+        can_write_artifacts:
+          $replace: [openapi-spec]          # ← LLM がこれを見て判断
+        can_read_artifacts: [api-handler]
+```
+
+---
+
+## 4. 提案② — artifact binding（config で artifact-contracts.yaml を上書き注入）
+
+### 4.1 binding の流れ
+
+```text
+1. artifact-contracts.yaml を読み込む（プロジェクト固有の artifact 一覧）
+2. artifact-contracts の ID と agent-contracts 中の artifact ID をマッピング
+   - ID が一致するもの → そのまま上書き
+   - ID が一致しないもの → mappings で明示的に対応付け
+3. agent-contracts 中の artifact 定義は、既存の artifacts: をそのまま利用
+   - ただし binding により artifact-contracts.yaml の値で上書きされる
+   - agent-contracts 中の値はデフォルト値程度の意味
+4. binding 後、新しい resolved layer を構築（Bound DSL）
+```
+
+### 4.2 config の設定
+
+config に `artifact_binding` フィールドを追加する。
+
+#### 簡易形式（ID が全一致する場合）
+
+```yaml
+# agent-contracts.config.yaml
+dsl: ./agent-contracts.yaml
+artifact_binding: ./artifact-contracts.yaml
+bindings: [./binding.yaml]
+paths:
+  api_dir: specs/openapi
+```
+
+#### 明示的マッピング形式（ID が一致しない場合）
+
+```yaml
+# agent-contracts.config.yaml
+dsl: ./agent-contracts.yaml
+artifact_binding:
+  source: ./artifact-contracts.yaml
+  mappings:
+    # agent-contracts の artifact ID → artifact-contracts の artifact ID
+    openapi-spec: billing_api_contract
+    api-handler: billing_api_handler
+    api-test: billing_api_test
+bindings: [./binding.yaml]
+paths:
+  api_dir: specs/openapi
+```
+
+#### config スキーマ
+
+```ts
+// AgentContractsConfigSchema に追加
+AgentContractsConfig += {
+  artifact_binding?: string | {            // 簡易形式: パス文字列
+    source: string;                        // 明示的形式: artifact-contracts.yaml へのパス
+    mappings?: Record<string, string>;     // agent-contracts ID → artifact-contracts ID
+  };
+}
+```
+
+`teams` 単位でも指定可能:
+
+```yaml
+teams:
+  billing:
+    dsl: ./agent-contracts.yaml
+    artifact_binding:
+      source: ./billing-artifact-contracts.yaml
+      mappings:
+        openapi-spec: billing_api_contract
+```
+
+### 4.3 上書きセマンティクス
+
+artifact-contracts.yaml の artifact 定義は、agent-contracts DSL の artifact 定義を
+**フィールド単位で上書き**する。DSL にしかないフィールドは維持、artifact-contracts にしか
+ないフィールドは追加。
+
+```text
+Bound artifact = deepMerge(DSL artifact, artifact-contracts artifact)
+```
+
+具体例:
+
+```yaml
+# agent-contracts DSL の定義（デフォルト値）
+openapi-spec:
+  type: api-contract
+  authority: canonical
+  path_patterns: ["specs/**/*.yaml"]    # デフォルト
+  required_validations: [openapi-lint]
+
+# artifact-contracts.yaml の定義（プロジェクト固有）
+billing_api_contract:                    # mappings: openapi-spec → billing_api_contract
+  type: api-contract
+  authority: canonical
+  path_patterns: ["{api_dir}/openapi.yaml"]   # 上書き
+  x-domain: billing                            # 追加
+
+# Bound 後の結果
+openapi-spec:
+  type: api-contract
+  authority: canonical
+  path_patterns: ["specs/openapi/openapi.yaml"]   # 上書き + {var} 展開
+  x-domain: billing                                # artifact-contracts から追加
+  required_validations: [openapi-lint]             # DSL から維持
+```
+
+### 4.4 artifact-contracts.yaml 不在時の挙動
+
+`artifact_binding` が config に未指定の場合:
+- **従来動作のまま**。DSL の `path_patterns` がそのまま使われる。
+- 既存プロジェクトは一切影響を受けない。
+
+### 4.5 接続規約
+
+```text
+DSL(デフォルト)              config(注入)                     artifact-contracts.yaml(具象)
+artifacts.openapi-spec       ── artifact_binding ──▶  billing_api_contract (via mappings)
+  path_patterns: [specs/**]                            path_patterns: [{api_dir}/openapi.yaml]
+  type: api-contract                                   x-domain: billing
+                             ── paths.api_dir ───────▶  {api_dir} → specs/openapi
+                                                         ↓
+                                                    上書きマージ → Bound artifact
+```
+
+---
+
+## 5. 提案③ — 2 層の resolve フロー
+
+### 5.1 既存 resolve（DSL 単体）— 変更なし
+
+```text
+loadDsl → resolveExtendsChain → resolveClone → resolveToolExtends → substituteVars → expandDefaults
+→ Resolved DSL
+```
+
+`resolveClone`（新規）を追加するが、`$clone` がなければ no-op。
+出力は **agent-contracts DSL 単体の完全定義**。プロジェクト固有の具象データは含まない。
+
+### 5.2 Bound resolve（config レベルの全マージ・新規）
+
+Bound resolve は artifact-contracts だけでなく、**config が注入する全プロジェクト固有情報を
+統合**した結果を生成する。artifact-contracts が最大の新規追加要素だが、既存の guardrail binding /
+paths / policy 解決も同じ層に属する。
+
+```text
+Resolved DSL
+  ↓
+config レベルの全マージ:
+  ├─ artifact_binding (artifact-contracts.yaml で artifacts を上書き)  ← 新規・メイン
+  ├─ bindings (SoftwareBinding — guardrail_impl の合成)                ← 既存
+  ├─ paths ({var} テンプレート展開)                                      ← 既存
+  ├─ active_guardrail_policy (ポリシー選択)                             ← 既存
+  └─ (将来: model_mapping 等)
+  ↓
+→ Bound DSL（プロジェクト固有の完全な resolved DSL）
+  ↓
+navigation-index / SDK adapter / guardrail scope 解決
+```
+
+### 5.3 2 層の比較
+
+| | 既存 resolve（DSL 単体） | Bound resolve（config 全マージ） |
+|---|---|---|
+| 入力 | agent-contracts.yaml (+ extends chain) | Resolved DSL + config 全体（artifact-contracts, bindings, paths, policy, ...） |
+| 出力 | Resolved DSL | Bound DSL |
+| artifacts | 抽象定義（path_patterns はデフォルト値） | 抽象 + 具象（artifact-contracts で上書き + `{var}` 展開済み） |
+| guardrails | 抽象宣言のみ | guardrail_impl と合成済み（`_guardrailRules`） |
+| artifact-contracts | 不要 | 必要（config.artifact_binding で指定） |
+| 用途 | DSL 構造検証、lint、`$clone` 展開 | SDK adapter、navigation-index、guardrail scope |
+| 後方互換 | 完全互換 | config 注入が未指定時は Resolved DSL = Bound DSL |
+
+### 5.4 `resolveArtifactBinding` の実装
+
+```ts
+resolveArtifactBinding(resolvedDsl, registry, mappings?, paths?): {
+  boundDsl: ResolvedDsl;
+  diagnostics: Diagnostic[];
+}
+
+for (dslArtifactId, dslArtifact) of resolvedDsl.artifacts:
+  registryId = mappings?.[dslArtifactId] ?? dslArtifactId
+
+  concrete = registry.artifacts[registryId]
+  if (!concrete):
+    diagnostics.push({ severity: "warning", message: `No binding for "${dslArtifactId}"` })
+    continue
+
+  boundDsl.artifacts[dslArtifactId] = deepMerge(dslArtifact, concrete)
+
+for (registryId) of registry.artifacts:
+  if registryId not in reverseMapping:
+    diagnostics.push({ severity: "warning", message: `Orphan artifact "${registryId}"` })
+
+substituteVarsInPaths(boundDsl.artifacts, paths)
+```
+
+### 5.5 navigation-index への接続
+
+`buildNavigationIndex` は今 `dsl.artifacts.path_patterns` を直接読んでいるが、
+**Bound DSL の artifacts を読む**よう差し替える。Bound DSL では path_patterns が
+artifact-contracts.yaml から上書きされ、`{var}` も展開済みになっている。
+
+`artifact_binding` 不在時は Resolved DSL = Bound DSL なので、従来の DSL path_patterns が
+そのまま使われる。
+
+---
+
+## 6. 提案④ — 検証（既存 binding lint と同型）
+
+| ルール | 内容 | 重大度 |
+|--------|------|--------|
+| unbound-artifact | DSL の artifact に対応する artifact-contracts エントリがない | warning |
+| orphan-binding | artifact-contracts の artifact が DSL に対応 ID を持たない | warning |
+| referenced-undefined | agent/tool/guardrail が未定義の artifact ID を参照 | error |
+| path-overlap | 複数 artifact の path_patterns が重複（既存 `detectOverlaps` 流用） | warning |
+| type-mismatch | DSL と artifact-contracts で同一 ID の type/authority が矛盾 | warning |
+
+---
+
+## 7. 副次効果 — guardrail scope の重複解消
+
+現状 `guardrail_impl[].checks[].matcher.file_glob` は具象パスを binding に直書きしている
+（`resolve-checks.ts` は `scope.artifacts` を glob へ展開しない）。
+
+artifact が Bound resolve で具象 path_patterns を持った後は、**`scope.artifacts: [openapi-spec]`
+を持つ guardrail の file_glob を、bound artifact の path_patterns から自動導出**できる。これにより
+guardrail binding でのパス重複記述を削減できる（オプション拡張）。
+
+---
+
+## 8. 全体像 — 同一パターンへの統一
+
+| 関心事 | 抽象（DSL・デフォルト） | 具象（binding / config） | Resolver |
+|--------|----------------------|--------------------------|----------|
+| guardrail | `guardrails[id].scope` + policy | `SoftwareBinding.guardrail_impl[id].checks` | `resolveChecks`（既存） |
+| **artifact** | **`artifacts[id]`（type/authority/path_patterns — デフォルト値）** | **artifact-contracts.yaml（`artifact_binding` で指定）** | **`resolveArtifactBinding`（新規）** |
+| **agent variant** | **`$clone`（resolve 時展開）** | **（不要 — resolve 時に完全定義に展開済み）** | **`resolveClone`（新規）** |
+| toolchain | `tools[id].cli_contract`（抽象） | cli-contracts `execution_profiles.command_sets` | cli-contracts |
+| model/env | task `model_class`（抽象） | `agent-runtime.config` `model_mapping` | runtime |
+| output path | binding `outputs[].target {var}` | `config.paths` | `resolveBindingTargetPath`（既存） |
+
+artifact 行だけが「具象が DSL 側」に固定されていた。artifact-contracts.yaml による上書きを
+config 注入（`artifact_binding`）で行うと、全行が同じ「config が選択・注入、本体は別ファイル、
+DSL はデフォルト値」に揃う。**Bound DSL はこれら全 config 注入の統合結果**であり、
+artifact binding はその中で最大の新規追加要素。
+
+---
+
+## 9. 移行（段階的・非破壊）
+
+| 段階 | 内容 | 影響 |
+|------|------|------|
+| 1 | `AgentContractsConfig` に `artifact_binding?`（team 単位含む）を追加 | config のみ。後方互換（無ければ従来動作） |
+| 2 | `resolveArtifactBinding(dsl, registry, mappings, paths)` 実装 | 新規。未指定時は no-op |
+| 3 | `buildNavigationIndex` を Bound DSL の artifacts から読むよう差し替え。`artifact_binding` 不在時は従来の DSL path_patterns に fallback | 既存 DSL を壊さない |
+| 4 | 段階的に artifact-contracts.yaml に具象を集約し、DSL の path_patterns をデフォルト値化 | SSoT 一本化 |
+
+---
+
+## 10. variant 生成モデル（`$clone` + LLM 委譲）
+
+> v1 の §10「エージェント粒度と呼び出し時結線」を全面改訂。fanout モデルを廃止し、
+> resolve 時の `$clone` による variant 生成 + LLM description ベース委譲に移行。
+
+### 10.1 設計原則 — fanout ではなく variant 並列定義
+
+| NG（廃止） | OK（採用） |
+|-----------|-----------|
+| workflow に fanout を書く | `$clone` で agent/task variant を並列定義として生成 |
+| runtime で fanout 制御する | LLM runtime には候補 agents を全部登録 |
+| 呼び出し元で agent variant を分岐する | LLM が `purpose` + `can_read/write_artifacts` を見て委譲先を選ぶ |
+
+### 10.2 `$clone` による variant 生成
+
+エージェント契約は **行動契約が安定する粒度**で base を定義する。variant は
+`$clone`（既存オブジェクトのコピー + 差分マージ）で生成する。
+
+```yaml
+agents:
+  implementer:
+    role_name: Implementer
+    purpose: "General-purpose implementer for code changes"
+    mode: read-write
+    can_execute_tools: [Read, Edit, Write]
+    can_write_artifacts: [openapi-spec, api-handler]
+
+  implementer.api_contract:
+    $clone:
+      from: implementer
+      merge:
+        purpose: "Implementer for API contract changes. Use when writing API contract specifications."
+        can_write_artifacts:
+          $replace: [openapi-spec]
+        can_read_artifacts: [api-handler, api-test]
+        responsibilities:
+          $append:
+            - "Preserve backward compatibility"
+            - "Validate schema changes"
+```
+
+resolve 後は **2 つの独立した agent 定義**が agents map に存在する。runtime は通常どおり
+`buildCandidateAgents()` で全候補を LLM に登録し、LLM が `purpose` + `can_write_artifacts`
+を見て委譲先を選ぶ。
+
+詳細は `agent-contracts/docs/spec/instantiate-variant-slots-spec.md` §2 を参照。
+
+### 10.3 guardrail との一貫性
+
+「割当ドメイン外を編集しない」型の guardrail も同型で解ける:
+
+- DSL: `scope.artifacts` は artifact ID（抽象）を指す
+- Bound resolve: artifact の path_patterns が artifact-contracts.yaml で具象化される
+- 実行時: guardrail scope が具象パスに展開される
+
+variant ごとに異なる guardrail scope が必要なら、variant の `$clone.merge` で
+`guardrails` を追加する。
+
+---
+
+## 11. resolve の二相と直列化境界
+
+### 11.1 二相モデル
+
+```text
+Phase 1 「DSL resolve + Bound resolve」  ── 静的・決定的・ハッシュ可能
+  入力 : agent-contracts.yaml + config 全体
+  処理 :
+    1. DSL resolve — extends / $clone / toolExtends / vars → Resolved DSL
+    2. Bound resolve — config レベルの全マージ:
+       ├─ artifact_binding (artifact-contracts.yaml で artifacts 上書き)
+       ├─ bindings (SoftwareBinding — guardrail_impl 合成)
+       ├─ paths ({var} 展開)
+       ├─ active_guardrail_policy
+       └─ (将来: model_mapping 等)
+       → Bound DSL
+  出力 : Bound DSL（= Resolved DSL + config 全プロジェクト固有情報の統合）
+         + 安定ハッシュ resolved_contract_hash
+  性質 : 純合成（参照透過）。同じ入力 → 同じ直列化 → 同じハッシュ
+
+Phase 2 「dispatch（実行時）」 ── LLM による委譲先選択
+  入力 : Bound DSL + task context（自然言語 request）
+  処理 : LLM が candidate agents の purpose / can_read_write_artifacts を見て委譲先を選択
+  出力 : 選択された agent による task 実行結果
+  性質 : LLM 依存。再現不能。結果は Envelope に記録
+```
+
+### 11.2 静的 / 動的の境界
+
+| 要素 | 静的（Phase 1・Bound DSL） | 動的（Phase 2・実行時） |
+|------|--------------------------|----------------------|
+| DSL resolve（extends / vars / $clone） | Yes | |
+| artifact binding（artifact-contracts.yaml で上書き） | Yes | |
+| guardrail binding（guardrail_impl 合成） | Yes | |
+| policy 選択（active_guardrail_policy） | Yes | |
+| `{var}`（config.paths）展開 | Yes | |
+| glob → **実際にマッチするファイル集合** | | Yes（FS 状態依存） |
+| **LLM による variant 選択**（どの agent に委譲するか） | | Yes（purpose + artifacts ベース） |
+| context-map / read-edit-validate ターゲット | | Yes |
+
+### 11.3 設計規範
+
+- **Phase 1 は純粋マージ**（順序確定・参照透過）。`(DSL, config) → Bound DSL` を
+  決定的にする。drift 検出・キャッシュ・再現性・navigation-index 安定化の基盤。
+  config が注入する全要素（artifact binding, guardrail binding, paths, policy）が
+  この Phase に含まれる。
+- **Phase 2 は LLM の委譲判断のみ**。全 binding は Phase 1 で完了済み。
+- `resolved_contract_hash` は Phase 1（Bound DSL）に対して計算。
+
+### 11.4 AaaC 対応
+
+- Bound DSL = **derived view**（手書きせず計算する派生物）。
+  `Contract Version` は DSL Owner、`resolved_contract_hash` は Registry Index。
+- LLM の委譲判断 = **run fact** → Envelope / Observer（Lineage）。
+  Bound DSL には書かない（Rule 1: 実行事実を契約に混ぜない）。
+
+---
+
+## 12. 残課題
+
+- `config.artifact_binding` のロード経路（artifact-contracts.yaml の `$ref` 解決と `paths`
+  による `{var}` 展開を、config loader が行うか resolveArtifactBinding が行うか）。
+- `tool.artifact_bindings`（既存・DSL 内の静的参照）と config `artifact_binding`（新規・
+  artifact-contracts.yaml 上書き）の関係の明確化:
+  - tool の `artifact_bindings`: DSL 内で tool の cli-contract slot を artifact ID に静的参照
+  - config の `artifact_binding`: artifact-contracts.yaml を読み込んで DSL artifacts を上書き
+- guardrail file_glob 自動導出（§7）を初期に含めるか後続にするか。

--- a/docs/spec/instantiate-variant-slots-spec.md
+++ b/docs/spec/instantiate-variant-slots-spec.md
@@ -1,0 +1,532 @@
+# $clone 仕様
+
+> **Status**: Proposal
+> **Created**: 2026-06-05
+> **目的**: エージェント定義の variant 生成（`$clone`）を agent-contracts DSL に追加し、
+> **実行時 fanout なしで LLM が `purpose` + `can_read/write_artifacts` ベースで
+> 委譲先を選択する**モデルを実現する。
+> **関連**: `docs/spec/artifact-binding-spec.md`, `docs/spec/guardrail-di.md`
+
+---
+
+## 1. 設計原則
+
+### 1.1 前提（runtime 制約）
+
+- **実行時 fanout は行わない**。runtime の `candidate-agents.ts` / `task-runner.ts` はそのまま。
+- variant は **resolve 時に完全な並列定義として展開**される。runtime から見れば通常の agents/tasks。
+- LLM は登録された agents の `purpose` + `can_read/write_artifacts` を見て自動委譲する。
+
+### 1.2 用語
+
+| 用語 | 定義 |
+|------|------|
+| **base** | `$clone` の `from` で参照される既存エンティティ定義（オブジェクト） |
+| **variant** | `$clone` の解決結果として生成されるエンティティ（別 ID） |
+| **binding** | artifact-contracts.yaml の具象データで DSL の artifact 定義を上書きする処理 |
+| **resolve** | `$clone` を展開し通常の定義に変換する静的処理 |
+
+### 1.3 設計判断
+
+| 判断 | 根拠 |
+|------|------|
+| fanout という概念を出さない | runtime 変更不要。LLM の description ベース委譲で十分 |
+| `$clone` は resolve 時オペレーター | runtime 機能ではない。tool `extends` と同じ resolve 時処理 |
+| `$clone`（not `$instantiate`）| base はクラスではなく既存オブジェクト。「コピーして差分適用」が正確 |
+| variant は完全な定義として emit | resolve 後は通常の agents/tasks — runtime に variant 概念は不要 |
+| 新規スキーマフィールド不要 | `purpose` + `can_read/write_artifacts`（既存フィールド）で LLM は委譲先を判断できる |
+
+---
+
+## 2. `$clone` オペレーター
+
+### 2.1 概要
+
+base 定義をコピーし、差分を merge し、別 ID の定義として emit する **resolve 時オペレーター**。
+`tool.extends`（`src/resolver/tool-extends.ts`）の一般化だが、エンティティを上書きするのではなく
+**新規 ID で追加する**点が異なる。
+
+base はクラスやテンプレートではなく**既存の具象オブジェクト**であるため、`$instantiate` ではなく
+`$clone` を採用する。操作の実態は「オブジェクトのディープコピー + 差分マージ」である。
+
+### 2.2 適用対象
+
+map 型の全 top-level セクションに適用する。`$clone` は「コピーして差分マージ」する汎用操作
+であり、特定のエンティティに限定する理由がない。
+
+| セクション | 備考 |
+|------------|------|
+| `agents` | 主要ユースケース（agent variant） |
+| `tasks` | task variant（同じ workflow で異なる成果物を扱う） |
+| `artifacts` | artifact variant（同じ type で domain が異なる） |
+| `tools` | `tool.extends`（継承・上書き）とは別用途（別 ID で新規 emit）。共存可 |
+| `guardrails` | guardrail variant（同じ scope で severity/action が異なる） |
+| `handoff_types` | handoff variant |
+| `workflow` | workflow variant |
+
+### 2.3 構文
+
+```yaml
+agents:
+  <new-id>:
+    $clone:
+      from: <base-entity-id>     # 必須。同一セクション内の既存 ID
+      merge:                     # 任意。差分フィールド
+        <field>: <value>         #   スカラー: 上書き
+        <field>:                 #   配列/マップ: merge operator 使用可
+          $append: [...]
+```
+
+#### フィールド定義
+
+| フィールド | 型 | 必須 | 説明 |
+|-----------|------|------|------|
+| `from` | `string` | Yes | コピー元の base エンティティ ID。同一セクション（`agents` / `tasks` / `artifacts`）内に存在すること |
+| `merge` | `object` | No | base にマージする差分フィールド。省略時は base の完全コピー |
+
+- `merge` 内では既存の merge operator（`$append`, `$prepend`, `$insert_after`, `$replace`, `$remove`）が使用可能。
+- `merge` 内のスカラーフィールドは base を上書きする。
+- `merge` 内のオブジェクトフィールドは `deepMergeEntities` と同じセマンティクスで再帰マージする。
+
+### 2.4 解決セマンティクス
+
+```text
+resolveClone(entities: Record<string, Entity>):
+  1. entries を走査し、$clone を持つ entry を収集
+  2. 各 entry について:
+     a. from で指定された base を lookup（base 自体も $clone の場合は先に解決 — 依存順）
+     b. base が見つからない → CloneError
+     c. base をディープコピー
+     d. merge があれば deepMergeEntities(copy, merge, path, hasExtends=true) を適用
+     e. $clone キーを削除
+     f. 結果を new-id で entities に配置
+  3. 循環参照 → CloneError
+```
+
+#### 既存 merge operator との関係
+
+`$clone.merge` 内での merge operator 使用は、top-level `extends` の有無に関わらず許可する。
+`$clone` 自体が「base をコピーして差分適用する」意味であり、`hasExtends=true` として扱う。
+
+これは `tool.extends` が top-level `extends` なしでも機能するのと同じ設計。
+
+### 2.5 resolve パイプラインへの配置
+
+```text
+既存:
+  loadDsl → resolveExtendsChain → resolveToolExtends → substituteVars → expandDefaults
+
+提案:
+  loadDsl → resolveExtendsChain → resolveClone → resolveToolExtends → substituteVars → expandDefaults
+                                  ^^^^^^^^^^^^
+                                  新規フェーズ
+```
+
+`resolveExtendsChain` の後（= 全 base 定義が確定済み）、`resolveToolExtends` の前に配置する。
+`resolveClone` は map 型の全 top-level セクションに対して適用する。
+
+### 2.6 例
+
+#### 入力（resolve 前）
+
+```yaml
+agents:
+  implementer:
+    role_name: Implementer
+    purpose: "General-purpose implementer"
+    mode: read-write
+    can_write_artifacts: [openapi-spec, api-handler]
+    responsibilities:
+      - "Implement changes safely"
+    rules:
+      - id: R-IMPL-001
+        description: "Preserve existing structure"
+        severity: mandatory
+    can_execute_tools: [Read, Edit, Write]
+
+  implementer.api_contract:
+    $clone:
+      from: implementer
+      merge:
+        purpose: "Implementer specialized for API contract changes"
+        can_write_artifacts:
+          $replace: [openapi-spec]
+        can_read_artifacts: [api-handler, api-test]
+        responsibilities:
+          $append:
+            - "Preserve backward compatibility"
+            - "Validate schema changes"
+        rules:
+          $append:
+            - id: R-IMPL-API-001
+              description: "Validate backward compatibility of API schema changes"
+              severity: mandatory
+```
+
+#### 出力（resolve 後）
+
+```yaml
+agents:
+  implementer:
+    role_name: Implementer
+    purpose: "General-purpose implementer"
+    mode: read-write
+    can_write_artifacts: [openapi-spec, api-handler]
+    responsibilities:
+      - "Implement changes safely"
+    rules:
+      - id: R-IMPL-001
+        description: "Preserve existing structure"
+        severity: mandatory
+    can_execute_tools: [Read, Edit, Write]
+
+  implementer.api_contract:
+    role_name: Implementer
+    purpose: "Implementer specialized for API contract changes"
+    mode: read-write
+    can_write_artifacts: [openapi-spec]
+    can_read_artifacts: [api-handler, api-test]
+    responsibilities:
+      - "Implement changes safely"
+      - "Preserve backward compatibility"
+      - "Validate schema changes"
+    rules:
+      - id: R-IMPL-001
+        description: "Preserve existing structure"
+        severity: mandatory
+      - id: R-IMPL-API-001
+        description: "Validate backward compatibility of API schema changes"
+        severity: mandatory
+    can_execute_tools: [Read, Edit, Write]
+```
+
+`$clone` は消え、通常の agent 定義だけが残る。runtime から見れば 2 つの独立した agent。
+LLM は `purpose` + `can_write_artifacts: [openapi-spec]` を見て委譲先を判断する。
+
+### 2.7 連鎖（chaining）
+
+`$clone` は連鎖可能。variant から更に variant を派生できる。
+
+```yaml
+agents:
+  implementer.api_contract.billing:
+    $clone:
+      from: implementer.api_contract
+      merge:
+        purpose: "Implementer for billing API contract changes"
+        can_write_artifacts:
+          $replace: [billing-openapi-spec]
+        can_read_artifacts:
+          $replace: [billing-api-handler, billing-api-test]
+```
+
+解決順序は依存グラフの位相ソートで決定する。循環は `CloneError`。
+
+### 2.8 制約
+
+| 制約 | 根拠 |
+|------|------|
+| `from` は同一セクション内の ID | 同一 map セクション内。cross-section は不可 |
+| base が `$clone` の場合は先に解決 | 位相ソート。循環は error |
+| `merge` 内の `$clone` はネスト不可 | `$clone` は entity 直下のみ |
+| resolve 後に `$clone` キーは残らない | runtime に variant 概念は不要 |
+| base entity は resolve 後も残る | 削除されない。base 自体も有効な定義 |
+
+### 2.9 エラー
+
+| エラー | 条件 | 重大度 |
+|--------|------|--------|
+| `CloneError: base not found` | `from` が同一セクション内に存在しない | error |
+| `CloneError: circular` | `$clone` チェーンが循環 | error |
+| `CloneError: merge conflict` | merge operator が base に存在しないフィールドに適用 | error (MergeError) |
+
+---
+
+## 3. 2 層の resolve パイプライン
+
+### 3.1 既存 resolve（DSL 単体）
+
+```text
+loadDsl (Phase 1: $ref/$refs assembly)
+  ↓
+resolveExtendsChain (top-level extends — file/package merge)
+  ↓
+resolveClone (NEW — agents/tasks/artifacts の $clone を展開)
+  ↓
+resolveToolExtends (tools map 内の extends chain)
+  ↓
+substituteVars (${vars.*} 置換)
+  ↓
+expandDefaults (optional — Zod defaults を展開)
+  ↓
+→ Resolved DSL（agent-contracts 単体の完全定義）
+```
+
+これは既存の resolve パイプラインに `resolveClone` を追加しただけ。
+**DSL 単体で閉じた resolve** であり、プロジェクト固有の具象データは含まない。
+
+### 3.2 Bound resolve（config レベルの全マージ・新規）
+
+Bound resolve は artifact-contracts だけでなく、**config が注入する全プロジェクト固有情報を
+統合**した結果を生成する。artifact-contracts が最大の新規追加要素だが、既存の guardrail binding /
+paths / policy 解決も同じ層に属する。
+
+```text
+Resolved DSL（§3.1 の出力）
+  ↓
+config レベルの全マージ:
+  ├─ artifact_binding (artifact-contracts.yaml で artifacts を上書き)  ← 新規・メイン
+  ├─ bindings (SoftwareBinding — guardrail_impl の合成)                ← 既存
+  ├─ paths ({var} テンプレート展開)                                      ← 既存
+  ├─ active_guardrail_policy (ポリシー選択)                             ← 既存
+  └─ (将来: model_mapping 等)
+  ↓
+→ Bound DSL（プロジェクト固有の完全な resolved DSL）
+  ↓
+validateSchema → checkReferences → lint → generate / navigation-index
+```
+
+Bound resolve の入力と出力:
+
+| | 既存 resolve（DSL 単体） | Bound resolve（config 全マージ） |
+|---|---|---|
+| 入力 | agent-contracts.yaml (+ extends chain) | Resolved DSL + config 全体（artifact-contracts, bindings, paths, policy, ...） |
+| 出力 | Resolved DSL | Bound DSL |
+| artifacts の内容 | 抽象定義（type, authority 等）。path_patterns はデフォルト値 | 抽象 + 具象（artifact-contracts で上書き + `{var}` 展開済み） |
+| guardrails | 抽象宣言のみ | guardrail_impl と合成済み（`_guardrailRules`） |
+| 用途 | DSL の構造検証、lint | SDK adapter、navigation-index、guardrail scope 解決 |
+
+### 3.3 resolveClone の位置の根拠
+
+| 位置 | 根拠 |
+|------|------|
+| `resolveExtendsChain` の後 | base 定義が file merge で確定している必要がある |
+| `resolveToolExtends` の前 | clone で生成された agent が tool の `invokable_by` に現れうる |
+| `substituteVars` の前 | `${vars.*}` は clone 後に統一的に展開 |
+
+### 3.4 validate / lint への影響
+
+| 検証 | 変更 |
+|------|------|
+| `checkReferences` | `$clone` 展開後の agent/task が参照する artifact ID の存在チェック |
+| schema validation | 変更なし（既存スキーマのみ使用） |
+
+---
+
+## 4. スキーマ変更サマリー
+
+### 4.1 既存スキーマ変更
+
+| ファイル | 変更 |
+|----------|------|
+| `src/config/types.ts` | `artifact_binding` フィールド追加（optional） |
+
+### 4.2 resolver 変更
+
+| ファイル | 変更 |
+|----------|------|
+| `src/resolver/clone.ts` (新規) | `resolveClone()` 実装 |
+| `src/resolver/resolve.ts` | パイプラインに `resolveClone` フェーズ追加 |
+| `src/resolver/artifact-binding.ts` (新規) | `resolveArtifactBinding()` — artifact-contracts.yaml との合成 |
+
+### 4.3 変更不要
+
+| ファイル | 根拠 |
+|----------|------|
+| `src/schema/agent.ts` | `can_read/write_artifacts` は既存フィールド |
+| `src/schema/artifact.ts` | 既存の `type` / `authority` で分類は十分 |
+| `src/schema/task.ts` | `input_artifacts` で artifact を直接参照（既存） |
+| `src/schema/dsl.ts` | 新規 top-level セクション追加なし |
+| `src/resolver/tool-extends.ts` | tool は `$clone` 対象外 |
+| `src/resolver/merger.ts` | 新規セクション追加なし |
+| runtime (`task-runner.ts` 等) | resolve 後は通常の定義。runtime 変更不要 |
+
+---
+
+## 5. 検証ルール
+
+### 5.1 `$clone` 検証
+
+| ルール ID | 条件 | 重大度 |
+|-----------|------|--------|
+| `clone-base-exists` | `from` が同一セクションに存在する | error |
+| `clone-no-circular` | `$clone` チェーンが循環しない | error |
+| `clone-merge-valid` | `merge` 内の merge operator が base のフィールドに適用可能 | error |
+
+### 5.2 artifact binding 検証（Bound resolve 時）
+
+| ルール ID | 条件 | 重大度 |
+|-----------|------|--------|
+| `unbound-artifact` | DSL の artifact に対応する artifact-contracts エントリがない | warning |
+| `orphan-binding` | artifact-contracts の artifact が DSL に対応 ID を持たない | warning |
+| `type-mismatch` | DSL と artifact-contracts で同一 ID の type/authority が矛盾 | warning |
+
+---
+
+## 6. 既存メカニズムとの比較
+
+### 6.1 `$clone` vs top-level `extends`
+
+| 比較軸 | top-level `extends` | `$clone` |
+|--------|---------------------|----------|
+| スコープ | ファイル全体（DSL 間） | エンティティ単位（セクション内） |
+| 用途 | base team の継承 | agent/task/artifact の variant 生成 |
+| 結果 | 1 つの merged DSL | 新規 ID のエンティティが追加 |
+| base の扱い | base ファイルの内容が project に merge | base エンティティは残る（削除されない） |
+| resolve 位置 | パイプライン最初期 | extends 解決後 |
+| メタファー | ファイル継承 | オブジェクトのクローン + diff |
+
+### 6.2 `$clone` vs `tool.extends`
+
+| 比較軸 | `tool.extends` | `$clone` |
+|--------|----------------|----------|
+| 対象 | tools のみ | agents, tasks, artifacts |
+| セマンティクス | child が base を継承・上書き | base をコピーし差分 merge して新 ID で emit |
+| base の扱い | base は残る | base は残る |
+| merge operator | 使用不可（フィールド単位の継承ルール） | 既存 merge operator が使用可 |
+| resolve 位置 | `resolveToolExtends` | `resolveClone`（より前） |
+
+---
+
+## 7. 具体例 — 全機能の組み合わせ
+
+### 7.1 DSL（agent-contracts.yaml）
+
+```yaml
+version: 1
+
+artifacts:
+  openapi-spec:
+    type: api-contract
+    authority: canonical
+    path_patterns: ["specs/**/*.yaml"]     # デフォルト値。binding で上書き可
+  api-handler:
+    type: implementation
+  api-test:
+    type: test
+
+agents:
+  implementer:
+    role_name: Implementer
+    purpose: "General-purpose implementer for code changes"
+    mode: read-write
+    can_execute_tools: [Read, Edit, Write]
+    can_write_artifacts: [openapi-spec, api-handler]
+    responsibilities:
+      - "Implement changes safely"
+    rules:
+      - id: R-IMPL-001
+        description: "Preserve existing code structure"
+        severity: mandatory
+
+  implementer.api_contract:
+    $clone:
+      from: implementer
+      merge:
+        purpose: "Implementer for API contract changes. Use when writing API contract specifications."
+        can_write_artifacts:
+          $replace: [openapi-spec]
+        can_read_artifacts: [api-handler, api-test]
+        responsibilities:
+          $append:
+            - "Preserve backward compatibility of API contracts"
+            - "Validate schema changes against consumers"
+        rules:
+          $append:
+            - id: R-IMPL-API-001
+              description: "Validate backward compatibility"
+              severity: mandatory
+
+tasks:
+  implement_change:
+    description: "Implement a requested change to a project artifact"
+    target_agent: implementer
+    workflow: implement
+    input_artifacts: [openapi-spec, api-handler]
+    invocation_handoff: task-delegation
+    result_handoff: task-result
+```
+
+### 7.2 Config（agent-contracts.config.yaml）
+
+```yaml
+dsl: ./agent-contracts.yaml
+artifact_binding: ./artifact-contracts.yaml
+bindings: [./binding.yaml]
+paths:
+  api_dir: contracts/billing
+```
+
+ID が一致しない場合は mappings で明示的に対応付ける:
+
+```yaml
+artifact_binding:
+  source: ./artifact-contracts.yaml
+  mappings:
+    openapi-spec: billing_api_contract
+    api-handler: billing_api_handler
+    api-test: billing_api_test
+```
+
+### 7.3 Artifact Registry（artifact-contracts.yaml）
+
+```yaml
+schema_version: "2026A"
+artifacts:
+  billing_api_contract:
+    type: api-contract
+    authority: canonical
+    path_patterns: ["{api_dir}/openapi.yaml"]
+    x-domain: billing
+
+  billing_api_handler:
+    type: implementation
+    authority: canonical
+    path_patterns: ["src/billing/api/**/*.ts"]
+    x-domain: billing
+
+  billing_api_test:
+    type: test
+    authority: canonical
+    path_patterns: ["tests/billing/api/**/*.test.ts"]
+    x-domain: billing
+```
+
+### 7.4 Bound resolve 後の artifacts（runtime に渡るもの）
+
+```yaml
+artifacts:
+  openapi-spec:
+    type: api-contract
+    authority: canonical
+    path_patterns: ["contracts/billing/openapi.yaml"]    # artifact-contracts から上書き + {var} 展開
+    x-domain: billing                                     # artifact-contracts から追加
+  api-handler:
+    type: implementation
+    authority: canonical
+    path_patterns: ["src/billing/api/**/*.ts"]
+    x-domain: billing
+  api-test:
+    type: test
+    authority: canonical
+    path_patterns: ["tests/billing/api/**/*.test.ts"]
+    x-domain: billing
+```
+
+LLM は `implementer.api_contract` の `purpose` + `can_write_artifacts: [openapi-spec]` を見て、
+openapi-spec を変更する task が来たときにこの variant に委譲する。
+
+---
+
+## 8. 移行（段階的・非破壊）
+
+| 段階 | 内容 | 影響 |
+|------|------|------|
+| 1 | `resolveClone` 実装、resolve パイプラインに追加 | `$clone` がなければ no-op |
+| 2 | config に `artifact_binding` サポート追加、`resolveArtifactBinding` 実装 | binding-spec と連動 |
+
+---
+
+## 9. 残課題
+
+（現時点でなし）


### PR DESCRIPTION
## Summary
- `docs/spec/artifact-binding-spec.md` (v2): abstract artifact binding — generic agent-contracts DSL artifact defaults overridden by artifact-contracts.yaml concrete data, combined via binding (same flow as guardrail binding). v2 introduces `$clone` (resolve-time variant generation + LLM delegation), replacing the fanout model; binding simplified to a single `artifact_binding`.
- `docs/spec/instantiate-variant-slots-spec.md`: `$clone` spec — agent-definition variant generation in the agent-contracts DSL.

Design docs only.

Made with [Cursor](https://cursor.com)