### PR TITLE
feat: effects aggregation, handoff render, component_contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ A **Tool** defines an invokable CLI/MCP tool:
 * `extends` — inherit from a base tool definition
 * `command` — single command name (alternative to `commands[]`)
 * `commands` — structured list of sub-commands with `category`, `reads`, `writes`, and `purpose`
+* `cli_contract` — path to a CLI contract YAML (for CLI/MCP adapter invocation)
+* `component_contract` — path to an AaaC Component contract YAML (for in-process / SDK / MCP Component invocation). Mutually exclusive with `cli_contract`.
+* `artifact_bindings` — maps contract slot names to project artifact IDs
+* `effects` (on agents/tasks) — optional narrow-only override of capability effects derived from executable tools
 
 ### Workflow
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.34.13",
+  "version": "0.34.14",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/sample/templates/agent-prompt.md.hbs
+++ b/sample/templates/agent-prompt.md.hbs
@@ -156,6 +156,62 @@
 {{/each}}
 {{/if}}
 
+{{#if producerHandoffs.length}}
+## Handoff Output Formats
+
+You must produce output in the following handoff_type formats:
+
+{{#each producerHandoffs}}
+### {{this.handoffId}}{{#if this.taskId}} (task: {{this.taskId}}){{/if}}
+
+{{#if this.description}}{{this.description}}
+
+{{/if}}
+{{#if this.fields.length}}
+| Field | Type | Required |
+|-------|------|----------|
+{{#each this.fields}}
+| {{this.name}} | {{this.type}}{{#if this.enum}} ({{this.enum}}){{/if}} | {{#if this.required}}yes{{else}}no{{/if}} |
+{{/each}}
+{{/if}}
+{{#if this.resolvedSchema}}
+**Resolved schema:**
+
+```yaml
+{{{yamlBlock this.resolvedSchema}}}
+```
+{{/if}}
+{{/each}}
+{{/if}}
+
+{{#if consumerHandoffs.length}}
+## Handoff Input Formats
+
+You will receive input in the following handoff_type formats:
+
+{{#each consumerHandoffs}}
+### {{this.handoffId}}{{#if this.taskId}} (task: {{this.taskId}}){{/if}}
+
+{{#if this.description}}{{this.description}}
+
+{{/if}}
+{{#if this.fields.length}}
+| Field | Type | Required |
+|-------|------|----------|
+{{#each this.fields}}
+| {{this.name}} | {{this.type}}{{#if this.enum}} ({{this.enum}}){{/if}} | {{#if this.required}}yes{{else}}no{{/if}} |
+{{/each}}
+{{/if}}
+{{#if this.resolvedSchema}}
+**Resolved schema:**
+
+```yaml
+{{{yamlBlock this.resolvedSchema}}}
+```
+{{/if}}
+{{/each}}
+{{/if}}
+
 {{#if (notEmpty relatedHandoffTypes)}}
 ## Handoff Types
 
@@ -166,13 +222,13 @@
 {{this.description}}
 
 {{/if}}
-{{#if this.schema}}
+{{#with (lookup ../resolvedHandoffTypes @key)}}
 **Schema:**
 
 ```yaml
-{{{yamlBlock this.schema}}}
+{{{yamlBlock this}}}
 ```
-{{/if}}
+{{/with}}
 {{#if this.example}}
 **Example:**
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export * from "./schema/index.js";
 export { loadDsl, DslLoadError, type LoadResult } from "./loader/index.js";
-export { resolve, mergeDsl, resolveBase, expandDefaults, resolveBound, resolveArtifactBinding, MergeError, CloneError, BaseResolveError, type ResolveResult, type BoundResolveOptions, type BoundResolveResult, type ArtifactBindingDiagnostic, type ArtifactBindingResult } from "./resolver/index.js";
+export { resolve, mergeDsl, resolveBase, expandDefaults, resolveBound, resolveArtifactBinding, resolveAgentEffects, resolveTaskEffects, resolveToolEffects, isNarrowOnlyOverride, collectAgentArtifactProducers, collectAgentArtifactConsumers, normalizeDerivedFrom, type EffectiveEffects, MergeError, CloneError, BaseResolveError, type ResolveResult, type BoundResolveOptions, type BoundResolveResult, type ArtifactBindingDiagnostic, type ArtifactBindingResult } from "./resolver/index.js";
 export { validateSchema, checkReferences, validateHandoffSchemas, type SchemaValidationResult, type DiagnosticMessage, type ReferenceDiagnostic } from "./validator/index.js";
 export { lint, builtinRules, spectralLint, yamlReservedKeySafetyRule, type LintRule, type LintDiagnostic, type Severity } from "./linter/index.js";
 export {
@@ -32,6 +32,8 @@ export {
   type PerGuardrailPolicyContext,
   type MergedBehavioralSpec,
   type DelegatableTaskView,
+  type HandoffRoleView,
+  type HandoffFieldView,
   type EntityGuardrailEntry,
   type EntityValidationEntry,
   resolveEffectiveGuardrails,

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -33,6 +33,8 @@ import { bindingDirectionMatchRule } from "./rules/binding-direction-match.js";
 import { slotDeclarationExistsRule } from "./rules/slot-declaration-exists.js";
 import { configPathConsistencyRule } from "./rules/config-path-consistency.js";
 import { memoryConsistencyRule } from "./rules/memory-consistency.js";
+import { artifactDataflowRule } from "./rules/artifact-dataflow.js";
+import { componentContractBindingRule } from "./rules/component-contract-binding.js";
 
 const builtinRules: LintRule[] = [
   validationCoverageRule,
@@ -62,6 +64,8 @@ const builtinRules: LintRule[] = [
   slotDeclarationExistsRule,
   configPathConsistencyRule,
   memoryConsistencyRule,
+  artifactDataflowRule,
+  componentContractBindingRule,
 ];
 
 export function lint(

--- a/src/linter/rules/artifact-dataflow.ts
+++ b/src/linter/rules/artifact-dataflow.ts
@@ -1,0 +1,101 @@
+import type { Dsl } from "../../schema/index.js";
+import {
+  collectAgentArtifactConsumers,
+  collectAgentArtifactProducers,
+  normalizeDerivedFrom,
+  resolveAgentEffects,
+  isNarrowOnlyOverride,
+  resolveTaskEffects,
+} from "../../resolver/effects.js";
+import { resolveToolExtends } from "../../resolver/tool-extends.js";
+import type { LintRule, LintDiagnostic } from "../types.js";
+
+export const artifactDataflowRule: LintRule = {
+  id: "artifact-dataflow",
+  description:
+    "Check artifact producer/consumer coverage, derived_from consistency, and consumer read permissions",
+
+  run(dsl: Dsl): LintDiagnostic[] {
+    const diagnostics: LintDiagnostic[] = [];
+    const resolvedTools = resolveToolExtends(dsl.tools);
+
+    for (const [artifactId, artifact] of Object.entries(dsl.artifacts)) {
+      const producers = collectAgentArtifactProducers(dsl, artifactId, resolvedTools);
+      const consumers = collectAgentArtifactConsumers(dsl, artifactId, resolvedTools);
+
+      if (producers.size === 0) {
+        diagnostics.push({
+          ruleId: "artifact-dataflow",
+          severity: "warning",
+          path: `artifacts.${artifactId}`,
+          message: `Artifact "${artifactId}" has no agent or tool that produces it`,
+        });
+      }
+
+      if (consumers.size === 0) {
+        diagnostics.push({
+          ruleId: "artifact-dataflow",
+          severity: "warning",
+          path: `artifacts.${artifactId}`,
+          message: `Artifact "${artifactId}" has no agent or tool that consumes it`,
+        });
+      }
+
+      for (const sourceId of normalizeDerivedFrom(artifact.derived_from)) {
+        if (!dsl.artifacts[sourceId]) {
+          diagnostics.push({
+            ruleId: "artifact-dataflow",
+            severity: "error",
+            path: `artifacts.${artifactId}.derived_from`,
+            message: `derived_from references non-existent artifact "${sourceId}"`,
+          });
+        }
+      }
+
+      for (const consumerId of artifact.consumers ?? []) {
+        const agent = dsl.agents[consumerId];
+        if (
+          agent &&
+          !agent.can_read_artifacts.includes(artifactId) &&
+          !agent.can_write_artifacts.includes(artifactId) &&
+          !agent.own_artifacts.includes(artifactId)
+        ) {
+          diagnostics.push({
+            ruleId: "artifact-dataflow",
+            severity: "error",
+            path: `artifacts.${artifactId}.consumers`,
+            message: `Agent "${consumerId}" consumes artifact "${artifactId}" but lacks read access (can_read_artifacts)`,
+          });
+        }
+      }
+    }
+
+    for (const [agentId, agent] of Object.entries(dsl.agents)) {
+      if (!agent.effects || agent.effects.length === 0) continue;
+      const { derived } = resolveAgentEffects(dsl, agentId, resolvedTools);
+      if (!isNarrowOnlyOverride(derived, agent.effects)) {
+        diagnostics.push({
+          ruleId: "artifact-dataflow",
+          severity: "error",
+          path: `agents.${agentId}.effects`,
+          message: `Agent effects override contains values not present in derived tool effects`,
+        });
+      }
+    }
+
+    for (const [taskId, task] of Object.entries(dsl.tasks)) {
+      if (!task.effects || task.effects.length === 0) continue;
+      const { derived } = resolveTaskEffects(dsl, taskId, resolvedTools);
+      if (!isNarrowOnlyOverride(derived, task.effects)) {
+        diagnostics.push({
+          ruleId: "artifact-dataflow",
+          severity: "error",
+          path: `tasks.${taskId}.effects`,
+          message: `Task effects override contains values not present in derived tool effects`,
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/src/linter/rules/component-contract-binding.ts
+++ b/src/linter/rules/component-contract-binding.ts
@@ -1,0 +1,36 @@
+import type { Dsl } from "../../schema/index.js";
+import { loadComponentContractSlots } from "../../navigation-index/component-contract-loader.js";
+import type { LintRule, LintDiagnostic } from "../types.js";
+
+export const componentContractBindingRule: LintRule = {
+  id: "component-contract-binding",
+  description:
+    "Check that artifact_bindings cover all slots referenced in the component contract",
+
+  run(dsl: Dsl): LintDiagnostic[] {
+    const diagnostics: LintDiagnostic[] = [];
+
+    for (const [toolId, tool] of Object.entries(dsl.tools)) {
+      if (!tool.component_contract || !tool.artifact_bindings) continue;
+
+      const command = tool.command ?? "";
+      const slotInfo = loadComponentContractSlots(tool.component_contract, command);
+      if (!slotInfo?.artifactSlots) continue;
+
+      const boundSlots = new Set(Object.keys(tool.artifact_bindings));
+
+      for (const slot of Object.keys(slotInfo.artifactSlots)) {
+        if (boundSlots.has(slot)) continue;
+
+        diagnostics.push({
+          ruleId: "component-contract-binding",
+          severity: "warning",
+          path: `tools.${toolId}.artifact_bindings`,
+          message: `Component contract references slot "${slot}" but tool has no artifact_bindings entry for it`,
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/src/navigation-index/component-contract-loader.ts
+++ b/src/navigation-index/component-contract-loader.ts
@@ -1,0 +1,108 @@
+import { existsSync, readFileSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
+
+export interface ComponentContractSlotInfo {
+  artifactSlots: Record<string, { direction: "read" | "write" | "readwrite" }>;
+}
+
+function extractStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function parseSlotDirection(
+  slotDef: unknown,
+): "read" | "write" | "readwrite" | null {
+  if (!slotDef || typeof slotDef !== "object") return null;
+  const direction = (slotDef as Record<string, unknown>).direction;
+  if (direction === "read" || direction === "write" || direction === "readwrite") {
+    return direction;
+  }
+  return null;
+}
+
+function extractArtifactSlots(
+  slots: unknown,
+): Record<string, { direction: "read" | "write" | "readwrite" }> | null {
+  if (!slots || typeof slots !== "object") return null;
+
+  const result: Record<string, { direction: "read" | "write" | "readwrite" }> = {};
+  for (const [name, slotDef] of Object.entries(slots)) {
+    if (typeof slotDef === "string") {
+      result[name] = { direction: "readwrite" };
+      continue;
+    }
+    const direction = parseSlotDirection(slotDef);
+    if (direction) {
+      result[name] = { direction };
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+function extractOperationSlots(
+  doc: Record<string, unknown>,
+  command: string,
+): Record<string, { direction: "read" | "write" | "readwrite" }> | null {
+  const operations = doc.operations;
+  if (!operations || typeof operations !== "object") return null;
+
+  const operation = (operations as Record<string, unknown>)[command];
+  if (!operation || typeof operation !== "object") return null;
+
+  const slots = (operation as Record<string, unknown>).artifact_slots;
+  return extractArtifactSlots(slots);
+}
+
+function resolveComponentContractPath(componentContractPath: string): string {
+  return isAbsolute(componentContractPath)
+    ? componentContractPath
+    : resolve(process.cwd(), componentContractPath);
+}
+
+export function loadComponentContractSlots(
+  componentContractPath: string,
+  command?: string,
+): ComponentContractSlotInfo | null {
+  const filePath = resolveComponentContractPath(componentContractPath);
+  if (!existsSync(filePath)) return null;
+
+  let doc: unknown;
+  try {
+    doc = parseYaml(readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+
+  if (!doc || typeof doc !== "object") return null;
+  const record = doc as Record<string, unknown>;
+
+  let artifactSlots: Record<string, { direction: "read" | "write" | "readwrite" }> | null =
+    null;
+
+  if (command) {
+    artifactSlots = extractOperationSlots(record, command);
+  }
+
+  if (!artifactSlots) {
+    artifactSlots = extractArtifactSlots(record.artifact_slots);
+  }
+
+  if (!artifactSlots) return null;
+
+  return { artifactSlots };
+}
+
+export function resolveComponentSlotDirection(
+  slot: string,
+  slotInfo: ComponentContractSlotInfo,
+): "read" | "write" {
+  const slotDecl = slotInfo.artifactSlots[slot];
+  if (!slotDecl) return "read";
+  if (slotDecl.direction === "write" || slotDecl.direction === "readwrite") {
+    return "write";
+  }
+  return "read";
+}

--- a/src/renderer/context.ts
+++ b/src/renderer/context.ts
@@ -14,7 +14,9 @@ import type {
   System,
   SoftwareBinding,
 } from "../schema/index.js";
-import { resolveAllOf } from "../schema/index.js";
+import { resolveAllOf, resolveSchemaRefs } from "../schema/index.js";
+import { resolveAgentEffects } from "../resolver/effects.js";
+import type { EffectiveEffects } from "../resolver/effects.js";
 import type { LoadedBinding } from "../config/binding-loader.js";
 
 export interface GlobalContext {
@@ -160,6 +162,22 @@ export interface MergedBehavioralSpec {
   completion_criteria: string[];
 }
 
+export interface HandoffFieldView {
+  name: string;
+  type: string;
+  required: boolean;
+  enum?: string;
+}
+
+export interface HandoffRoleView {
+  handoffId: string;
+  role: "producer" | "consumer";
+  taskId?: string;
+  description?: string;
+  resolvedSchema: Record<string, unknown>;
+  fields: HandoffFieldView[];
+}
+
 export interface DelegatableTaskView {
   id: string;
   description: string;
@@ -181,6 +199,10 @@ export interface PerAgentContext {
   relatedArtifacts: Dsl["artifacts"];
   relatedTools: Dsl["tools"];
   relatedHandoffTypes: Dsl["handoff_types"];
+  resolvedHandoffTypes: Record<string, Record<string, unknown>>;
+  producerHandoffs: HandoffRoleView[];
+  consumerHandoffs: HandoffRoleView[];
+  effectiveEffects: EffectiveEffects;
   mergedBehavior: MergedBehavioralSpec;
   relatedGuardrails: EntityGuardrailEntry[];
   relatedValidations: EntityValidationEntry[];
@@ -745,6 +767,113 @@ function extractSchemaFieldNames(
   return Object.keys(schema);
 }
 
+function extractSchemaFields(
+  schema: Record<string, unknown>,
+): HandoffFieldView[] {
+  const effective = resolveAllOf(schema);
+  const props = effective["properties"] as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  if (!props) return [];
+  const requiredSet = new Set(
+    (effective["required"] as string[] | undefined) ?? [],
+  );
+  return Object.entries(props).map(([name, sub]) => {
+    const enumVals = sub["enum"] as string[] | undefined;
+    return {
+      name,
+      type: (sub["type"] as string) ?? "any",
+      required: requiredSet.has(name),
+      enum: enumVals ? enumVals.join(" | ") : undefined,
+    };
+  });
+}
+
+function resolveHandoffSchema(
+  dsl: Dsl,
+  handoffId: string,
+): Record<string, unknown> | null {
+  const handoff = dsl.handoff_types[handoffId];
+  if (!handoff?.schema) return null;
+  return resolveSchemaRefs(
+    handoff.schema as Record<string, unknown>,
+    dsl.components?.schemas ?? {},
+  );
+}
+
+function buildHandoffRoleView(
+  dsl: Dsl,
+  handoffId: string,
+  role: "producer" | "consumer",
+  taskId?: string,
+): HandoffRoleView | null {
+  const handoff = dsl.handoff_types[handoffId];
+  const resolvedSchema = resolveHandoffSchema(dsl, handoffId);
+  if (!handoff || !resolvedSchema) return null;
+  return {
+    handoffId,
+    role,
+    taskId,
+    description: handoff.description,
+    resolvedSchema,
+    fields: extractSchemaFields(resolvedSchema),
+  };
+}
+
+function buildHandoffRoles(
+  dsl: Dsl,
+  agentId: string,
+  receivableTasks: Array<(Task & Record<string, unknown>) & { id: string }>,
+  delegatableTasks: DelegatableTaskView[],
+): { producer: HandoffRoleView[]; consumer: HandoffRoleView[] } {
+  const producer = new Map<string, HandoffRoleView>();
+  const consumer = new Map<string, HandoffRoleView>();
+
+  const addRole = (
+    map: Map<string, HandoffRoleView>,
+    view: HandoffRoleView | null,
+  ) => {
+    if (!view) return;
+    const key = `${view.handoffId}:${view.role}:${view.taskId ?? ""}`;
+    map.set(key, view);
+  };
+
+  for (const task of receivableTasks) {
+    addRole(
+      consumer,
+      buildHandoffRoleView(dsl, task.invocation_handoff, "consumer", task.id),
+    );
+    addRole(
+      producer,
+      buildHandoffRoleView(dsl, task.result_handoff, "producer", task.id),
+    );
+  }
+
+  for (const task of delegatableTasks) {
+    addRole(
+      producer,
+      buildHandoffRoleView(dsl, task.invocation_handoff, "producer", task.id),
+    );
+    addRole(
+      consumer,
+      buildHandoffRoleView(dsl, task.result_handoff, "consumer", task.id),
+    );
+  }
+
+  const agent = dsl.agents[agentId];
+  for (const handoffId of agent?.can_return_handoffs ?? []) {
+    addRole(
+      producer,
+      buildHandoffRoleView(dsl, handoffId, "producer"),
+    );
+  }
+
+  return {
+    producer: [...producer.values()],
+    consumer: [...consumer.values()],
+  };
+}
+
 function buildDelegatableTasks(
   dsl: Dsl,
   agentId: string,
@@ -806,14 +935,25 @@ export function buildPerAgentContext(
     ...delegatableTasks.map((t) => t.result_handoff),
   ]);
   const relatedHandoffTypes: Dsl["handoff_types"] = {};
+  const resolvedHandoffTypes: Record<string, Record<string, unknown>> = {};
   for (const [kind, ht] of Object.entries(dsl.handoff_types)) {
-    if (handoffKinds.has(kind)) relatedHandoffTypes[kind] = ht;
+    if (!handoffKinds.has(kind)) continue;
+    relatedHandoffTypes[kind] = ht;
+    const resolved = resolveHandoffSchema(dsl, kind);
+    if (resolved) resolvedHandoffTypes[kind] = resolved;
   }
 
+  const handoffRoles = buildHandoffRoles(
+    dsl,
+    agentId,
+    receivableTasks,
+    delegatableTasks,
+  );
   const rawReceivableTasks = receivableTasks.map(({ id: _id, ...rest }) => rest as Task);
   const mergedBehavior = mergeBehavioralSpec(agent, rawReceivableTasks);
   const relatedGuardrails = resolveEffectiveGuardrails(dsl, "agents", agentId);
   const relatedValidations = resolveEntityValidations(dsl, "agents", agentId);
+  const effectiveEffects = resolveAgentEffects(dsl, agentId);
 
   return {
     agent,
@@ -823,6 +963,10 @@ export function buildPerAgentContext(
     relatedArtifacts,
     relatedTools,
     relatedHandoffTypes,
+    resolvedHandoffTypes,
+    producerHandoffs: handoffRoles.producer,
+    consumerHandoffs: handoffRoles.consumer,
+    effectiveEffects,
     mergedBehavior,
     relatedGuardrails,
     relatedValidations,

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -35,6 +35,8 @@ export {
   type PerGuardrailPolicyContext,
   type MergedBehavioralSpec,
   type DelegatableTaskView,
+  type HandoffRoleView,
+  type HandoffFieldView,
   type GuardrailEnforcementEntry,
   type EntityGuardrailEntry,
   type EntityValidationEntry,

--- a/src/resolver/effects.ts
+++ b/src/resolver/effects.ts
@@ -1,0 +1,247 @@
+import type { Dsl, Agent, Task, Tool } from "../schema/index.js";
+import { resolveToolExtends } from "./tool-extends.js";
+import { loadCliContractSlots, resolveSlotDirection } from "../navigation-index/cli-contract-loader.js";
+
+export interface EffectiveEffects {
+  derived: string[];
+  override?: string[];
+  effective: string[];
+}
+
+function addEffect(set: Set<string>, effect: string): void {
+  if (effect.length > 0) set.add(effect);
+}
+
+function collectToolEffects(tool: Tool): Set<string> {
+  const effects = new Set<string>();
+
+  for (const sideEffect of tool.side_effects ?? []) {
+    addEffect(effects, sideEffect);
+  }
+
+  if (tool.cli_contract) {
+    const command = tool.command ?? "";
+    const slotInfo = loadCliContractSlots(tool.cli_contract);
+    if (slotInfo) {
+      for (const [slot, artifactId] of Object.entries(tool.artifact_bindings ?? {})) {
+        const direction = resolveSlotDirection(slot, command, slotInfo);
+        addEffect(effects, `${direction}:${artifactId}`);
+      }
+    }
+  }
+
+  for (const artifactId of tool.input_artifacts ?? []) {
+    addEffect(effects, `read:${artifactId}`);
+  }
+  for (const artifactId of tool.output_artifacts ?? []) {
+    addEffect(effects, `write:${artifactId}`);
+  }
+
+  for (const cmd of tool.commands ?? []) {
+    for (const artifactId of cmd.reads ?? []) {
+      addEffect(effects, `read:${artifactId}`);
+    }
+    for (const artifactId of cmd.writes ?? []) {
+      addEffect(effects, `write:${artifactId}`);
+    }
+  }
+
+  return effects;
+}
+
+function sortEffects(effects: Iterable<string>): string[] {
+  return [...effects].sort();
+}
+
+function applyNarrowOverride(
+  derived: string[],
+  override: string[] | undefined,
+): EffectiveEffects {
+  if (!override || override.length === 0) {
+    return { derived, effective: derived };
+  }
+  return { derived, override, effective: [...override].sort() };
+}
+
+export function resolveToolEffects(tool: Tool): string[] {
+  return sortEffects(collectToolEffects(tool));
+}
+
+export function resolveAgentEffects(
+  dsl: Dsl,
+  agentId: string,
+  resolvedTools?: Record<string, Tool>,
+): EffectiveEffects {
+  const agent = dsl.agents[agentId];
+  if (!agent) {
+    return { derived: [], effective: [] };
+  }
+
+  const tools = resolvedTools ?? resolveToolExtends(dsl.tools);
+  const derived = new Set<string>();
+
+  for (const toolId of agent.can_execute_tools ?? []) {
+    const tool = tools[toolId];
+    if (!tool) continue;
+    for (const effect of collectToolEffects(tool)) {
+      derived.add(effect);
+    }
+  }
+
+  const derivedSorted = sortEffects(derived);
+  return applyNarrowOverride(derivedSorted, agent.effects);
+}
+
+export function resolveTaskEffects(
+  dsl: Dsl,
+  taskId: string,
+  resolvedTools?: Record<string, Tool>,
+): EffectiveEffects {
+  const task = dsl.tasks[taskId];
+  if (!task) {
+    return { derived: [], effective: [] };
+  }
+
+  const tools = resolvedTools ?? resolveToolExtends(dsl.tools);
+  const derived = new Set<string>();
+
+  const agentEffects = resolveAgentEffects(dsl, task.target_agent, tools);
+  for (const effect of agentEffects.derived) {
+    derived.add(effect);
+  }
+
+  for (const step of task.execution_steps ?? []) {
+    if (!step.uses_tool) continue;
+    const tool = tools[step.uses_tool];
+    if (!tool) continue;
+    for (const effect of collectToolEffects(tool)) {
+      derived.add(effect);
+    }
+  }
+
+  const derivedSorted = sortEffects(derived);
+  return applyNarrowOverride(derivedSorted, task.effects);
+}
+
+export function isNarrowOnlyOverride(
+  derived: string[],
+  override: string[] | undefined,
+): boolean {
+  if (!override || override.length === 0) return true;
+  const derivedSet = new Set(derived);
+  return override.every((effect) => derivedSet.has(effect));
+}
+
+export function collectAgentArtifactProducers(
+  dsl: Dsl,
+  artifactId: string,
+  resolvedTools?: Record<string, Tool>,
+): Set<string> {
+  const producers = new Set<string>();
+  const tools = resolvedTools ?? resolveToolExtends(dsl.tools);
+
+  for (const [agentId, agent] of Object.entries(dsl.agents)) {
+    if (agent.can_write_artifacts.includes(artifactId)) {
+      producers.add(`agent:${agentId}`);
+    }
+  }
+
+  for (const [taskId, task] of Object.entries(dsl.tasks)) {
+    for (const step of task.execution_steps ?? []) {
+      if (step.produces_artifact === artifactId) {
+        producers.add(`agent:${task.target_agent}`);
+        producers.add(`task:${taskId}`);
+      }
+    }
+  }
+
+  for (const [toolId, tool] of Object.entries(tools)) {
+    if (tool.output_artifacts.includes(artifactId)) {
+      producers.add(`tool:${toolId}`);
+    }
+    if (tool.cli_contract) {
+      const command = tool.command ?? "";
+      const slotInfo = loadCliContractSlots(tool.cli_contract);
+      if (slotInfo) {
+        for (const [slot, boundArtifact] of Object.entries(tool.artifact_bindings ?? {})) {
+          if (
+            boundArtifact === artifactId &&
+            resolveSlotDirection(slot, command, slotInfo) === "write"
+          ) {
+            producers.add(`tool:${toolId}`);
+          }
+        }
+      }
+    }
+  }
+
+  for (const producer of dsl.artifacts[artifactId]?.producers ?? []) {
+    producers.add(`agent:${producer}`);
+  }
+  for (const editor of dsl.artifacts[artifactId]?.editors ?? []) {
+    producers.add(`agent:${editor}`);
+  }
+
+  return producers;
+}
+
+export function collectAgentArtifactConsumers(
+  dsl: Dsl,
+  artifactId: string,
+  resolvedTools?: Record<string, Tool>,
+): Set<string> {
+  const consumers = new Set<string>();
+  const tools = resolvedTools ?? resolveToolExtends(dsl.tools);
+
+  for (const [agentId, agent] of Object.entries(dsl.agents)) {
+    if (agent.can_read_artifacts.includes(artifactId)) {
+      consumers.add(`agent:${agentId}`);
+    }
+  }
+
+  for (const [taskId, task] of Object.entries(dsl.tasks)) {
+    if (task.input_artifacts.includes(artifactId)) {
+      consumers.add(`agent:${task.target_agent}`);
+      consumers.add(`task:${taskId}`);
+    }
+    for (const step of task.execution_steps ?? []) {
+      if (step.reads_artifact === artifactId) {
+        consumers.add(`agent:${task.target_agent}`);
+        consumers.add(`task:${taskId}`);
+      }
+    }
+  }
+
+  for (const [toolId, tool] of Object.entries(tools)) {
+    if (tool.input_artifacts.includes(artifactId)) {
+      consumers.add(`tool:${toolId}`);
+    }
+    if (tool.cli_contract) {
+      const command = tool.command ?? "";
+      const slotInfo = loadCliContractSlots(tool.cli_contract);
+      if (slotInfo) {
+        for (const [slot, boundArtifact] of Object.entries(tool.artifact_bindings ?? {})) {
+          if (
+            boundArtifact === artifactId &&
+            resolveSlotDirection(slot, command, slotInfo) === "read"
+          ) {
+            consumers.add(`tool:${toolId}`);
+          }
+        }
+      }
+    }
+  }
+
+  for (const consumer of dsl.artifacts[artifactId]?.consumers ?? []) {
+    consumers.add(`agent:${consumer}`);
+  }
+
+  return consumers;
+}
+
+export function normalizeDerivedFrom(
+  derivedFrom: string | string[] | undefined,
+): string[] {
+  if (!derivedFrom) return [];
+  return Array.isArray(derivedFrom) ? derivedFrom : [derivedFrom];
+}

--- a/src/resolver/index.ts
+++ b/src/resolver/index.ts
@@ -12,6 +12,16 @@ export {
 export { resolve, type ResolveResult } from "./resolve.js";
 export { resolveClone, CloneError } from "./clone.js";
 export { resolveToolExtends, ToolExtendsError } from "./tool-extends.js";
+export {
+  resolveAgentEffects,
+  resolveTaskEffects,
+  resolveToolEffects,
+  isNarrowOnlyOverride,
+  collectAgentArtifactProducers,
+  collectAgentArtifactConsumers,
+  normalizeDerivedFrom,
+  type EffectiveEffects,
+} from "./effects.js";
 export { substituteVars, VarsSubstitutionError } from "./substitute-vars.js";
 export { expandDefaults } from "./expand-defaults.js";
 export {

--- a/src/resolver/tool-extends.ts
+++ b/src/resolver/tool-extends.ts
@@ -42,6 +42,10 @@ function mergeToolFields(base: Tool, child: Tool): Tool {
     merged.cli_contract = base.cli_contract;
   }
 
+  if (isUnset(child.component_contract) && !isUnset(base.component_contract)) {
+    merged.component_contract = base.component_contract;
+  }
+
   if (isUnset(child.description) && !isUnset(base.description)) {
     merged.description = base.description;
   }

--- a/src/schema/agent.ts
+++ b/src/schema/agent.ts
@@ -74,6 +74,7 @@ export const AgentSchema = z
     prerequisites: z.array(PrerequisiteSchema).optional(),
     guardrails: z.array(z.string()).optional(),
     memory: MemoryCapabilitySchema.optional(),
+    effects: z.array(z.string()).optional(),
   })
   .passthrough();
 export type Agent = z.infer<typeof AgentSchema>;

--- a/src/schema/artifact.ts
+++ b/src/schema/artifact.ts
@@ -18,6 +18,7 @@ export const ArtifactSchema = z
     exclude_patterns: z.array(z.string()).optional(),
     manual_edit: z.enum(["allowed", "discouraged", "forbidden"]).optional(),
     change_control: z.enum(["none", "approval-required", "regeneration-required"]).optional(),
+    derived_from: z.union([z.string(), z.array(z.string())]).optional(),
   })
   .passthrough();
 export type Artifact = z.infer<typeof ArtifactSchema>;

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -64,6 +64,7 @@ export {
   type GuardrailScope,
 } from "./guardrail.js";
 export { resolveAllOf } from "./json-schema-utils.js";
+export { resolveSchemaRefs } from "./resolve-schema-refs.js";
 export {
   AppendOperatorSchema,
   type AppendOperator,

--- a/src/schema/resolve-schema-refs.ts
+++ b/src/schema/resolve-schema-refs.ts
@@ -1,0 +1,84 @@
+import { resolveAllOf } from "./json-schema-utils.js";
+
+type AnyRecord = Record<string, unknown>;
+
+const COMPONENTS_REF_PATTERN = /^#\/components\/schemas\/(.+)$/;
+
+export function resolveSchemaRefs(
+  schema: AnyRecord,
+  components: Record<string, AnyRecord> = {},
+): AnyRecord {
+  const resolved = resolveRefsDeep(schema, components, new Set());
+  return resolveAllOf(resolved);
+}
+
+function resolveRefsDeep(
+  schema: AnyRecord,
+  components: Record<string, AnyRecord>,
+  resolving: Set<string>,
+): AnyRecord {
+  const ref = schema["$ref"];
+  if (typeof ref === "string") {
+    const match = ref.match(COMPONENTS_REF_PATTERN);
+    if (match) {
+      const name = match[1];
+      if (resolving.has(name)) return schema;
+      const target = components[name];
+      if (target && typeof target === "object") {
+        resolving.add(name);
+        try {
+          return resolveRefsDeep({ ...target }, components, resolving);
+        } finally {
+          resolving.delete(name);
+        }
+      }
+    }
+    return schema;
+  }
+
+  const result: AnyRecord = { ...schema };
+
+  const allOf = schema["allOf"];
+  if (Array.isArray(allOf)) {
+    result["allOf"] = allOf.map((sub) =>
+      typeof sub === "object" && sub !== null && !Array.isArray(sub)
+        ? resolveRefsDeep(sub as AnyRecord, components, resolving)
+        : sub,
+    );
+  }
+
+  const props = schema["properties"];
+  if (props && typeof props === "object") {
+    const resolvedProps: AnyRecord = {};
+    for (const [key, value] of Object.entries(props as AnyRecord)) {
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        resolvedProps[key] = resolveRefsDeep(
+          value as AnyRecord,
+          components,
+          resolving,
+        );
+      } else {
+        resolvedProps[key] = value;
+      }
+    }
+    result["properties"] = resolvedProps;
+  }
+
+  const items = schema["items"];
+  if (items && typeof items === "object" && !Array.isArray(items)) {
+    result["items"] = resolveRefsDeep(items as AnyRecord, components, resolving);
+  }
+
+  for (const combiner of ["oneOf", "anyOf"] as const) {
+    const values = schema[combiner];
+    if (Array.isArray(values)) {
+      result[combiner] = values.map((sub) =>
+        typeof sub === "object" && sub !== null && !Array.isArray(sub)
+          ? resolveRefsDeep(sub as AnyRecord, components, resolving)
+          : sub,
+      );
+    }
+  }
+
+  return result;
+}

--- a/src/schema/task.ts
+++ b/src/schema/task.ts
@@ -44,6 +44,7 @@ export const TaskSchema = z
     validations: z.array(z.string()).default([]),
     guardrails: z.array(z.string()).optional(),
     model_class: ModelClassSchema.optional(),
+    effects: z.array(z.string()).optional(),
   })
   .passthrough();
 export type Task = z.infer<typeof TaskSchema>;

--- a/src/schema/tool.ts
+++ b/src/schema/tool.ts
@@ -19,6 +19,7 @@ export const ToolSchema = z
     output_artifacts: z.array(z.string()).default([]),
     invokable_by: z.array(z.string()).default([]),
     cli_contract: z.string().optional(),
+    component_contract: z.string().optional(),
     artifact_bindings: z.record(z.string(), z.string()).default({}),
     side_effects: z.array(z.string()).default([]),
     commands: z.array(CommandSchema).default([]),

--- a/src/validator/schema-validator.ts
+++ b/src/validator/schema-validator.ts
@@ -117,6 +117,28 @@ function checkExtensionsKeys(
   return diagnostics;
 }
 
+function checkToolContractExclusivity(
+  data: Record<string, unknown>,
+): DiagnosticMessage[] {
+  const tools = data["tools"];
+  if (!isRecord(tools)) return [];
+  const diagnostics: DiagnosticMessage[] = [];
+
+  for (const [toolId, tool] of Object.entries(tools)) {
+    if (!isRecord(tool)) continue;
+    if (tool["cli_contract"] && tool["component_contract"]) {
+      diagnostics.push({
+        path: `tools.${toolId}`,
+        message:
+          'Tool cannot specify both "cli_contract" and "component_contract". Use one contract reference.',
+        code: "tool-contract-mutual-exclusion",
+      });
+    }
+  }
+
+  return diagnostics;
+}
+
 function checkDecisionStepRoutingKey(
   data: Record<string, unknown>,
 ): DiagnosticMessage[] {
@@ -831,6 +853,7 @@ export function validateSchema(
   const diagnostics: DiagnosticMessage[] = [
     ...deprecationWarnings,
     ...checkCustomPropsRecursive(data, DslSchema, ""),
+    ...checkToolContractExclusivity(data),
     ...checkDecisionStepRoutingKey(data),
     ...checkExtensionsKeys(data),
     ...checkExtensionValidation(data),

--- a/test/fixtures/component-contracts/review-component.yaml
+++ b/test/fixtures/component-contracts/review-component.yaml
@@ -1,0 +1,18 @@
+schema: aaac/v1
+info:
+  id: review-component
+  version: "1.0.0"
+  description: Review component for testing
+
+operations:
+  review:
+    description: Review source code changes
+    artifact_slots:
+      source-diff:
+        direction: read
+      review-report:
+        direction: write
+  summarize:
+    description: Summarize review findings
+    artifact_slots:
+      review-report: review-report

--- a/test/fixtures/templates/agent-prompt.md.hbs
+++ b/test/fixtures/templates/agent-prompt.md.hbs
@@ -48,6 +48,28 @@
 {{/each}}
 {{/if}}
 
+{{#if producerHandoffs.length}}
+## Handoff Output Formats
+
+{{#each producerHandoffs}}
+### {{this.handoffId}}
+{{#each this.fields}}
+- {{this.name}}: {{this.type}}
+{{/each}}
+{{/each}}
+{{/if}}
+
+{{#if consumerHandoffs.length}}
+## Handoff Input Formats
+
+{{#each consumerHandoffs}}
+### {{this.handoffId}}
+{{#each this.fields}}
+- {{this.name}}: {{this.type}}
+{{/each}}
+{{/each}}
+{{/if}}
+
 {{#if (notEmpty relatedHandoffTypes)}}
 ## Handoff Types
 

--- a/test/linter/artifact-dataflow.test.ts
+++ b/test/linter/artifact-dataflow.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { DslSchema, type Dsl } from "../../src/schema/index.js";
+import { artifactDataflowRule } from "../../src/linter/rules/artifact-dataflow.js";
+
+function makeDsl(partial: Partial<Record<string, unknown>>): Dsl {
+  return DslSchema.parse({
+    version: 1,
+    system: { id: "s", name: "S", default_workflow_order: ["implement"] },
+    ...partial,
+  });
+}
+
+describe("artifactDataflowRule", () => {
+  it("warns when artifact has no producer", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        orphan: { type: "doc", owner: "a1", producers: [], editors: [], consumers: ["a1"], states: ["draft"] },
+      },
+    });
+
+    const diags = artifactDataflowRule.run(dsl);
+    expect(diags.some((d) => d.message.includes("no agent or tool that produces"))).toBe(true);
+  });
+
+  it("errors when derived_from references missing artifact", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P", can_write_artifacts: ["derived"] } },
+      artifacts: {
+        derived: {
+          type: "doc",
+          owner: "a1",
+          producers: ["a1"],
+          editors: ["a1"],
+          consumers: ["a1"],
+          states: ["draft"],
+          derived_from: ["missing-source"],
+        },
+      },
+    });
+
+    const diags = artifactDataflowRule.run(dsl);
+    expect(diags.some((d) => d.message.includes("non-existent artifact"))).toBe(true);
+  });
+
+  it("errors when consumer lacks read permission", () => {
+    const dsl = makeDsl({
+      agents: {
+        a1: { role_name: "R", purpose: "P" },
+        a2: { role_name: "R2", purpose: "P2" },
+      },
+      artifacts: {
+        doc: {
+          type: "doc",
+          owner: "a1",
+          producers: ["a1"],
+          editors: ["a1"],
+          consumers: ["a2"],
+          states: ["draft"],
+        },
+      },
+    });
+
+    const diags = artifactDataflowRule.run(dsl);
+    expect(diags.some((d) => d.message.includes("lacks read access"))).toBe(true);
+  });
+});

--- a/test/linter/component-contract-binding.test.ts
+++ b/test/linter/component-contract-binding.test.ts
@@ -1,0 +1,66 @@
+import { resolve, join } from "node:path";
+import { describe, it, expect } from "vitest";
+import { DslSchema, type Dsl } from "../../src/schema/index.js";
+import { componentContractBindingRule } from "../../src/linter/rules/component-contract-binding.js";
+
+const fixturesDir = resolve(import.meta.dirname, "../fixtures");
+const reviewComponent = join(fixturesDir, "component-contracts/review-component.yaml");
+
+function makeDsl(partial: Partial<Record<string, unknown>>): Dsl {
+  return DslSchema.parse({
+    version: 1,
+    system: { id: "s", name: "S", default_workflow_order: ["implement"] },
+    ...partial,
+  });
+}
+
+describe("componentContractBindingRule", () => {
+  it("warns when component contract slots are missing from artifact_bindings", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        diff: { type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      tools: {
+        reviewer: {
+          kind: "component",
+          invokable_by: ["a1"],
+          component_contract: reviewComponent,
+          command: "review",
+          artifact_bindings: {
+            "source-diff": "diff",
+          },
+        },
+      },
+    });
+
+    const diags = componentContractBindingRule.run(dsl);
+    expect(diags.length).toBe(1);
+    expect(diags[0].message).toContain("review-report");
+  });
+
+  it("passes when artifact_bindings cover all component slots", () => {
+    const dsl = makeDsl({
+      agents: { a1: { role_name: "R", purpose: "P" } },
+      artifacts: {
+        diff: { type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+        report: { type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      tools: {
+        reviewer: {
+          kind: "component",
+          invokable_by: ["a1"],
+          component_contract: reviewComponent,
+          command: "review",
+          artifact_bindings: {
+            "source-diff": "diff",
+            "review-report": "report",
+          },
+        },
+      },
+    });
+
+    const diags = componentContractBindingRule.run(dsl);
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/test/renderer/handoff-roles.test.ts
+++ b/test/renderer/handoff-roles.test.ts
@@ -1,0 +1,147 @@
+import { readFileSync, rmSync, existsSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, it, expect, afterAll } from "vitest";
+import { DslSchema, type Dsl } from "../../src/schema/index.js";
+import { buildPerAgentContext } from "../../src/renderer/context.js";
+import { renderFromConfig } from "../../src/renderer/renderer.js";
+import type { ResolvedRenderTarget } from "../../src/config/types.js";
+
+const templateDir = join(resolve(import.meta.dirname, "../fixtures"), "templates");
+const outputDir = join(tmpdir(), "agc-handoff-roles-output");
+
+afterAll(() => {
+  if (existsSync(outputDir)) {
+    rmSync(outputDir, { recursive: true, force: true });
+  }
+});
+
+function makeDsl(): Dsl {
+  return DslSchema.parse({
+    version: 1,
+    system: { id: "s", name: "S", default_workflow_order: ["impl"] },
+    components: {
+      schemas: {
+        BaseHandoff: {
+          type: "object",
+          properties: {
+            from_agent: { type: "string" },
+            to_agent: { type: "string" },
+          },
+          required: ["from_agent", "to_agent"],
+        },
+      },
+    },
+    agents: {
+      producer: {
+        role_name: "Producer",
+        purpose: "Produces handoffs",
+        can_invoke_agents: ["consumer"],
+        can_return_handoffs: ["result"],
+      },
+      consumer: {
+        role_name: "Consumer",
+        purpose: "Consumes handoffs",
+        can_return_handoffs: ["result"],
+      },
+    },
+    tasks: {
+      "do-work": {
+        description: "Do work",
+        target_agent: "consumer",
+        allowed_from_agents: ["producer"],
+        workflow: "impl",
+        input_artifacts: [],
+        invocation_handoff: "delegation",
+        result_handoff: "result",
+      },
+    },
+    handoff_types: {
+      delegation: {
+        version: 1,
+        description: "Task delegation",
+        schema: {
+          allOf: [
+            { $ref: "#/components/schemas/BaseHandoff" },
+            {
+              type: "object",
+              properties: {
+                payload: {
+                  type: "object",
+                  properties: { objective: { type: "string" } },
+                },
+              },
+            },
+          ],
+        },
+      },
+      result: {
+        version: 1,
+        description: "Task result",
+        schema: {
+          type: "object",
+          properties: {
+            status: { type: "string", enum: ["success", "failure"] },
+          },
+          required: ["status"],
+        },
+      },
+    },
+  });
+}
+
+describe("handoff role rendering", () => {
+  it("builds producer and consumer handoff views with resolved schemas", () => {
+    const dsl = makeDsl();
+    const producerCtx = buildPerAgentContext(dsl, {
+      ...dsl.agents.producer,
+      id: "producer",
+    });
+    const consumerCtx = buildPerAgentContext(dsl, {
+      ...dsl.agents.consumer,
+      id: "consumer",
+    });
+
+    expect(producerCtx.producerHandoffs.some((h) => h.handoffId === "delegation")).toBe(true);
+    expect(consumerCtx.consumerHandoffs.some((h) => h.handoffId === "delegation")).toBe(true);
+    expect(consumerCtx.producerHandoffs.some((h) => h.handoffId === "result")).toBe(true);
+    expect(producerCtx.consumerHandoffs.some((h) => h.handoffId === "result")).toBe(true);
+
+    const delegationProducer = producerCtx.producerHandoffs.find(
+      (h) => h.handoffId === "delegation",
+    );
+    expect(delegationProducer?.fields.map((f) => f.name)).toEqual(
+      expect.arrayContaining(["from_agent", "to_agent", "payload"]),
+    );
+    expect(delegationProducer?.resolvedSchema.properties).toHaveProperty("from_agent");
+  });
+
+  it("renders producer/consumer handoff sections into agent prompt", async () => {
+    const dsl = makeDsl();
+    const targets: ResolvedRenderTarget[] = [
+      {
+        template: join(templateDir, "agent-prompt.md.hbs"),
+        context: "agent",
+        output: join(outputDir, "{agent.id}.md"),
+        include: ["producer", "consumer"],
+      },
+    ];
+
+    const files = await renderFromConfig(dsl, targets);
+    const producerFile = files.find((f) => f.includes("producer"));
+    const consumerFile = files.find((f) => f.includes("consumer"));
+    expect(producerFile).toBeDefined();
+    expect(consumerFile).toBeDefined();
+
+    const producerContent = readFileSync(producerFile!, "utf8");
+    const consumerContent = readFileSync(consumerFile!, "utf8");
+
+    expect(producerContent).toContain("Handoff Output Formats");
+    expect(producerContent).toContain("delegation");
+    expect(producerContent).toContain("from_agent");
+
+    expect(consumerContent).toContain("Handoff Input Formats");
+    expect(consumerContent).toContain("delegation");
+    expect(consumerContent).toContain("result");
+  });
+});

--- a/test/resolver/effects.test.ts
+++ b/test/resolver/effects.test.ts
@@ -1,0 +1,165 @@
+import { resolve, join } from "node:path";
+import { describe, it, expect } from "vitest";
+import { DslSchema, type Dsl } from "../../src/schema/index.js";
+import {
+  resolveAgentEffects,
+  resolveTaskEffects,
+  isNarrowOnlyOverride,
+  collectAgentArtifactProducers,
+  collectAgentArtifactConsumers,
+} from "../../src/resolver/effects.js";
+
+const fixturesDir = resolve(import.meta.dirname, "../fixtures");
+const speckeeperCliContract = join(fixturesDir, "cli-contracts/speckeeper-cli-contract.yaml");
+
+function makeDsl(partial: Partial<Record<string, unknown>>): Dsl {
+  return DslSchema.parse({
+    version: 1,
+    system: { id: "s", name: "S", default_workflow_order: ["implement"] },
+    ...partial,
+  });
+}
+
+describe("resolveAgentEffects", () => {
+  it("aggregates read/write effects from cli_contract artifact_bindings", () => {
+    const dsl = makeDsl({
+      agents: {
+        a1: { role_name: "R", purpose: "P", can_execute_tools: ["speckeeper"] },
+      },
+      artifacts: {
+        spec: { type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+        output: { type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      tools: {
+        speckeeper: {
+          kind: "cli",
+          invokable_by: ["a1"],
+          cli_contract: speckeeperCliContract,
+          command: "build",
+          artifact_bindings: {
+            "spec-source": "spec",
+            "output-docs": "output",
+          },
+        },
+      },
+    });
+
+    const effects = resolveAgentEffects(dsl, "a1");
+    expect(effects.derived).toContain("read:spec");
+    expect(effects.derived).toContain("write:output");
+    expect(effects.effective).toEqual(effects.derived);
+  });
+
+  it("applies narrow-only override from agent.effects", () => {
+    const dsl = makeDsl({
+      agents: {
+        a1: {
+          role_name: "R",
+          purpose: "P",
+          can_execute_tools: ["speckeeper"],
+          effects: ["read:spec"],
+        },
+      },
+      artifacts: {
+        spec: { type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+        output: { type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      tools: {
+        speckeeper: {
+          kind: "cli",
+          invokable_by: ["a1"],
+          cli_contract: speckeeperCliContract,
+          command: "build",
+          artifact_bindings: {
+            "spec-source": "spec",
+            "output-docs": "output",
+          },
+        },
+      },
+    });
+
+    const effects = resolveAgentEffects(dsl, "a1");
+    expect(effects.override).toEqual(["read:spec"]);
+    expect(effects.effective).toEqual(["read:spec"]);
+    expect(isNarrowOnlyOverride(effects.derived, effects.override)).toBe(true);
+  });
+
+  it("detects invalid narrow-only override", () => {
+    const derived = ["read:spec", "write:output"];
+    expect(isNarrowOnlyOverride(derived, ["read:spec"])).toBe(true);
+    expect(isNarrowOnlyOverride(derived, ["network:api"])).toBe(false);
+  });
+});
+
+describe("resolveTaskEffects", () => {
+  it("includes execution step tool effects in derived set", () => {
+    const dsl = makeDsl({
+      agents: {
+        a1: { role_name: "R", purpose: "P", can_execute_tools: [] },
+      },
+      artifacts: {
+        spec: { type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      tools: {
+        speckeeper: {
+          kind: "cli",
+          invokable_by: ["a1"],
+          cli_contract: speckeeperCliContract,
+          command: "lint",
+          artifact_bindings: { "spec-source": "spec" },
+        },
+      },
+      tasks: {
+        t1: {
+          description: "Lint",
+          target_agent: "a1",
+          allowed_from_agents: ["a1"],
+          workflow: "implement",
+          input_artifacts: [],
+          invocation_handoff: "h",
+          result_handoff: "h",
+          execution_steps: [{ id: "s1", action: "lint", uses_tool: "speckeeper" }],
+        },
+      },
+    });
+
+    const effects = resolveTaskEffects(dsl, "t1");
+    expect(effects.derived).toContain("read:spec");
+  });
+});
+
+describe("artifact producer/consumer collection", () => {
+  it("collects producers from agents, tools, and execution steps", () => {
+    const dsl = makeDsl({
+      agents: {
+        a1: { role_name: "R", purpose: "P", can_write_artifacts: ["out"] },
+      },
+      artifacts: {
+        out: { type: "doc", owner: "a1", producers: ["a1"], editors: ["a1"], consumers: ["a1"], states: ["draft"] },
+      },
+      tools: {
+        t1: { kind: "cli", invokable_by: ["a1"], output_artifacts: ["out"] },
+      },
+      tasks: {
+        t1: {
+          description: "D",
+          target_agent: "a1",
+          allowed_from_agents: ["a1"],
+          workflow: "implement",
+          input_artifacts: [],
+          invocation_handoff: "h",
+          result_handoff: "h",
+          execution_steps: [{ id: "s1", action: "write", produces_artifact: "out" }],
+        },
+      },
+    });
+
+    const producers = collectAgentArtifactProducers(dsl, "out");
+    expect(producers.has("agent:a1")).toBe(true);
+    expect(producers.has("tool:t1")).toBe(true);
+    expect(producers.has("task:t1")).toBe(true);
+
+    const consumers = collectAgentArtifactConsumers(dsl, "out");
+    expect(consumers.size).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/test/schema/resolve-schema-refs.test.ts
+++ b/test/schema/resolve-schema-refs.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { resolveSchemaRefs } from "../../src/schema/resolve-schema-refs.js";
+
+describe("resolveSchemaRefs", () => {
+  it("resolves $ref to components.schemas before flattening allOf", () => {
+    const components = {
+      BaseHandoff: {
+        type: "object",
+        properties: {
+          from_agent: { type: "string" },
+          to_agent: { type: "string" },
+        },
+        required: ["from_agent", "to_agent"],
+      },
+    };
+
+    const schema = {
+      allOf: [
+        { $ref: "#/components/schemas/BaseHandoff" },
+        {
+          type: "object",
+          properties: {
+            payload: {
+              type: "object",
+              properties: { objective: { type: "string" } },
+            },
+          },
+        },
+      ],
+    };
+
+    const resolved = resolveSchemaRefs(schema, components);
+    const props = resolved.properties as Record<string, unknown>;
+    expect(props).toHaveProperty("from_agent");
+    expect(props).toHaveProperty("to_agent");
+    expect(props).toHaveProperty("payload");
+    expect(resolved.required).toEqual(
+      expect.arrayContaining(["from_agent", "to_agent"]),
+    );
+  });
+});

--- a/test/schema/schema.test.ts
+++ b/test/schema/schema.test.ts
@@ -353,6 +353,43 @@ describe("schema default values", () => {
     expect(t.kind).toBeUndefined();
   });
 
+  it("accepts component_contract on ToolSchema", () => {
+    const t = ToolSchema.parse({
+      ...minimalValidTool,
+      component_contract: "components/review.yaml",
+      command: "review",
+    });
+    expect(t.component_contract).toBe("components/review.yaml");
+  });
+
+  it("accepts effects on AgentSchema and TaskSchema", () => {
+    const a = AgentSchema.parse({
+      ...minimalValidAgent,
+      effects: ["read:spec"],
+    });
+    expect(a.effects).toEqual(["read:spec"]);
+
+    const t = TaskSchema.parse({
+      ...minimalValidTask,
+      effects: ["write:output"],
+    });
+    expect(t.effects).toEqual(["write:output"]);
+  });
+
+  it("accepts derived_from on ArtifactSchema", () => {
+    const single = ArtifactSchema.parse({
+      ...minimalValidArtifact,
+      derived_from: "source-art",
+    });
+    expect(single.derived_from).toBe("source-art");
+
+    const multi = ArtifactSchema.parse({
+      ...minimalValidArtifact,
+      derived_from: ["source-a", "source-b"],
+    });
+    expect(multi.derived_from).toEqual(["source-a", "source-b"]);
+  });
+
   it("defaults WorkflowSchema entry_conditions to [] when omitted", () => {
     const w = WorkflowSchema.parse({
       steps: [

--- a/test/validator/validator.test.ts
+++ b/test/validator/validator.test.ts
@@ -1248,3 +1248,24 @@ describe("validateSchema — deprecated x-extensions aliases", () => {
     });
   });
 });
+
+describe("validateSchema — tool contract mutual exclusion", () => {
+  it("fails when tool specifies both cli_contract and component_contract", () => {
+    const data = {
+      version: 1,
+      system: { id: "s", name: "S", default_workflow_order: ["implement"] },
+      tools: {
+        t1: {
+          kind: "cli",
+          cli_contract: "cli.yaml",
+          component_contract: "component.yaml",
+        },
+      },
+    };
+    const result = validateSchema(data);
+    expect(result.success).toBe(false);
+    expect(
+      result.diagnostics.some((d) => d.code === "tool-contract-mutual-exclusion"),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- #127: capability-level effects aggregation + artifact dataflow lint
- #128: handoff_type rendering in producer/consumer prompts
- #130: component_contract field in tools schema

## Changes
- Added `effects` field to agent/task schemas with 3-stage resolution
- Added `derived_from` to artifact schema for dataflow declaration
- Added dataflow consistency lint rules
- Fixed render templates to include handoff_type in producer/consumer prompts
- Added `component_contract` to ToolSchema with mutual exclusion validation
- Bumped version to 0.34.14

Closes #127, #128, #130

Made with [Cursor](https://cursor.com)