### PR TITLE
feat(schema): add evaluate workflow step for Closed Agent Looping (0.35.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/schemas/dsl.schema.json
+++ b/schemas/dsl.schema.json
@@ -309,6 +309,12 @@
               }
             },
             "additionalProperties": false
+          },
+          "effects": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
@@ -564,6 +570,12 @@
               "standard",
               "thinking"
             ]
+          },
+          "effects": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
@@ -680,6 +692,19 @@
               "approval-required",
               "regeneration-required"
             ]
+          },
+          "derived_from": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
           }
         },
         "required": [
@@ -736,6 +761,9 @@
             }
           },
           "cli_contract": {
+            "type": "string"
+          },
+          "component_contract": {
             "type": "string"
           },
           "artifact_bindings": {
@@ -892,6 +920,12 @@
               "type": "string"
             },
             "additionalProperties": {}
+          },
+          "target_agent": {
+            "type": "string"
+          },
+          "workflow_phase": {
+            "type": "string"
           }
         },
         "required": [
@@ -1277,6 +1311,63 @@
                     "workflow",
                     "handoff",
                     "expects"
+                  ],
+                  "additionalProperties": {}
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "evaluate"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "task": {
+                      "type": "string"
+                    },
+                    "from_agent": {
+                      "type": "string"
+                    },
+                    "evaluator_agent": {
+                      "type": "string"
+                    },
+                    "loop_to": {
+                      "type": "string"
+                    },
+                    "max_iterations": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 10
+                    },
+                    "inject_as": {
+                      "type": "string"
+                    },
+                    "on_exhausted": {
+                      "type": "string",
+                      "enum": [
+                        "fail_partial",
+                        "escalate",
+                        "abort"
+                      ]
+                    },
+                    "group": {
+                      "type": "string"
+                    },
+                    "depends_on": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "task",
+                    "from_agent",
+                    "loop_to",
+                    "max_iterations"
                   ],
                   "additionalProperties": {}
                 }

--- a/src/schema/workflow.ts
+++ b/src/schema/workflow.ts
@@ -91,6 +91,37 @@ const WorkflowTeamTaskStepSchema = z
   })
   .passthrough();
 
+/**
+ * Closed Agent Looping: a verification step that evaluates whether the goal has
+ * converged and, if not, loops back to an earlier step (Verification → Iteration
+ * back-edge). The evaluator returns a fixed `convergence-envelope` whose `verdict`
+ * (pass/fail) the runtime reads deterministically.
+ */
+const WorkflowEvaluateStepSchema = z
+  .object({
+    type: z.literal("evaluate"),
+    description: z.string().optional(),
+    /** GAP-analysis task that produces the convergence verdict. */
+    task: z.string(),
+    /** Agent that delegates the evaluation. */
+    from_agent: z.string(),
+    /** Agent that performs the evaluation (Producer != Verifier). */
+    evaluator_agent: z.string().optional(),
+    /** Step (task ID) to loop back to when not converged. */
+    loop_to: z.string(),
+    /** Iteration ceiling (bounded execution). */
+    max_iterations: z.number().int().min(1).max(10),
+    /** Context variable to inject the gap feedback into on the next iteration. */
+    inject_as: z.string().optional(),
+    /** Behavior when max_iterations is reached without convergence. */
+    on_exhausted: z
+      .enum(["fail_partial", "escalate", "abort"])
+      .optional(),
+    group: z.string().optional(),
+    depends_on: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
 export const WorkflowStepSchema = z.discriminatedUnion("type", [
   WorkflowDelegateStepSchema,
   WorkflowGateStepSchema,
@@ -98,6 +129,7 @@ export const WorkflowStepSchema = z.discriminatedUnion("type", [
   WorkflowValidationStepSchema,
   WorkflowDecisionStepSchema,
   WorkflowTeamTaskStepSchema,
+  WorkflowEvaluateStepSchema,
 ]);
 export type WorkflowStep = z.infer<typeof WorkflowStepSchema>;
 

--- a/test/schema/schema.test.ts
+++ b/test/schema/schema.test.ts
@@ -193,6 +193,67 @@ describe("schema normal cases", () => {
     expect(() => WorkflowSchema.parse(minimalValidWorkflow)).not.toThrow();
   });
 
+  it("parses WorkflowStepSchema evaluate step (Closed Agent Looping)", () => {
+    expect(() =>
+      WorkflowStepSchema.parse({
+        type: "evaluate",
+        task: "implementation-quality-check",
+        from_agent: "architect",
+        evaluator_agent: "test-police",
+        loop_to: "plan-and-implement",
+        max_iterations: 3,
+        inject_as: "gap_feedback",
+        on_exhausted: "fail_partial",
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts a minimal evaluate step (only required fields)", () => {
+    expect(() =>
+      WorkflowStepSchema.parse({
+        type: "evaluate",
+        task: "gap-analysis",
+        from_agent: "architect",
+        loop_to: "plan",
+        max_iterations: 1,
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects an evaluate step with max_iterations out of range (1-10)", () => {
+    expect(() =>
+      WorkflowStepSchema.parse({
+        type: "evaluate",
+        task: "gap-analysis",
+        from_agent: "architect",
+        loop_to: "plan",
+        max_iterations: 0,
+      }),
+    ).toThrow();
+    expect(() =>
+      WorkflowStepSchema.parse({
+        type: "evaluate",
+        task: "gap-analysis",
+        from_agent: "architect",
+        loop_to: "plan",
+        max_iterations: 11,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects an evaluate step with invalid on_exhausted", () => {
+    expect(() =>
+      WorkflowStepSchema.parse({
+        type: "evaluate",
+        task: "gap-analysis",
+        from_agent: "architect",
+        loop_to: "plan",
+        max_iterations: 2,
+        on_exhausted: "retry-forever",
+      }),
+    ).toThrow();
+  });
+
   it("parses PolicySchema", () => {
     expect(() => PolicySchema.parse(minimalValidPolicy)).not.toThrow();
   });


### PR DESCRIPTION
## Summary

Adds an `evaluate` workflow step type to enable **Closed Agent Looping** (Verification → Iteration back-edge) in the workflow DSL.

`WorkflowStepSchema` gains a 7th discriminated-union variant, `evaluate`: a verification step that evaluates whether the goal has converged and, when it has not, loops back to an earlier step. The evaluator returns a fixed convergence-envelope whose `verdict` (`pass`/`fail`) is read deterministically by the runtime.

Fields:

| field | required | meaning |
|---|---|---|
| `task` | yes | gap-analysis task that produces the verdict |
| `from_agent` | yes | delegating agent |
| `evaluator_agent` | no | agent that performs the evaluation (Producer ≠ Verifier) |
| `loop_to` | yes | step (task ID) to loop back to when not converged |
| `max_iterations` | yes | iteration ceiling, 1–10 (bounded execution) |
| `inject_as` | no | context variable to inject gap feedback into |
| `on_exhausted` | no | `fail_partial` \| `escalate` \| `abort` |

- regenerated `schemas/dsl.schema.json`
- schema tests for the variant (valid / minimal / out-of-range / invalid enum)

Bumps `0.35.0` → `0.35.1`. Unblocks the runtime-side evaluate loop (consumed by `@aaac/runtime`).

## Test plan

- [x] `npm test` — 971 passed
- [x] `npm run build` — clean
- [x] `npm run generate:schema` — `evaluate` present in `schemas/dsl.schema.json`
- [x] new files lint-clean
