### PR TITLE
chore: bump version to 0.34.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.34.6",
+  "version": "0.34.7",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",
@@ -67,10 +67,8 @@
     "url": "https://github.com/foo-log-inc/agent-contracts/issues"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.138",
     "@eslint/js": "^10.0.1",
-    "@google/genai": "^2.0.1",
-    "@openai/agents": "^0.11.1",
+    "@google/adk": "^1.2.0",
     "@stoplight/spectral-core": "^1.22.0",
     "@stoplight/spectral-functions": "^1.9.0",
     "@stoplight/spectral-rulesets": "^1.22.1",


### PR DESCRIPTION
Version bump for Gemini fix release.

Made with [Cursor](https://cursor.com)