### PR TITLE
feat: add $clone operator and artifact_binding config (v0.34.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.34.2",
+  "version": "0.34.3",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -6,14 +6,17 @@ export {
   type AgentContractsConfig,
   type ResolvedConfig,
   type ResolvedTeamConfig,
+  type ResolvedArtifactBinding,
   type RenderTarget,
   type ResolvedRenderTarget,
   type TeamConfig,
+  type ArtifactBindingConfig,
   type ContextType,
   CONTEXT_TYPES,
   AgentContractsConfigSchema,
   RenderTargetSchema,
   TeamConfigSchema,
+  ArtifactBindingConfigSchema,
   ContextTypeSchema,
 } from "./types.js";
 export { loadConfig, resolveDslPath, ConfigLoadError } from "./loader.js";

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -3,9 +3,11 @@ import { resolve, dirname } from "node:path";
 import { parse as parseYaml } from "yaml";
 import {
   AgentContractsConfigSchema,
+  type ResolvedArtifactBinding,
   type ResolvedConfig,
   type ResolvedTeamConfig,
   type TeamConfig,
+  type ArtifactBindingConfig,
 } from "./types.js";
 
 const DEFAULT_CONFIG_NAME = "agent-contracts.config.yaml";
@@ -27,6 +29,24 @@ async function fileExists(filePath: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+function resolveArtifactBindingConfig(
+  binding: ArtifactBindingConfig | undefined,
+  configDir: string,
+): ResolvedArtifactBinding | undefined {
+  if (binding === undefined) {
+    return undefined;
+  }
+
+  if (typeof binding === "string") {
+    return { source: resolve(configDir, binding) };
+  }
+
+  return {
+    source: resolve(configDir, binding.source),
+    mappings: binding.mappings,
+  };
 }
 
 function resolveTeamConfigs(
@@ -63,6 +83,10 @@ function resolveTeamConfigs(
       interfaceOutput: team.interface_output
         ? resolve(configDir, team.interface_output)
         : undefined,
+      artifactBinding: resolveArtifactBindingConfig(
+        team.artifact_binding ?? defaults?.artifact_binding,
+        configDir,
+      ),
     };
   }
 
@@ -151,6 +175,7 @@ export async function loadConfig(
     paths: config.paths,
     audit: config.audit ?? undefined,
     artifactCoverage: config.artifact_coverage ?? undefined,
+    artifactBinding: resolveArtifactBindingConfig(config.artifact_binding, configDir),
   };
 }
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -34,6 +34,16 @@ export const RenderTargetSchema = z
 
 export type RenderTarget = z.infer<typeof RenderTargetSchema>;
 
+export const ArtifactBindingConfigSchema = z.union([
+  z.string(),
+  z.object({
+    source: z.string(),
+    mappings: z.record(z.string(), z.string()).optional(),
+  }),
+]);
+
+export type ArtifactBindingConfig = z.infer<typeof ArtifactBindingConfigSchema>;
+
 export const TeamConfigSchema = z.object({
   dsl: z.string().optional(),
   bindings: z.array(z.string()).default([]),
@@ -41,6 +51,7 @@ export const TeamConfigSchema = z.object({
   paths: z.record(z.string(), z.string()).optional(),
   active_guardrail_policy: z.string().optional(),
   interface_output: z.string().optional(),
+  artifact_binding: ArtifactBindingConfigSchema.optional(),
 });
 
 export type TeamConfig = z.infer<typeof TeamConfigSchema>;
@@ -75,6 +86,7 @@ export const AgentContractsConfigSchema = z
     teams: z.record(z.string(), TeamConfigSchema).optional(),
     audit: AuditConfigSchema,
     artifact_coverage: ArtifactCoverageConfigSchema,
+    artifact_binding: ArtifactBindingConfigSchema.optional(),
   })
   .superRefine((data, ctx) => {
     if (data.dsl !== undefined && data.teams !== undefined) {
@@ -118,6 +130,11 @@ export interface ResolvedRenderTarget {
   skip_empty?: boolean;
 }
 
+export interface ResolvedArtifactBinding {
+  source: string;
+  mappings?: Record<string, string>;
+}
+
 export interface ResolvedTeamConfig {
   dsl: string;
   vars?: Record<string, string>;
@@ -125,6 +142,7 @@ export interface ResolvedTeamConfig {
   activeGuardrailPolicy?: string;
   paths?: Record<string, string>;
   interfaceOutput?: string;
+  artifactBinding?: ResolvedArtifactBinding;
 }
 
 export interface ResolvedConfig {
@@ -138,4 +156,5 @@ export interface ResolvedConfig {
   teams?: Record<string, ResolvedTeamConfig>;
   audit?: AuditConfig;
   artifactCoverage?: { exclude_patterns: string[] };
+  artifactBinding?: ResolvedArtifactBinding;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export * from "./schema/index.js";
 export { loadDsl, DslLoadError, type LoadResult } from "./loader/index.js";
-export { resolve, mergeDsl, resolveBase, expandDefaults, MergeError, BaseResolveError, type ResolveResult } from "./resolver/index.js";
+export { resolve, mergeDsl, resolveBase, expandDefaults, resolveBound, resolveArtifactBinding, MergeError, CloneError, BaseResolveError, type ResolveResult, type BoundResolveOptions, type BoundResolveResult, type ArtifactBindingDiagnostic, type ArtifactBindingResult } from "./resolver/index.js";
 export { validateSchema, checkReferences, validateHandoffSchemas, type SchemaValidationResult, type DiagnosticMessage, type ReferenceDiagnostic } from "./validator/index.js";
 export { lint, builtinRules, spectralLint, yamlReservedKeySafetyRule, type LintRule, type LintDiagnostic, type Severity } from "./linter/index.js";
 export {
@@ -45,6 +45,7 @@ export {
   type AgentContractsConfig,
   type LoadedBinding,
   type ResolvedConfig,
+  type ResolvedArtifactBinding,
   type RenderTarget,
   type ResolvedRenderTarget,
   type ContextType,

--- a/src/navigation-index/builder.ts
+++ b/src/navigation-index/builder.ts
@@ -298,6 +298,8 @@ export function buildNavigationIndex(dsl: Dsl): ProjectNavigationIndex {
   const agentsByArtifact = new Map<string, CompiledArtifactNode["agents"]>();
 
   for (const [artifactId, artifactDef] of Object.entries(dsl.artifacts)) {
+    // Artifacts are read from the caller-supplied DSL. When artifact_binding is
+    // configured, pass Bound DSL from resolveBound() so merged path_patterns apply.
     const properties = defaultProperties(artifactDef);
     const agents = buildAgentMapping(dsl, artifactId);
     agentsByArtifact.set(artifactId, agents);

--- a/src/resolver/artifact-binding.ts
+++ b/src/resolver/artifact-binding.ts
@@ -1,0 +1,145 @@
+export interface ArtifactBindingDiagnostic {
+  severity: "warning" | "error";
+  rule: "unbound-artifact" | "orphan-binding" | "type-mismatch";
+  message: string;
+}
+
+export interface ArtifactBindingResult {
+  artifacts: Record<string, unknown>;
+  diagnostics: ArtifactBindingDiagnostic[];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function deepMerge(
+  base: Record<string, unknown>,
+  overlay: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, overlayValue] of Object.entries(overlay)) {
+    const baseValue = result[key];
+    if (isPlainObject(baseValue) && isPlainObject(overlayValue)) {
+      result[key] = deepMerge(baseValue, overlayValue);
+    } else {
+      result[key] = overlayValue;
+    }
+  }
+  return result;
+}
+
+function substitutePathPatterns(
+  artifact: Record<string, unknown>,
+  paths?: Record<string, string>,
+): Record<string, unknown> {
+  if (!paths) {
+    return artifact;
+  }
+
+  const pathPatterns = artifact.path_patterns;
+  if (!Array.isArray(pathPatterns)) {
+    return artifact;
+  }
+
+  const substituted = pathPatterns.map((pattern) => {
+    if (typeof pattern !== "string") {
+      return pattern;
+    }
+    return pattern.replace(/\{(\w+)\}/g, (match, varName: string) => {
+      return paths[varName] ?? match;
+    });
+  });
+
+  return { ...artifact, path_patterns: substituted };
+}
+
+function asArtifactRecord(value: unknown): Record<string, unknown> | undefined {
+  if (isPlainObject(value)) {
+    return value;
+  }
+  return undefined;
+}
+
+function checkTypeMismatch(
+  dslArtifactId: string,
+  dslArtifact: Record<string, unknown>,
+  registryArtifact: Record<string, unknown>,
+): ArtifactBindingDiagnostic | undefined {
+  for (const field of ["type", "authority"] as const) {
+    const dslValue = dslArtifact[field];
+    const registryValue = registryArtifact[field];
+    if (
+      dslValue !== undefined &&
+      registryValue !== undefined &&
+      dslValue !== registryValue
+    ) {
+      return {
+        severity: "warning",
+        rule: "type-mismatch",
+        message:
+          `Artifact "${dslArtifactId}" has conflicting ${field}: ` +
+          `DSL="${String(dslValue)}" vs registry="${String(registryValue)}"`,
+      };
+    }
+  }
+  return undefined;
+}
+
+export function resolveArtifactBinding(
+  dslArtifacts: Record<string, unknown>,
+  registry: { artifacts: Record<string, unknown> },
+  mappings?: Record<string, string>,
+  paths?: Record<string, string>,
+): ArtifactBindingResult {
+  const diagnostics: ArtifactBindingDiagnostic[] = [];
+  const mergedArtifacts: Record<string, unknown> = {};
+  const usedRegistryIds = new Set<string>();
+
+  for (const [dslArtifactId, dslArtifactRaw] of Object.entries(dslArtifacts)) {
+    const dslArtifact = asArtifactRecord(dslArtifactRaw) ?? {};
+    const registryId = mappings?.[dslArtifactId] ?? dslArtifactId;
+    const registryArtifact = asArtifactRecord(registry.artifacts[registryId]);
+
+    if (registryArtifact) {
+      usedRegistryIds.add(registryId);
+
+      const mismatch = checkTypeMismatch(
+        dslArtifactId,
+        dslArtifact,
+        registryArtifact,
+      );
+      if (mismatch) {
+        diagnostics.push(mismatch);
+      }
+
+      const merged = deepMerge(dslArtifact, registryArtifact);
+      mergedArtifacts[dslArtifactId] = substitutePathPatterns(merged, paths);
+    } else {
+      diagnostics.push({
+        severity: "warning",
+        rule: "unbound-artifact",
+        message:
+          `DSL artifact "${dslArtifactId}" has no matching registry artifact ` +
+          `(mapped to "${registryId}")`,
+      });
+      mergedArtifacts[dslArtifactId] = substitutePathPatterns(
+        { ...dslArtifact },
+        paths,
+      );
+    }
+  }
+
+  for (const registryId of Object.keys(registry.artifacts)) {
+    if (!usedRegistryIds.has(registryId)) {
+      diagnostics.push({
+        severity: "warning",
+        rule: "orphan-binding",
+        message:
+          `Registry artifact "${registryId}" is not mapped to any DSL artifact`,
+      });
+    }
+  }
+
+  return { artifacts: mergedArtifacts, diagnostics };
+}

--- a/src/resolver/bound-resolve.ts
+++ b/src/resolver/bound-resolve.ts
@@ -1,0 +1,70 @@
+import { readFile } from "node:fs/promises";
+import { parse as parseYaml } from "yaml";
+import { ConfigLoadError } from "../config/loader.js";
+import {
+  resolveArtifactBinding,
+  type ArtifactBindingDiagnostic,
+} from "./artifact-binding.js";
+
+export interface BoundResolveOptions {
+  artifactBinding?: {
+    source: string;
+    mappings?: Record<string, string>;
+  };
+  paths?: Record<string, string>;
+}
+
+export interface BoundResolveResult {
+  data: Record<string, unknown>;
+  diagnostics: ArtifactBindingDiagnostic[];
+}
+
+export async function resolveBound(
+  resolvedDsl: Record<string, unknown>,
+  options: BoundResolveOptions,
+): Promise<BoundResolveResult> {
+  if (!options.artifactBinding) {
+    return { data: resolvedDsl, diagnostics: [] };
+  }
+
+  const sourcePath = options.artifactBinding.source;
+  let content: string;
+  try {
+    content = await readFile(sourcePath, "utf8");
+  } catch {
+    throw new ConfigLoadError(
+      `Failed to read artifact binding file: ${sourcePath}`,
+      sourcePath,
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = parseYaml(content);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new ConfigLoadError(
+      `Invalid YAML syntax in artifact binding file ${sourcePath}: ${msg}`,
+      sourcePath,
+    );
+  }
+
+  const parsed = raw as Record<string, unknown>;
+  const registryArtifacts = (parsed.artifacts ?? {}) as Record<string, unknown>;
+  const dslArtifacts = (resolvedDsl.artifacts ?? {}) as Record<string, unknown>;
+
+  const bindingResult = resolveArtifactBinding(
+    dslArtifacts,
+    { artifacts: registryArtifacts },
+    options.artifactBinding.mappings,
+    options.paths,
+  );
+
+  return {
+    data: {
+      ...resolvedDsl,
+      artifacts: bindingResult.artifacts,
+    },
+    diagnostics: bindingResult.diagnostics,
+  };
+}

--- a/src/resolver/clone.ts
+++ b/src/resolver/clone.ts
@@ -1,0 +1,152 @@
+import { deepMergeEntities } from "./merger.js";
+
+export class CloneError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CloneError";
+  }
+}
+
+type AnyRecord = Record<string, unknown>;
+
+function isRecord(v: unknown): v is AnyRecord {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Map-type top-level DSL sections (mirrors merger.ts DSL_SECTIONS where mode === "map"). */
+const MAP_SECTIONS = [
+  "agents",
+  "tasks",
+  "artifacts",
+  "tools",
+  "validations",
+  "handoff_types",
+  "imports",
+  "workflow",
+  "policies",
+  "guardrails",
+  "guardrail_policies",
+  "components",
+  "extensions",
+] as const;
+
+function deepCopy<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function hasClone(entity: unknown): boolean {
+  return isRecord(entity) && "$clone" in entity;
+}
+
+function getCloneSpec(
+  entity: AnyRecord,
+): { from: string; merge?: AnyRecord } {
+  const clone = entity["$clone"];
+  if (!isRecord(clone)) {
+    throw new CloneError("Invalid $clone: expected object");
+  }
+  const from = clone["from"];
+  if (typeof from !== "string") {
+    throw new CloneError("Invalid $clone: from must be a string");
+  }
+  const merge = clone["merge"];
+  return {
+    from,
+    merge: isRecord(merge) ? merge : undefined,
+  };
+}
+
+function topologicalSortCloneIds(
+  cloneIds: string[],
+  entities: AnyRecord,
+): string[] {
+  const cloneSet = new Set(cloneIds);
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const result: string[] = [];
+
+  function visit(id: string): void {
+    if (visited.has(id)) {
+      return;
+    }
+    if (visiting.has(id)) {
+      throw new CloneError(
+        `circular reference detected involving "${id}"`,
+      );
+    }
+
+    visiting.add(id);
+    const spec = getCloneSpec(entities[id] as AnyRecord);
+    if (cloneSet.has(spec.from)) {
+      visit(spec.from);
+    }
+    visiting.delete(id);
+    visited.add(id);
+    result.push(id);
+  }
+
+  for (const id of cloneIds) {
+    visit(id);
+  }
+
+  return result;
+}
+
+function resolveSectionClones(section: string, entities: AnyRecord): void {
+  const cloneIds = Object.keys(entities).filter((id) =>
+    hasClone(entities[id]),
+  );
+  if (cloneIds.length === 0) {
+    return;
+  }
+
+  const sorted = topologicalSortCloneIds(cloneIds, entities);
+  const resolved = new Map<string, AnyRecord>();
+
+  for (const id of sorted) {
+    const spec = getCloneSpec(entities[id] as AnyRecord);
+    const fromId = spec.from;
+
+    let baseEntity: AnyRecord;
+    if (resolved.has(fromId)) {
+      baseEntity = resolved.get(fromId)!;
+    } else if (fromId in entities) {
+      const raw = entities[fromId];
+      if (hasClone(raw)) {
+        throw new CloneError(
+          `base "${fromId}" not found in section "${section}"`,
+        );
+      }
+      baseEntity = raw as AnyRecord;
+    } else {
+      throw new CloneError(
+        `base "${fromId}" not found in section "${section}"`,
+      );
+    }
+
+    let copy = deepCopy(baseEntity) as AnyRecord;
+    if (spec.merge !== undefined) {
+      copy = deepMergeEntities(copy, spec.merge, `${section}.${id}`, true);
+    }
+
+    resolved.set(id, copy);
+    entities[id] = copy;
+  }
+}
+
+export function resolveClone(data: Record<string, unknown>): Record<string, unknown> {
+  for (const section of MAP_SECTIONS) {
+    const sectionValue = data[section];
+    if (
+      sectionValue === undefined ||
+      sectionValue === null ||
+      !isRecord(sectionValue) ||
+      Array.isArray(sectionValue)
+    ) {
+      continue;
+    }
+    resolveSectionClones(section, sectionValue as AnyRecord);
+  }
+
+  return data;
+}

--- a/src/resolver/index.ts
+++ b/src/resolver/index.ts
@@ -10,6 +10,17 @@ export {
   type SectionMode,
 } from "./merger.js";
 export { resolve, type ResolveResult } from "./resolve.js";
+export { resolveClone, CloneError } from "./clone.js";
 export { resolveToolExtends, ToolExtendsError } from "./tool-extends.js";
 export { substituteVars, VarsSubstitutionError } from "./substitute-vars.js";
 export { expandDefaults } from "./expand-defaults.js";
+export {
+  resolveArtifactBinding,
+  type ArtifactBindingDiagnostic,
+  type ArtifactBindingResult,
+} from "./artifact-binding.js";
+export {
+  resolveBound,
+  type BoundResolveOptions,
+  type BoundResolveResult,
+} from "./bound-resolve.js";

--- a/src/resolver/resolve.ts
+++ b/src/resolver/resolve.ts
@@ -3,6 +3,7 @@ import { loadDsl } from "../loader/index.js";
 import type { Tool } from "../schema/tool.js";
 import { resolveBase, BaseResolveError } from "./base-resolver.js";
 import { mergeDsl } from "./merger.js";
+import { resolveClone } from "./clone.js";
 import { resolveToolExtends } from "./tool-extends.js";
 
 export interface ResolveResult {
@@ -58,6 +59,8 @@ export async function resolve(
     projectResult.filePath,
     new Set(),
   );
+
+  resolveClone(data);
 
   const tools = data["tools"];
   if (tools !== undefined && tools !== null && typeof tools === "object" && !Array.isArray(tools)) {

--- a/test/resolver/artifact-binding.test.ts
+++ b/test/resolver/artifact-binding.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFile, mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  resolveArtifactBinding,
+  type ArtifactBindingDiagnostic,
+} from "../../src/resolver/artifact-binding.js";
+import { resolveBound } from "../../src/resolver/bound-resolve.js";
+
+const TEMP_DIR = join(tmpdir(), "agc-artifact-binding-test");
+
+beforeEach(async () => {
+  await mkdir(TEMP_DIR, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(TEMP_DIR, { recursive: true, force: true });
+});
+
+function findDiagnostic(
+  diagnostics: ArtifactBindingDiagnostic[],
+  rule: ArtifactBindingDiagnostic["rule"],
+  substring?: string,
+): ArtifactBindingDiagnostic | undefined {
+  return diagnostics.find(
+    (d) => d.rule === rule && (substring === undefined || d.message.includes(substring)),
+  );
+}
+
+describe("resolveArtifactBinding", () => {
+  it("merges registry path_patterns over DSL defaults", () => {
+    const dslArtifacts = {
+      "openapi-spec": {
+        type: "api-contract",
+        path_patterns: ["specs/**/*.yaml"],
+      },
+    };
+    const registry = {
+      artifacts: {
+        "openapi-spec": {
+          path_patterns: ["specs/openapi.yaml"],
+        },
+      },
+    };
+
+    const result = resolveArtifactBinding(dslArtifacts, registry);
+    const artifact = result.artifacts["openapi-spec"] as Record<string, unknown>;
+
+    expect(artifact.path_patterns).toEqual(["specs/openapi.yaml"]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("preserves DSL-only fields after merge", () => {
+    const dslArtifacts = {
+      "openapi-spec": {
+        type: "api-contract",
+        required_validations: ["openapi-lint"],
+        path_patterns: ["specs/**/*.yaml"],
+      },
+    };
+    const registry = {
+      artifacts: {
+        "openapi-spec": {
+          path_patterns: ["specs/openapi.yaml"],
+        },
+      },
+    };
+
+    const result = resolveArtifactBinding(dslArtifacts, registry);
+    const artifact = result.artifacts["openapi-spec"] as Record<string, unknown>;
+
+    expect(artifact.required_validations).toEqual(["openapi-lint"]);
+    expect(artifact.path_patterns).toEqual(["specs/openapi.yaml"]);
+  });
+
+  it("adds registry-only fields such as x-domain", () => {
+    const dslArtifacts = {
+      "openapi-spec": {
+        type: "api-contract",
+        path_patterns: ["specs/**/*.yaml"],
+      },
+    };
+    const registry = {
+      artifacts: {
+        "openapi-spec": {
+          path_patterns: ["specs/openapi.yaml"],
+          "x-domain": "billing",
+        },
+      },
+    };
+
+    const result = resolveArtifactBinding(dslArtifacts, registry);
+    const artifact = result.artifacts["openapi-spec"] as Record<string, unknown>;
+
+    expect(artifact["x-domain"]).toBe("billing");
+  });
+
+  it("maps DSL ID to a different registry ID via mappings", () => {
+    const dslArtifacts = {
+      "openapi-spec": {
+        type: "api-contract",
+        path_patterns: ["specs/**/*.yaml"],
+      },
+    };
+    const registry = {
+      artifacts: {
+        billing_api_contract: {
+          path_patterns: ["billing/openapi.yaml"],
+          "x-domain": "billing",
+        },
+      },
+    };
+
+    const result = resolveArtifactBinding(dslArtifacts, registry, {
+      "openapi-spec": "billing_api_contract",
+    });
+    const artifact = result.artifacts["openapi-spec"] as Record<string, unknown>;
+
+    expect(artifact.path_patterns).toEqual(["billing/openapi.yaml"]);
+    expect(artifact["x-domain"]).toBe("billing");
+    expect(findDiagnostic(result.diagnostics, "orphan-binding")).toBeUndefined();
+  });
+
+  it("substitutes {var} patterns in path_patterns using paths", () => {
+    const dslArtifacts = {
+      "openapi-spec": {
+        type: "api-contract",
+        path_patterns: ["{api_dir}/openapi.yaml"],
+      },
+    };
+    const registry = {
+      artifacts: {
+        "openapi-spec": {
+          path_patterns: ["{api_dir}/openapi.yaml"],
+        },
+      },
+    };
+
+    const result = resolveArtifactBinding(dslArtifacts, registry, undefined, {
+      api_dir: "specs/openapi",
+    });
+    const artifact = result.artifacts["openapi-spec"] as Record<string, unknown>;
+
+    expect(artifact.path_patterns).toEqual(["specs/openapi/openapi.yaml"]);
+  });
+
+  it("emits unbound-artifact when DSL artifact has no registry match", () => {
+    const dslArtifacts = {
+      "missing-artifact": {
+        type: "source",
+        path_patterns: ["src/**"],
+      },
+    };
+    const registry = { artifacts: {} };
+
+    const result = resolveArtifactBinding(dslArtifacts, registry);
+    const artifact = result.artifacts["missing-artifact"] as Record<string, unknown>;
+
+    expect(artifact.path_patterns).toEqual(["src/**"]);
+    expect(findDiagnostic(result.diagnostics, "unbound-artifact", "missing-artifact")).toBeDefined();
+  });
+
+  it("emits orphan-binding when registry artifact has no DSL match", () => {
+    const dslArtifacts = {
+      "openapi-spec": {
+        type: "api-contract",
+        path_patterns: ["specs/**/*.yaml"],
+      },
+    };
+    const registry = {
+      artifacts: {
+        "openapi-spec": {
+          path_patterns: ["specs/openapi.yaml"],
+        },
+        orphan_registry: {
+          path_patterns: ["orphan/**"],
+        },
+      },
+    };
+
+    const result = resolveArtifactBinding(dslArtifacts, registry);
+
+    expect(findDiagnostic(result.diagnostics, "orphan-binding", "orphan_registry")).toBeDefined();
+  });
+
+  it("emits type-mismatch when type conflicts", () => {
+    const dslArtifacts = {
+      "openapi-spec": {
+        type: "api-contract",
+        path_patterns: ["specs/**/*.yaml"],
+      },
+    };
+    const registry = {
+      artifacts: {
+        "openapi-spec": {
+          type: "source",
+          path_patterns: ["specs/openapi.yaml"],
+        },
+      },
+    };
+
+    const result = resolveArtifactBinding(dslArtifacts, registry);
+
+    expect(findDiagnostic(result.diagnostics, "type-mismatch", "type")).toBeDefined();
+    expect(result.artifacts["openapi-spec"]).toBeDefined();
+  });
+
+  it("emits type-mismatch when authority conflicts", () => {
+    const dslArtifacts = {
+      "openapi-spec": {
+        type: "api-contract",
+        authority: "canonical",
+        path_patterns: ["specs/**/*.yaml"],
+      },
+    };
+    const registry = {
+      artifacts: {
+        "openapi-spec": {
+          authority: "generated",
+          path_patterns: ["specs/openapi.yaml"],
+        },
+      },
+    };
+
+    const result = resolveArtifactBinding(dslArtifacts, registry);
+
+    expect(findDiagnostic(result.diagnostics, "type-mismatch", "authority")).toBeDefined();
+  });
+
+  it("deep-merges nested objects and replaces arrays from registry", () => {
+    const dslArtifacts = {
+      "config-artifact": {
+        type: "config",
+        metadata: {
+          owner: "platform",
+          tags: ["core", "shared"],
+        },
+        path_patterns: ["config/**"],
+      },
+    };
+    const registry = {
+      artifacts: {
+        "config-artifact": {
+          metadata: {
+            team: "billing",
+            tags: ["billing"],
+          },
+          path_patterns: ["config/billing/**"],
+        },
+      },
+    };
+
+    const result = resolveArtifactBinding(dslArtifacts, registry);
+    const artifact = result.artifacts["config-artifact"] as Record<string, unknown>;
+    const metadata = artifact.metadata as Record<string, unknown>;
+
+    expect(metadata.owner).toBe("platform");
+    expect(metadata.team).toBe("billing");
+    expect(metadata.tags).toEqual(["billing"]);
+    expect(artifact.path_patterns).toEqual(["config/billing/**"]);
+  });
+
+  it("processes multiple artifacts correctly", () => {
+    const dslArtifacts = {
+      "art-a": { type: "source", path_patterns: ["a/**"] },
+      "art-b": { type: "source", path_patterns: ["b/**"] },
+      "art-c": { type: "source", path_patterns: ["c/**"] },
+    };
+    const registry = {
+      artifacts: {
+        "art-a": { path_patterns: ["a/overridden/**"] },
+        "art-b": { path_patterns: ["b/overridden/**"] },
+      },
+    };
+
+    const result = resolveArtifactBinding(dslArtifacts, registry);
+
+    expect(result.artifacts["art-a"]).toMatchObject({
+      path_patterns: ["a/overridden/**"],
+    });
+    expect(result.artifacts["art-b"]).toMatchObject({
+      path_patterns: ["b/overridden/**"],
+    });
+    expect(findDiagnostic(result.diagnostics, "unbound-artifact", "art-c")).toBeDefined();
+  });
+});
+
+describe("resolveBound", () => {
+  it("returns resolved DSL unchanged when artifact_binding is not configured", async () => {
+    const resolvedDsl = {
+      version: 1,
+      artifacts: {
+        "openapi-spec": {
+          type: "api-contract",
+          path_patterns: ["specs/**/*.yaml"],
+        },
+      },
+    };
+
+    const result = await resolveBound(resolvedDsl, {});
+
+    expect(result.data).toBe(resolvedDsl);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("loads artifact-contracts.yaml and merges artifacts", async () => {
+    const registryPath = join(TEMP_DIR, "artifact-contracts.yaml");
+    await writeFile(
+      registryPath,
+      `artifacts:
+  billing_api_contract:
+    type: api-contract
+    path_patterns:
+      - "{api_dir}/openapi.yaml"
+    x-domain: billing
+`,
+    );
+
+    const resolvedDsl = {
+      version: 1,
+      artifacts: {
+        "openapi-spec": {
+          type: "api-contract",
+          required_validations: ["openapi-lint"],
+          path_patterns: ["specs/**/*.yaml"],
+        },
+      },
+    };
+
+    const result = await resolveBound(resolvedDsl, {
+      artifactBinding: {
+        source: registryPath,
+        mappings: {
+          "openapi-spec": "billing_api_contract",
+        },
+      },
+      paths: {
+        api_dir: "specs/openapi",
+      },
+    });
+
+    const artifact = result.data.artifacts as Record<string, Record<string, unknown>>;
+    expect(artifact["openapi-spec"].path_patterns).toEqual(["specs/openapi/openapi.yaml"]);
+    expect(artifact["openapi-spec"].required_validations).toEqual(["openapi-lint"]);
+    expect(artifact["openapi-spec"]["x-domain"]).toBe("billing");
+    expect(findDiagnostic(result.diagnostics, "orphan-binding")).toBeUndefined();
+  });
+});

--- a/test/resolver/clone.test.ts
+++ b/test/resolver/clone.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, it } from "vitest";
+import { MergeError } from "../../src/resolver/merger.js";
+import { resolveClone, CloneError } from "../../src/resolver/clone.js";
+
+describe("resolveClone", () => {
+  const baseAgent = {
+    role_name: "Implementer",
+    purpose: "General-purpose implementer",
+    mode: "read-write",
+    can_write_artifacts: ["openapi-spec", "api-handler"],
+    responsibilities: ["Implement changes safely"],
+    rules: [
+      {
+        id: "R-IMPL-001",
+        description: "Preserve existing structure",
+        severity: "mandatory",
+      },
+    ],
+    can_execute_tools: ["Read", "Edit", "Write"],
+  };
+
+  it("performs basic clone copying all fields from base", () => {
+    const data = {
+      agents: {
+        implementer: baseAgent,
+        "implementer.copy": {
+          $clone: { from: "implementer" },
+        },
+      },
+    };
+
+    resolveClone(data);
+    const agents = data.agents as Record<string, Record<string, unknown>>;
+
+    expect(agents.implementer).toEqual(baseAgent);
+    expect(agents["implementer.copy"]).toEqual(baseAgent);
+    expect(agents["implementer.copy"]).not.toBe(agents.implementer);
+  });
+
+  it("clones with merge scalar overwrite and deep merge", () => {
+    const data = {
+      agents: {
+        implementer: baseAgent,
+        "implementer.api_contract": {
+          $clone: {
+            from: "implementer",
+            merge: {
+              purpose: "Implementer specialized for API contract changes",
+              can_read_artifacts: ["api-handler", "api-test"],
+            },
+          },
+        },
+      },
+    };
+
+    resolveClone(data);
+    const variant = (data.agents as Record<string, Record<string, unknown>>)[
+      "implementer.api_contract"
+    ];
+
+    expect(variant.purpose).toBe(
+      "Implementer specialized for API contract changes",
+    );
+    expect(variant.can_read_artifacts).toEqual(["api-handler", "api-test"]);
+    expect(variant.role_name).toBe("Implementer");
+    expect(variant.can_write_artifacts).toEqual([
+      "openapi-spec",
+      "api-handler",
+    ]);
+  });
+
+  it("applies merge operators ($append, $prepend, $replace, $remove, $insert_after)", () => {
+    const data = {
+      agents: {
+        base: {
+          role_name: "R",
+          purpose: "P",
+          append_tags: ["a"],
+          prepend_tags: ["b"],
+          replace_tags: ["old"],
+          remove_tags: ["keep", "drop", "stay"],
+          steps: [
+            { id: "s1", action: "first" },
+            { id: "s2", action: "second" },
+          ],
+        },
+        variant: {
+          $clone: {
+            from: "base",
+            merge: {
+              append_tags: { $append: ["c"] },
+              prepend_tags: { $prepend: ["a"] },
+              replace_tags: { $replace: ["new"] },
+              remove_tags: { $remove: ["drop"] },
+              steps: {
+                $insert_after: {
+                  target: "s1",
+                  items: [{ id: "s1b", action: "between" }],
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    resolveClone(data);
+    const variant = (data.agents as Record<string, Record<string, unknown>>).variant;
+
+    expect(variant.append_tags).toEqual(["a", "c"]);
+    expect(variant.prepend_tags).toEqual(["a", "b"]);
+    expect(variant.replace_tags).toEqual(["new"]);
+    expect(variant.remove_tags).toEqual(["keep", "stay"]);
+    expect(variant.steps).toEqual([
+      { id: "s1", action: "first" },
+      { id: "s1b", action: "between" },
+      { id: "s2", action: "second" },
+    ]);
+  });
+
+  it("preserves base entity after clone", () => {
+    const data = {
+      agents: {
+        implementer: { ...baseAgent },
+        "implementer.variant": {
+          $clone: {
+            from: "implementer",
+            merge: { purpose: "Variant" },
+          },
+        },
+      },
+    };
+
+    resolveClone(data);
+    const agents = data.agents as Record<string, Record<string, unknown>>;
+
+    expect(agents.implementer.purpose).toBe("General-purpose implementer");
+    expect(agents["implementer.variant"].purpose).toBe("Variant");
+  });
+
+  it("removes $clone key from output", () => {
+    const data = {
+      agents: {
+        base: { role_name: "R", purpose: "P" },
+        copy: { $clone: { from: "base" } },
+      },
+    };
+
+    resolveClone(data);
+    const copy = (data.agents as Record<string, Record<string, unknown>>).copy;
+
+    expect(copy).not.toHaveProperty("$clone");
+    expect(copy.role_name).toBe("R");
+  });
+
+  it("resolves chained clones (B from A from base)", () => {
+    const data = {
+      agents: {
+        base: {
+          role_name: "R",
+          purpose: "Base purpose",
+          can_write_artifacts: ["a", "b"],
+        },
+        "variant.a": {
+          $clone: {
+            from: "base",
+            merge: {
+              purpose: "Variant A",
+              can_write_artifacts: { $replace: ["a"] },
+            },
+          },
+        },
+        "variant.b": {
+          $clone: {
+            from: "variant.a",
+            merge: {
+              purpose: "Variant B",
+              can_read_artifacts: { $replace: ["x", "y"] },
+            },
+          },
+        },
+      },
+    };
+
+    resolveClone(data);
+    const agents = data.agents as Record<string, Record<string, unknown>>;
+
+    expect(agents["variant.a"].purpose).toBe("Variant A");
+    expect(agents["variant.a"].can_write_artifacts).toEqual(["a"]);
+    expect(agents["variant.b"].purpose).toBe("Variant B");
+    expect(agents["variant.b"].can_write_artifacts).toEqual(["a"]);
+    expect(agents["variant.b"].can_read_artifacts).toEqual(["x", "y"]);
+    expect(agents.base.purpose).toBe("Base purpose");
+  });
+
+  it("throws CloneError when base is not found", () => {
+    const data = {
+      agents: {
+        orphan: { $clone: { from: "missing" } },
+      },
+    };
+
+    expect(() => resolveClone(data)).toThrow(CloneError);
+    expect(() => resolveClone(data)).toThrow(
+      'base "missing" not found in section "agents"',
+    );
+  });
+
+  it("throws CloneError on circular reference", () => {
+    const data = {
+      agents: {
+        a: { $clone: { from: "b" } },
+        b: { $clone: { from: "a" } },
+      },
+    };
+
+    expect(() => resolveClone(data)).toThrow(CloneError);
+    expect(() => resolveClone(data)).toThrow(/circular reference detected/i);
+  });
+
+  it("clones across multiple sections in the same DSL", () => {
+    const data = {
+      agents: {
+        "agent-base": { role_name: "A", purpose: "Agent base" },
+        "agent-variant": {
+          $clone: {
+            from: "agent-base",
+            merge: { purpose: "Agent variant" },
+          },
+        },
+      },
+      tasks: {
+        "task-base": {
+          description: "Task base",
+          target_agent: "agent-base",
+          workflow: "w",
+          input_artifacts: [],
+          invocation_handoff: "h",
+          result_handoff: "r",
+        },
+        "task-variant": {
+          $clone: {
+            from: "task-base",
+            merge: { description: "Task variant" },
+          },
+        },
+      },
+    };
+
+    resolveClone(data);
+    const agents = data.agents as Record<string, Record<string, unknown>>;
+    const tasks = data.tasks as Record<string, Record<string, unknown>>;
+
+    expect(agents["agent-variant"].purpose).toBe("Agent variant");
+    expect(tasks["task-variant"].description).toBe("Task variant");
+    expect(tasks["task-base"].description).toBe("Task base");
+  });
+
+  it("clones without merge as exact copy with different ID", () => {
+    const data = {
+      artifacts: {
+        "art-base": { type: "code", owner: "agent-1" },
+        "art-copy": { $clone: { from: "art-base" } },
+      },
+    };
+
+    resolveClone(data);
+    const artifacts = data.artifacts as Record<string, Record<string, unknown>>;
+
+    expect(artifacts["art-copy"]).toEqual(artifacts["art-base"]);
+    expect(artifacts["art-copy"]).not.toBe(artifacts["art-base"]);
+  });
+
+  it("supports all map-type sections", () => {
+    const sections = [
+      "agents",
+      "tasks",
+      "artifacts",
+      "tools",
+      "validations",
+      "handoff_types",
+      "imports",
+      "workflow",
+      "policies",
+      "guardrails",
+      "guardrail_policies",
+      "components",
+      "extensions",
+    ] as const;
+
+    const data: Record<string, unknown> = {};
+    for (const section of sections) {
+      data[section] = {
+        base: { name: `${section}-base` },
+        variant: {
+          $clone: {
+            from: "base",
+            merge: { name: `${section}-variant` },
+          },
+        },
+      };
+    }
+
+    resolveClone(data);
+
+    for (const section of sections) {
+      const map = data[section] as Record<string, Record<string, unknown>>;
+      expect(map.base.name).toBe(`${section}-base`);
+      expect(map.variant.name).toBe(`${section}-variant`);
+      expect(map.variant).not.toHaveProperty("$clone");
+    }
+  });
+
+  it("is a no-op when no $clone entries exist", () => {
+    const data = {
+      version: 1,
+      agents: {
+        a: { role_name: "R", purpose: "P" },
+      },
+    };
+    const snapshot = structuredClone(data);
+
+    resolveClone(data);
+    expect(data).toEqual(snapshot);
+  });
+
+  it("propagates MergeError from invalid merge operators", () => {
+    const data = {
+      agents: {
+        base: { tags: ["a"] },
+        bad: {
+          $clone: {
+            from: "base",
+            merge: {
+              tags: { $remove: ["missing"] },
+            },
+          },
+        },
+      },
+    };
+
+    expect(() => resolveClone(data)).toThrow(MergeError);
+  });
+});


### PR DESCRIPTION
## Summary

- **$clone resolve-time operator** (#109): Deep-copies a base entity, applies merge diff, and emits the result under a new ID. Supports all map-type DSL sections, topological sort for chaining, circular reference detection, and all existing merge operators.
- **artifact_binding config field** (#110): Adds `artifact_binding` to config schema (string or object form with mappings). `resolveArtifactBinding()` deep-merges registry artifacts onto DSL defaults with `{var}` path substitution. Emits diagnostics for unbound-artifact, orphan-binding, and type-mismatch.
- Version bump: 0.34.2 → 0.34.3

Closes #109, closes #110

## Test plan

- [x] 13 unit tests for `$clone` (basic clone, merge operators, chaining, circular detection, base preserved, multi-section)
- [x] 13 unit tests for `artifact_binding` (deep merge, mappings, {var} substitution, diagnostics, backward compatibility)
- [x] All 912 existing tests pass
- [x] Build succeeds

Made with [Cursor](https://cursor.com)