### PR TITLE
fix: improve adapter error messages and prevent ADK agent transfer

### DIFF
--- a/dsl_base/agents/dsl-auditor.yaml
+++ b/dsl_base/agents/dsl-auditor.yaml
@@ -4,6 +4,7 @@ dsl-auditor:
     Audit completeness of agent-contracts DSL definitions against generated
     agent prompts, detect gaps, and present improvement recommendations.
   mode: read-write
+  can_invoke_agents: []
   can_execute_tools:
     - agent-contracts-cli
   can_perform_validations:

--- a/dsl_base/agents/dsl-designer.yaml
+++ b/dsl_base/agents/dsl-designer.yaml
@@ -6,6 +6,7 @@ dsl-designer:
     Holds specification knowledge of DSL structure, schemas, merge operators,
     and variable substitution.
   mode: read-write
+  can_invoke_agents: []
   can_execute_tools:
     - agent-contracts-cli
   can_perform_validations:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,26 @@
 {
   "name": "agent-contracts",
-  "version": "0.34.6",
+  "version": "0.34.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-contracts",
-      "version": "0.34.6",
+      "version": "0.34.7",
       "license": "MIT",
       "bin": {
         "agent-contracts": "dist/agent-contracts.bundle.mjs"
       },
       "devDependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.167",
         "@eslint/js": "^10.0.1",
         "@google/adk": "^1.2.0",
+        "@openai/agents": "^0.11.6",
         "@stoplight/spectral-core": "^1.22.0",
         "@stoplight/spectral-functions": "^1.9.0",
         "@stoplight/spectral-rulesets": "^1.22.1",
         "@types/node": "^25.6.0",
-        "agent-contracts-runtime": "^0.36.1",
+        "agent-contracts-runtime": "file:../agent-contracts-runtime/agent-contracts-runtime-0.36.2.tgz",
         "ajv": "^8.18.0",
         "cli-contracts": "^0.32.0",
         "commander": "^14.0.3",
@@ -39,6 +41,26 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/claude-agent-sdk": ">=0.2.0",
+        "@google/adk": ">=1.2.0",
+        "@openai/agents": ">=0.10.0",
+        "agent-contracts-runtime": "file:../agent-contracts-runtime/agent-contracts-runtime-0.36.2.tgz"
+      },
+      "peerDependenciesMeta": {
+        "@anthropic-ai/claude-agent-sdk": {
+          "optional": true
+        },
+        "@google/adk": {
+          "optional": true
+        },
+        "@openai/agents": {
+          "optional": true
+        },
+        "agent-contracts-runtime": {
+          "optional": true
+        }
       }
     },
     "node_modules/@a2a-js/sdk": {
@@ -66,6 +88,178 @@
           "optional": true
         },
         "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.167",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.167.tgz",
+      "integrity": "sha512-FTwjBkfcJlqDugBp/kR2GtQ7wPE1ekU4IJzIuUni0pVikdrOVmAPel3EE9LMSJ0WVqFVnHvoYIuj4U9z4gC+5w==",
+      "dev": true,
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.167",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.167",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.167",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.167",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.167",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.167",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.167",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.167"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.167",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.167.tgz",
+      "integrity": "sha512-lRdC0lWpRQmoo3geCia/9M0/72BraWwZLxyIQrwWhUCvvlGwqvPLRlPd7Ls20W3py1U4qe2UHt8/NlKMMmoq2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.167",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.167.tgz",
+      "integrity": "sha512-24WCqqXc9SBliROFQz+JhO8+u9DARqhmMGWAZwT+/fs9RDJtHd2SZ7o8rWPAVnUicKQCMsjxdhtp/vFWELGenA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.167",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.167.tgz",
+      "integrity": "sha512-f6269JZ8KngRIHDK9tmQMFWHg8XhOyJww6pbTVHqlUnf70pJPEP7hsmg6OQErRIvqQzHQWBiakQA8VIdRrOrjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.167",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.167.tgz",
+      "integrity": "sha512-g9KB5JIDvcLENitm6+QLnY3YC40FvJroWz65C0etK6ri07SALFxfahSPHQqlbHlAo8a/+ZibSihwjqkvOXQtfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.167",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.167.tgz",
+      "integrity": "sha512-ecxQI20+Fr+PexMgmHlG9/WrUOUi9uQT9n1laUDn4bQAcQX3xDqgZbiH7RErCuTJW+mBSauSh4X68b4jmf64Bg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.167",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.167.tgz",
+      "integrity": "sha512-VA+0oQS8jTl2vyeMt4vjFiHf14F0mOxQbNJ6PLdy4etelYxC0lipPtSxVHbdzrgd0cF91uqUDhUMexNkVqS4MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.167",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.167.tgz",
+      "integrity": "sha512-uB2E9w0bReXONBbaGM27S60F1h+NI/P2HyYoDy+eJsFhMv1lVbko9NG2Wm3kT5qOooBGRlSE5GgiCAK80xBcTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.167",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.167.tgz",
+      "integrity": "sha512-r2IzO8ADzu4uRorXSs07baXee0LtTUIVDXP2ubYW32oTcAr98eip2VfkxwL9xm0tHXN63rp4fporU0eAy9fLPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.101.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.101.0.tgz",
+      "integrity": "sha512-fw/Y7kCZPRZ1IuyDHGj0bCDTYLgsZgvgg01gVdbphHvpGMdOzGSYWGiSyzrRMMBWkbG1ijvuYaAQLKkAlQc3Ww==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
           "optional": true
         }
       }
