### PR TITLE
fix: deprecated-ownership-fields lint rule should not warn on agent-side fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ An **Agent** defines who an execution entity is:
 * constraints
 * behavioral rules
 * structured content sections (reference material, procedures, criteria)
+* memory — optional capability declaration for session resume support (`resumable`, `ref_required`, `emits_memory_ref`)
 
 ### Task
 
@@ -601,6 +602,10 @@ agents:
     constraints:
       - "Never write code directly"
 
+    memory:
+      resumable: true
+      emits_memory_ref: true
+
     sections:
       - title: "Delegation Protocol"
         content: |
@@ -933,6 +938,25 @@ tasks:
             uses_tool: api-pipeline
 ````
 
+### `$clone` — resolve-time entity duplication
+
+`$clone` creates a new entity by copying an existing entity within the same section and optionally applying a merge diff:
+
+````yaml
+agents:
+  implementer.api:
+    $clone:
+      from: implementer
+      merge:
+        purpose: "API-specialized implementer"
+        can_write_artifacts:
+          $replace: [openapi-spec]
+        responsibilities:
+          $append: ["Validate schema changes"]
+````
+
+`$clone` is processed during `resolve` (after `extends`, before tool inheritance). All merge operators (`$append`, `$prepend`, `$replace`, `$remove`, `$insert_after`) work within `merge`. The base entity is preserved; chained clones (A→B→C) are resolved via topological sort. Circular clones are rejected.
+
 Supported merge operators:
 
 | Operator        | Behavior                                   |
@@ -1138,6 +1162,7 @@ npx agent-contracts
 | `agent-contracts check`           | Run resolve → validate → lint → render --check         |
 | `agent-contracts navigation-index` | Build artifact-centric navigation index |
 | `agent-contracts artifact-coverage` | Measure file coverage by artifact definitions |
+| `agent-contracts extract`           | Extract embedded CLI contract specification            |
 | `agent-contracts render`          | _(deprecated)_ Alias for `generate templates`          |
 
 The `[path]` argument defaults to `agent-contracts.yaml` in the current directory.
