### PR TITLE
fix: bundle test config fallback for CI

### DIFF
--- a/test/bundle/isolation.test.ts
+++ b/test/bundle/isolation.test.ts
@@ -20,6 +20,11 @@ describe("bundle-isolation", () => {
 
     if (existsSync(join(ROOT, "agent-contracts.config.yaml"))) {
       cpSync(join(ROOT, "agent-contracts.config.yaml"), join(tempDir, "agent-contracts.config.yaml"));
+    } else {
+      writeFileSync(
+        join(tempDir, "agent-contracts.config.yaml"),
+        "dsl: dsl_base/agent-contracts.yaml\naudit:\n  adapter: openai\n",
+      );
     }
     if (existsSync(join(ROOT, "dsl_base"))) {
       cpSync(join(ROOT, "dsl_base"), join(tempDir, "dsl_base"), { recursive: true });


### PR DESCRIPTION
config file is gitignored so generate a minimal one in CI bundle test

Made with [Cursor](https://cursor.com)