@@ -371,6 +565,17 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -2134,6 +2339,76 @@
         "node": ">=10"
       }
     },
+    "node_modules/@openai/agents": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.11.6.tgz",
+      "integrity": "sha512-YLwycYJQ65ETEq1SzjdFO6U9VhWHOKKIVh6wZCd/FmTZoqYq9UF/5uvX+wF8cZ58J+wIyyLynPdCmzEEov2rhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.11.6",
+        "@openai/agents-openai": "0.11.6",
+        "@openai/agents-realtime": "0.11.6",
+        "debug": "^4.4.0",
+        "openai": "^6.35.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openai/agents-core": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.11.6.tgz",
+      "integrity": "sha512-jWeo4mF+zjp9R80OPg+9prAnwF53dIpok2ymp9OkC3DpK2qcqBO8CfoEgocNp+E5HXXFW4uvCaY0olNCCcmTFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "openai": "^6.35.0"
+      },
+      "optionalDependencies": {
+        "@modelcontextprotocol/sdk": "^1.26.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@openai/agents-openai": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.11.6.tgz",
+      "integrity": "sha512-63zXy+EPmg3WErLO12jLEjCTqGBZ/f0ApsW/t5wpccqUYCtImIT6IYZDgGM+zSEafHNGJmNOwGtEqHjz/Pyl+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.11.6",
+        "debug": "^4.4.0",
+        "openai": "^6.35.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openai/agents-realtime": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.11.6.tgz",
+      "integrity": "sha512-jw4lLO6B2xyCBtgLtAXZmqhjEAqSLO1EtJzfwfrZuzGpPgs4nJBQ+O7ybtdPPKt8iWdIOlrYRDqxhBHv7Qqo7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.11.6",
+        "@types/ws": "^8.18.1",
+        "debug": "^4.4.0",
+        "ws": "^8.18.1"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -3400,6 +3675,14 @@
         "text-hex": "1.0.x"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -3967,6 +4250,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.60.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
@@ -4424,9 +4717,9 @@
       }
     },
     "node_modules/agent-contracts-runtime": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/agent-contracts-runtime/-/agent-contracts-runtime-0.36.1.tgz",
-      "integrity": "sha512-bXSqLofA4X8H/LOITOmBjuAHO1T8S5wEv86QX7pVZoUM11hiAipb00p6zfLYE7EoE0ORGGV08f3IJzfEXHsLxw==",
+      "version": "0.36.2",
+      "resolved": "file:../agent-contracts-runtime/agent-contracts-runtime-0.36.2.tgz",
+      "integrity": "sha512-kjrmI8kPqiX6/Tc4XbqP6kA/+bxdZSF6K33d9yhHNcccfUJW2+/yWph40aiAwgS5Ob06ZeU/PEp7VtEEs/Tj+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6529,6 +6822,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
+      "license": "Unlicense",
+      "peer": true
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -8433,6 +8734,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -9993,6 +10309,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.42.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.42.0.tgz",
+      "integrity": "sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {
@@ -11755,6 +12090,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -12374,6 +12721,14 @@
       "engines": {
         "node": ">= 14.0.0"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.34.7",
+  "version": "0.34.8",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",
@@ -67,13 +67,15 @@
     "url": "https://github.com/foo-log-inc/agent-contracts/issues"
   },
   "devDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.167",
     "@eslint/js": "^10.0.1",
     "@google/adk": "^1.2.0",
