### PR TITLE
docs: 内部リポカタログへの相互リンクを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -1993,11 +1993,3 @@ That separation keeps runtime concerns and architecture concerns from being mixe
 ## License
 
 MIT
-
----
-
-## 関連リポジトリ
-
-本リポジトリは foo-log-inc の AI 駆動開発関連リポジトリ群の一つです。各リポジトリの役割と一覧は以下のカタログを参照してください。
-
-📦 [AI関連リポジトリ カタログ](https://github.com/foo-log-inc/foolog_ojt/blob/main/REPOSITORIES.md)


### PR DESCRIPTION
## 概要

本リポジトリは public のため、private リポ (foolog_ojt) のカタログ REPOSITORIES.md へのリンクが外部に露出していました。該当リンクを削除します。

revert: `de73982a096420b5d25874b6fb4e4ad84150034b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)