### PR TITLE
fix: replace RUNTIME_PKG variable with string literals in auditor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.34.3",
+  "version": "0.34.4",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/auditor/auditor.ts
+++ b/src/auditor/auditor.ts
@@ -24,14 +24,14 @@ import {
 import type { DslAuditResult } from "../generated/dsl-base/handoffs.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function createAdapter(runtimePkg: string, name: string, config: AuditConfig): Promise<any> {
+async function createAdapter(name: string, config: AuditConfig): Promise<any> {
   switch (name) {
     case "mock": {
-      const mod = await import(`${runtimePkg}/adapters/mock`);
+      const mod = await import("agent-contracts-runtime/adapters/mock");
       return new mod.MockAdapter();
     }
     case "cursor": {
-      const mod = await import(`${runtimePkg}/adapters/cursor-sdk`);
+      const mod = await import("agent-contracts-runtime/adapters/cursor-sdk");
       const apiKey = process.env.CURSOR_API_KEY;
       if (!apiKey) {
         throw new Error(
@@ -42,7 +42,7 @@ async function createAdapter(runtimePkg: string, name: string, config: AuditConf
       return mod.CursorSdkAdapter.create({ apiKey, model: config.model });
     }
     case "claude": {
-      const mod = await import(`${runtimePkg}/adapters/claude-agent-sdk`);
+      const mod = await import("agent-contracts-runtime/adapters/claude-agent-sdk");
       return new mod.ClaudeAgentSdkAdapter({
         model: config.model,
         tools: ["Read", "Glob", "Grep"],
@@ -50,14 +50,14 @@ async function createAdapter(runtimePkg: string, name: string, config: AuditConf
       });
     }
     case "openai": {
-      const mod = await import(`${runtimePkg}/adapters/openai-agents-sdk`);
+      const mod = await import("agent-contracts-runtime/adapters/openai-agents-sdk");
       return new mod.OpenAIAgentsSdkAdapter({
         model: config.model,
         maxTurns: 1,
       });
     }
     case "gemini": {
-      const mod = await import(`${runtimePkg}/adapters/gemini-sdk`);
+      const mod = await import("agent-contracts-runtime/adapters/gemini-sdk");
       return new mod.GeminiSdkAdapter({
         apiKey: process.env.GEMINI_API_KEY,
         model: config.model ?? "gemini-2.5-flash",
@@ -115,16 +115,12 @@ export async function runAudit(
     };
   }
 
-  // Dynamic import — agent-contracts-runtime is optional.
-  // Module names are constructed to prevent TypeScript from resolving them at compile time.
-  const RUNTIME_PKG = ["agent-contracts", "runtime"].join("-");
-
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let runTask: (...args: any[]) => Promise<any>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let createProgressSink: (options: any) => { write: (chunk: string) => void; close: () => void };
   try {
-    const runtime = await import(RUNTIME_PKG);
+    const runtime = await import("agent-contracts-runtime");
     runTask = runtime.runTask;
     createProgressSink = runtime.createProgressSink;
   } catch {
@@ -136,7 +132,7 @@ export async function runAudit(
   }
 
   const adapterName = auditConfig.adapter ?? "mock";
-  const adapter = await createAdapter(RUNTIME_PKG, adapterName, auditConfig);
+  const adapter = await createAdapter(adapterName, auditConfig);
 
   const progressSink = options.logFile
     ? createProgressSink({ stderr: true, file: resolve(options.logFile), naming: "single" })

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -16,6 +16,14 @@ export default defineConfig({
     "@stoplight/spectral-functions",
     "@stoplight/spectral-rulesets",
   ],
+  external: [
+    "agent-contracts-runtime",
+    "@cursor/sdk",
+    "@anthropic-ai/claude-agent-sdk",
+    "@anthropic-ai/sdk",
+    "@openai/agents",
+    "@google/adk",
+  ],
   banner: {
     js: "import { createRequire } from 'module'; const require = createRequire(import.meta.url);",
   },


### PR DESCRIPTION
## Summary

- Replace `RUNTIME_PKG` variable pattern with direct string literals in `src/auditor/auditor.ts`
- Add `agent-contracts-runtime` and SDK packages to tsup `external` list
- Bump version to 0.34.4

## Problem

The `RUNTIME_PKG = ["agent-contracts", "runtime"].join("-")` pattern was designed to prevent TypeScript from resolving the module at compile time. However, when downstream consumers (e.g. artifact-contracts) bundle this package, esbuild plugins strip the variable declaration but leave references intact, causing `ReferenceError: RUNTIME_PKG is not defined` at runtime.

## Fix

Replace all indirect variable references with direct string literals (`"agent-contracts-runtime"`, `"agent-contracts-runtime/adapters/..."`) so that bundlers can properly resolve or externalize them.

## Test plan

- [x] All 912 unit tests pass
- [x] Build succeeds with tsup

Made with [Cursor](https://cursor.com)