+    "@openai/agents": "^0.11.6",
     "@stoplight/spectral-core": "^1.22.0",
     "@stoplight/spectral-functions": "^1.9.0",
     "@stoplight/spectral-rulesets": "^1.22.1",
     "@types/node": "^25.6.0",
-    "agent-contracts-runtime": "^0.36.1",
+    "agent-contracts-runtime": "^0.36.2",
     "ajv": "^8.18.0",
     "cli-contracts": "^0.32.0",
     "commander": "^14.0.3",
@@ -91,6 +93,26 @@
     "yaml": "^2.8.3",
     "zod": "^4.3.6",
     "zod-to-json-schema": "^3.25.2"
+  },
+  "peerDependencies": {
+    "@anthropic-ai/claude-agent-sdk": ">=0.2.0",
+    "@google/adk": ">=1.2.0",
+    "@openai/agents": ">=0.10.0",
+    "agent-contracts-runtime": ">=0.36.2"
+  },
+  "peerDependenciesMeta": {
+    "agent-contracts-runtime": {
+      "optional": true
+    },
+    "@anthropic-ai/claude-agent-sdk": {
+      "optional": true
+    },
+    "@openai/agents": {
+      "optional": true
+    },
+    "@google/adk": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=20.0.0"

--- a/src/generated/dsl-base/.manifest.json
+++ b/src/generated/dsl-base/.manifest.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-06-06T02:32:00.090Z",
-  "dsl_hash": "b1eebfb616af1912ec6d376b39721525eea3e27b5f60eb38863b2efedbd1bfd2",
-  "generation_input_hash": "b1eebfb616af1912ec6d376b39721525eea3e27b5f60eb38863b2efedbd1bfd2",
+  "generated_at": "2026-06-06T04:09:44.703Z",
+  "dsl_hash": "dcf97d5ffe8eb43ee2232706891b9658c3c5071b56d4b019e131ff8ee20e8d31",
+  "generation_input_hash": "dcf97d5ffe8eb43ee2232706891b9658c3c5071b56d4b019e131ff8ee20e8d31",
   "files": [
     "../src/generated/dsl-base/agents.ts",
     "../src/generated/dsl-base/tasks.ts",

--- a/src/generated/dsl-base/dsl-data.ts
+++ b/src/generated/dsl-base/dsl-data.ts
@@ -19,6 +19,7 @@ export const resolvedDsl: Record<string, unknown> = {
       "role_name": "DSL Auditor",
       "purpose": "Audit completeness of agent-contracts DSL definitions against generated agent prompts, detect gaps, and present improvement recommendations.",
       "mode": "read-write",
+      "can_invoke_agents": [],
       "can_execute_tools": [
         "agent-contracts-cli"
       ],
@@ -104,6 +105,7 @@ export const resolvedDsl: Record<string, unknown> = {
       "role_name": "DSL Designer",
       "purpose": "Design, create, and update agent-contracts DSL definitions and bindings. Verify quality using validate, lint, render, and score commands. Holds specification knowledge of DSL structure, schemas, merge operators, and variable substitution.",
       "mode": "read-write",
+      "can_invoke_agents": [],
       "can_execute_tools": [
         "agent-contracts-cli"
       ],


### PR DESCRIPTION
## Summary
- Add `can_invoke_agents: []` to dsl-auditor and dsl-designer to prevent unintended ADK agent transfer (which caused empty output)
- Bump agent-contracts-runtime to >=0.36.2 which includes:
  - Clear error messages when SDK packages are missing (e.g. `Install it with: npm install @google/adk`)
  - Proper error surfacing for Gemini API errors (rate limits, auth) instead of silent empty output

## Test plan
- [x] `npm test` — 912 tests pass
- [x] OpenAI audit: success
- [x] Gemini adapter: responds correctly (rate limit error properly surfaced)
- [x] Bundle builds without errors

Made with [Cursor](https://cursor.com)