@@ -1369,6 +1394,41 @@ The `check` command also validates that imported interface files exist on disk (
 * `dsl` and `teams` are mutually exclusive at the config root
 * Every team except `_defaults` must specify `dsl`
 * Existing single-team configs (top-level `dsl` only) remain valid unchanged
+
+### Artifact binding (config-level)
+
+The `artifact_binding` config field connects DSL artifact definitions to an external artifact registry (e.g., `artifact-contracts.yaml`). Registry values override DSL defaults using deep-merge semantics.
+
+Two forms are supported:
+
+````yaml
+# Simple form (IDs match between DSL and registry)
+artifact_binding: ./artifact-contracts.yaml
+
+# Explicit mapping form (IDs differ)
+artifact_binding:
+  source: ./artifact-contracts.yaml
+  mappings:
+    openapi-spec: billing_api_contract
+````
+
+**Merge semantics:**
+
+* Registry fields override DSL fields (deep-merge at field level)
+* DSL-only fields are preserved
+* `{var}` templates in `path_patterns` are substituted using `config.paths`
+
+**Diagnostics:**
+
+| Rule | Severity | Description |
+|------|----------|-------------|
+| `unbound-artifact` | warning | DSL artifact has no registry counterpart |
+| `orphan-binding` | warning | Registry artifact has no DSL counterpart |
+| `type-mismatch` | warning | DSL and registry disagree on `type`/`authority` |
+
+**Placement:** Top-level for single-team configs, or per-team in `teams` (inheritable from `_defaults`).
+
+Currently consumed by `navigation-index` and `artifact-coverage` commands. When not configured, behavior is unchanged (full backward compatibility).
 
 ### Render target options
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2,7 +2,7 @@
 
 Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows. Provides static validation, semantic linting, prompt rendering, guardrail generation, and completeness scoring for agent contract definitions.
 
-**Version:** 0.33.0
+**Version:** 0.34.0
 
 ## Table of Contents
 
@@ -354,7 +354,7 @@ agent-contracts audit extensions -c agent-contracts.config.yaml
 agent-contracts audit all -c agent-contracts.config.yaml
 ```
 ```
-agent-contracts audit dsl --dry-run -c agent-contracts.config.yaml
+agent-contracts audit dsl --show-prompt -c agent-contracts.config.yaml
 ```
 ```
 agent-contracts audit render --format json -c agent-contracts.config.yaml
@@ -377,7 +377,7 @@ agent-contracts audit dsl --scope agents:architect,implementer -c config.yaml
 | `--team` |  | No |  | Limit to one team (multi-team config only). |
 | `--format` |  | No | `"text"` | Output format. |
 | `--scope` |  | No |  | Limit audit scope to specified entities (e.g. agents:architect,implementer). |
-| `--dry-run` |  | No | `false` | Output the audit prompt without calling LLM. |
+| `--show-prompt` |  | No | `false` | Output the constructed prompt without calling the LLM API. |
 | `--adapter` |  | No |  | SDK adapter to use for LLM calls (overrides config audit.adapter). |
 | `--model` |  | No |  | LLM model override (overrides config audit.model). |
 | `--log-file` | -l | No |  | Write agent progress log to this file path. |
@@ -845,12 +845,21 @@ agent-contracts audit dsl --scope agents:architect,implementer -c config.yaml
 
 ```yaml
 x-agent: 
-  retryable_exit_codes: 
+  riskLevel: medium
+  requiresConfirmation: false
+  idempotent: false
+  sideEffects: 
+    - network
+  sideEffectNote: Network calls to LLM provider when adapter is not mock. Filesystem write only when --output is specified.
+  safeDryRunOption: show-prompt
+  expectedDurationMs: 120000
+  retryableExitCodes: 
+    - 1
     - 12
   recommended_before_use: 
     - Ensure agent-contracts.config.yaml exists with render targets.
     - Run validate first to confirm DSL is valid.
-    - Install agent-contracts-runtime if not using --dry-run.
+    - Install agent-contracts-runtime if not using --show-prompt.
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.34.12",
+  "version": "0.34.13",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/linter/rules/deprecated-ownership-fields.ts
+++ b/src/linter/rules/deprecated-ownership-fields.ts
@@ -2,11 +2,6 @@ import type { Dsl } from "../../schema/index.js";
 import type { LintRule, LintDiagnostic } from "../types.js";
 
 const ARTIFACT_FIELDS = ["owner", "producers", "editors", "consumers"] as const;
-const AGENT_FIELDS = [
-  "own_artifacts",
-  "can_read_artifacts",
-  "can_write_artifacts",
-] as const;
 
 function isArtifactFieldUsed(
   artifact: Dsl["artifacts"][string],
@@ -24,24 +19,10 @@ function isArtifactFieldUsed(
   }
 }
 
-function isAgentFieldUsed(
-  agent: Dsl["agents"][string],
-  field: (typeof AGENT_FIELDS)[number],
-): boolean {
-  switch (field) {
-    case "own_artifacts":
-      return agent.own_artifacts.length > 0;
-    case "can_read_artifacts":
-      return agent.can_read_artifacts.length > 0;
-    case "can_write_artifacts":
-      return agent.can_write_artifacts.length > 0;
-  }
-}
-
 export const deprecatedOwnershipFieldsRule: LintRule = {
   id: "deprecated-ownership-fields",
   description:
-    "Warn when deprecated ownership/permission fields are used instead of artifact_bindings + artifact_slots",
+    "Warn when deprecated artifact-side ownership fields are used instead of declaring ownership on agents via own_artifacts, can_write_artifacts, and can_read_artifacts",
 
   run(dsl: Dsl): LintDiagnostic[] {
     const diagnostics: LintDiagnostic[] = [];
@@ -53,20 +34,7 @@ export const deprecatedOwnershipFieldsRule: LintRule = {
             ruleId: "deprecated-ownership-fields",
             severity: "warning",
             path: `artifacts.${artId}.${field}`,
-            message: `Artifact "${artId}" uses deprecated field "${field}". Ownership is derived from artifact_bindings + artifact_slots in the binding model.`,
-          });
-        }
-      }
-    }
-
-    for (const [agentId, agent] of Object.entries(dsl.agents)) {
-      for (const field of AGENT_FIELDS) {
-        if (isAgentFieldUsed(agent, field)) {
-          diagnostics.push({
-            ruleId: "deprecated-ownership-fields",
-            severity: "warning",
-            path: `agents.${agentId}.${field}`,
-            message: `Agent "${agentId}" uses deprecated field "${field}". Artifact permissions are derived from artifact_bindings + artifact_slots in the binding model.`,
+            message: `Artifact "${artId}" uses deprecated field "${field}". Declare ownership on agents via own_artifacts, can_write_artifacts, and can_read_artifacts instead.`,
           });
         }
       }

--- a/test/linter/linter.test.ts
+++ b/test/linter/linter.test.ts
@@ -711,10 +711,12 @@ describe("deprecatedOwnershipFieldsRule", () => {
     expect(diags.length).toBe(4);
     expect(diags.every((d) => d.ruleId === "deprecated-ownership-fields")).toBe(true);
     expect(diags.every((d) => d.severity === "warning")).toBe(true);
-    expect(diags[0].message).toContain("artifact_bindings + artifact_slots");
+    expect(diags[0].message).toContain("own_artifacts");
+    expect(diags[0].message).toContain("can_write_artifacts");
+    expect(diags[0].message).toContain("can_read_artifacts");
   });
 
-  it("warns when agent uses deprecated permission fields", () => {
+  it("does not warn when agent uses canonical permission fields", () => {
     const dsl = makeDsl({
       agents: {
         a1: {
@@ -730,9 +732,39 @@ describe("deprecatedOwnershipFieldsRule", () => {
       },
     });
     const diags = deprecatedOwnershipFieldsRule.run(dsl);
-    expect(diags.length).toBe(3);
-    expect(diags.every((d) => d.ruleId === "deprecated-ownership-fields")).toBe(true);
-    expect(diags[0].message).toContain("artifact_bindings + artifact_slots");
+    expect(diags).toHaveLength(0);
+  });
+
+  it("warns only on artifact-side when both sides are populated", () => {
+    const dsl = makeDsl({
+      agents: {
+        a1: {
+          role_name: "R",
+          purpose: "P",
+          own_artifacts: ["art1"],
+          can_read_artifacts: ["art1"],
+          can_write_artifacts: ["art1"],
+        },
+      },
+      artifacts: {
+        art1: {
+          type: "code",
+          owner: "a1",
+          producers: ["a1"],
+          editors: ["a1"],
+          consumers: ["a1"],
+          states: ["draft"],
+        },
+      },
+    });
+    const diags = deprecatedOwnershipFieldsRule.run(dsl);
+    expect(diags).toHaveLength(4);
+    expect(diags.map((d) => d.path).sort()).toEqual([
+      "artifacts.art1.consumers",
+      "artifacts.art1.editors",
+      "artifacts.art1.owner",
+      "artifacts.art1.producers",
+    ]);
   });
 
   it("passes when deprecated fields are empty", () => {


### PR DESCRIPTION
## Summary

Fixes #126.

- deprecated-ownership-fields lint rule was incorrectly flagging agent-side canonical fields (own_artifacts, can_read_artifacts, can_write_artifacts) as deprecated
- These fields are the canonical source used by navigation-index buildAgentMapping() — only artifact-side fields (owner, producers, editors, consumers) should be deprecated
- Removed agent-side checks from the lint rule, updated warning message to direct users toward agent-side declarations
- Added regression test and mixed-scenario test

Also includes README updates (memory, clone docs) and cli-reference updates.

## Test plan

- [x] npm run build passes
- [x] npm run test:unit passes (913 tests)
- [x] Regression test: agent with canonical fields produces zero warnings
- [x] Mixed scenario test: both sides populated, only artifact-side warned (4 diagnostics)

Made with [Cursor](https://cursor.com)