### PR TITLE
docs: AI関連リポカタログへの相互リンクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1993,3 +1993,11 @@ That separation keeps runtime concerns and architecture concerns from being mixe
 ## License
 
 MIT
+
+---
+
+## 関連リポジトリ
+
+本リポジトリは foo-log-inc の AI 駆動開発関連リポジトリ群の一つです。各リポジトリの役割と一覧は以下のカタログを参照してください。
+
+📦 [AI関連リポジトリ カタログ](https://github.com/foo-log-inc/foolog_ojt/blob/main/REPOSITORIES.md)


### PR DESCRIPTION
## 概要

本リポジトリの README 末尾に、foo-log-inc の AI 駆動開発関連リポジトリ群をまとめたカタログ [REPOSITORIES.md](https://github.com/foo-log-inc/foolog_ojt/blob/main/REPOSITORIES.md) への相互リンクを追加しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)