### PR TITLE
chore: bump version to 0.35.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-contracts",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "description": "Declarative YAML DSL toolkit for defining, validating, and rendering multi-agent development workflows",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump `package.json` version from `0.35.1` to `0.35.2`
- Verify new CI gate on PR
- After merge, verify `release.yml` creates tag `v0.35.2` and `publish.yml` publishes to npm

## Test plan
- [ ] CI passes on this PR
- [ ] GitHub Release workflow creates `v0.35.2`
- [ ] npm publish workflow completes for `0.35.2`